### PR TITLE
fix mismatched lifetime

### DIFF
--- a/src/query_result.rs
+++ b/src/query_result.rs
@@ -21,7 +21,7 @@ impl QueryResult {
         String::from_utf8(buf.to_vec()).map_err(Error::NonUtf8Sequence)
     }
 
-    pub fn data_utf8_lossy(&self) -> Cow<str> {
+    pub fn data_utf8_lossy(&self) -> Cow<'_, str> {
         String::from_utf8_lossy(self.data_ref())
     }
 


### PR DESCRIPTION
Fix the following compile warning:

```
warning: hiding a lifetime that's elided elsewhere is confusing
  --> src/query_result.rs:24:28
   |
24 |     pub fn data_utf8_lossy(&self) -> Cow<str> {
   |                            ^^^^^     ^^^^^^^^ the same lifetime is hidden here
   |                            |
   |                            the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
   |
24 |     pub fn data_utf8_lossy(&self) -> Cow<'_, str> {
   |                                          +++

```