### PR TITLE
Make the crate say which engine it carries, and keep the three copies in step

### DIFF
--- a/.github/scripts/check-engine-pin.sh
+++ b/.github/scripts/check-engine-pin.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# The chdb-core release this crate builds against is written in three places, and
+# they have to say the same thing:
+#
+#   build.rs             CHDB_ENGINE_PIN   what a build actually downloads
+#   update_libchdb.sh    CHDB_ENGINE_PIN   what the script installs
+#   Cargo.toml           [package.metadata.chdb] engine   what a user is told
+#
+# The first two disagreeing means the engine a build links against is not the one
+# the script put there, which surfaces as missing symbols or as behaviour that
+# does not match the version anyone thinks they are running. The third disagreeing
+# is quieter and worse: the crate says it carries one ClickHouse and carries
+# another, and a crates.io version cannot be replaced — only yanked — so it says
+# the wrong thing permanently.
+#
+# Only vX.Y.Z and vX.Y.Z-rc.N are accepted. Those are the two shapes chdb-core
+# tags and the two the other bindings can parse, so a pin outside them is either a
+# typo or a tag nothing downstream can consume.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+fail() {
+	echo "::error::$*" >&2
+	exit 1
+}
+
+shell_pin=$(sed -n 's/^CHDB_ENGINE_PIN=\(.*\)$/\1/p' update_libchdb.sh | head -1)
+build_pin=$(sed -n 's/^const CHDB_ENGINE_PIN: &str = "\(.*\)";$/\1/p' build.rs | head -1)
+# Read only inside [package.metadata.chdb], so an engine= key in another table
+# cannot be mistaken for this one.
+meta_pin=$(awk '
+	/^\[package\.metadata\.chdb\]/ { inside = 1; next }
+	/^\[/                          { inside = 0 }
+	inside && /^engine[[:space:]]*=/ {
+		sub(/^engine[[:space:]]*=[[:space:]]*"/, "")
+		sub(/".*$/, "")
+		print
+		exit
+	}
+' Cargo.toml)
+
+[ -n "$shell_pin" ] || fail "update_libchdb.sh has no CHDB_ENGINE_PIN= line"
+[ -n "$build_pin" ] || fail "build.rs has no CHDB_ENGINE_PIN constant"
+[ -n "$meta_pin" ] || fail "Cargo.toml has no engine = \"...\" under [package.metadata.chdb]"
+
+if [ "$shell_pin" != "$build_pin" ] || [ "$shell_pin" != "$meta_pin" ]; then
+	cat >&2 <<EOF
+::error::the engine pin does not agree across the three places that carry it.
+
+  build.rs                        $build_pin
+  update_libchdb.sh               $shell_pin
+  Cargo.toml [package.metadata.chdb]  $meta_pin
+
+A build downloads what build.rs names, and a user reads what Cargo.toml says.
+Moving the pin means moving all three.
+EOF
+	exit 1
+fi
+
+case "$shell_pin" in
+v*) ;;
+*) fail "engine pin $shell_pin does not start with v" ;;
+esac
+
+rest=${shell_pin#v}
+base=${rest%%-*}
+suffix=${rest#"$base"}
+
+# Exactly three numeric fields. Counted rather than matched with a glob, because
+# * matches a dot too: v26.7.2.59 would pass a v[0-9]*.[0-9]*.[0-9]* pattern.
+IFS=. read -r major minor patch extra <<EOF
+$base
+EOF
+[ -n "$extra" ] && fail "engine pin $shell_pin has more than three version fields"
+for field in "$major" "$minor" "$patch"; do
+	case "$field" in
+	"" | *[!0-9]*) fail "engine pin $shell_pin is not vX.Y.Z or vX.Y.Z-rc.N" ;;
+	esac
+done
+
+case "$suffix" in
+"") ;;
+-rc.[0-9]*)
+	case "${suffix#-rc.}" in
+	*[!0-9]*) fail "engine pin $shell_pin has a release-candidate number that is not a number" ;;
+	esac
+	;;
+*) fail "engine pin $shell_pin has the suffix '$suffix'; only -rc.N is understood" ;;
+esac
+
+echo "engine pin $shell_pin, agreed by build.rs, update_libchdb.sh and Cargo.toml"

--- a/.github/workflows/engine-release-check.yml
+++ b/.github/workflows/engine-release-check.yml
@@ -174,7 +174,10 @@ jobs:
           {
             echo "The release check built and ran the tests against \`$ENGINE_VERSION\` and"
             echo "they passed, so the engine can be adopted. This moves the pin"
-            echo "$current → \`$ENGINE_VERSION\` in both \`update_libchdb.sh\` and \`build.rs\`."
+            echo "$current → \`$ENGINE_VERSION\` in all three places that carry it:"
+            echo "\`update_libchdb.sh\`, \`build.rs\`, and \`engine\` under"
+            echo "\`[package.metadata.chdb]\` in \`Cargo.toml\`, which is what tells a user"
+            echo "of the published crate which ClickHouse is inside it."
             echo
             echo "$RUN_URL"
             echo

--- a/.github/workflows/engine-release-check.yml
+++ b/.github/workflows/engine-release-check.yml
@@ -145,12 +145,16 @@ jobs:
           git switch -c "$branch"
           sed -i "s|^CHDB_ENGINE_PIN=.*|CHDB_ENGINE_PIN=$ENGINE_VERSION|" update_libchdb.sh
           sed -i "s|^const CHDB_ENGINE_PIN: &str = .*|const CHDB_ENGINE_PIN: \&str = \"$ENGINE_VERSION\";|" build.rs
+          # Only the engine key under [package.metadata.chdb], so the neighbouring
+          # docs.rs table is left alone.
+          sed -i "/^\[package\.metadata\.chdb\]/,/^\[package\.metadata\.docs\.rs\]/ \
+            s|^engine = \".*\"$|engine = \"$ENGINE_VERSION\"|" Cargo.toml
 
-          # Both files carry the pin, and a bump that moves only one of them puts
-          # the linked engine and the loaded engine on different builds.
-          for f in update_libchdb.sh build.rs; do
-            grep -q "$ENGINE_VERSION" "$f" || { echo "::error::$f was not rewritten"; exit 1; }
-          done
+          # Three files carry the pin. A bump that moves some of them puts the
+          # linked engine, the installed engine and what the crate tells a user on
+          # different footings — and leaves a pull request that cannot pass its own
+          # checks, so the automation would be proposing work it had blocked.
+          .github/scripts/check-engine-pin.sh
 
           git -c user.name="github-actions[bot]" \
               -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,6 +15,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # cargo publish runs with --no-verify, so nothing is built here and build.rs
+      # never executes — the pin is never exercised on the way out. This is the
+      # last point at which a crate claiming an engine it does not carry can be
+      # stopped: a crates.io version cannot be replaced afterwards, only yanked.
+      - name: The engine pin has to agree with itself
+        run: .github/scripts/check-engine-pin.sh
+
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,11 @@ jobs:
     - run: .github/scripts/check-engine-pin.sh
 
   build:
+    # Not merely ordered before the build — a gate on it. Without this the two run
+    # side by side, and a disagreeing pin still downloads an engine, links against
+    # it and reports test results for it, which is exactly the misleading outcome
+    # the check exists to prevent.
+    needs: engine_pin
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,14 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Seconds, and ahead of the build, because a pin that disagrees with itself
+  # makes everything after it a test of an engine nobody chose.
+  engine_pin:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: .github/scripts/check-engine-pin.sh
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,17 @@ required-features = ["arrow"]
 name = "arrow_stream_roundtrip"
 required-features = ["arrow"]
 
+[package.metadata.chdb]
+# The chdb-core release this crate builds against. The crate version above says
+# nothing about it — 1.4.0 is this crate's own numbering — so without this there
+# is no way to tell which ClickHouse a published version carries short of reading
+# build.rs at the matching tag. Here it travels with the package and can be read
+# from `cargo metadata` or the crates.io API.
+#
+# .github/scripts/check-engine-pin.sh keeps it in step with build.rs and
+# update_libchdb.sh, which are what actually fetch the engine.
+engine = "v26.7.0"
+
 [package.metadata.docs.rs]
 # docs.rs cannot download libchdb or link native libraries.
 # Setting DOCS_RS env var tells build.rs to skip native build steps.


### PR DESCRIPTION
chdb-node and chdb-go both check that what they publish names the engine inside
it (chdb-node#86, chdb-go#55). chdb-rust had nothing equivalent, and two problems
that made it worth having.

## The pin was written twice and never compared

`build.rs` and `update_libchdb.sh` each carry `CHDB_ENGINE_PIN`, with nothing
checking they agree. They disagree quietly: the build downloads what `build.rs`
names while the script installs something else, and it surfaces as missing symbols
or as behaviour that does not match the version anyone believes they are running.

The release check's bump path already rewrites both — but a hand edit, or a bump
that touched only one, had nothing to stop it.

## Nothing told a user which ClickHouse they were getting

The crate version is this crate's own numbering: `1.4.0` says nothing about the
engine, and finding the baseline meant reading `build.rs` at the matching tag.

```toml
[package.metadata.chdb]
engine = "v26.7.0"
```

travels with the package and is readable from `cargo metadata` and the crates.io
API — the same thing an `@chdb/lib-*` version gives a chdb-node user and a
`lib/<platform>` tag gives a chdb-go user.

## The check

`.github/scripts/check-engine-pin.sh` requires all three to agree, and the pin to
be `vX.Y.Z` or `vX.Y.Z-rc.N` — the two shapes chdb-core tags and the two the other
bindings can parse.

It runs in two places:

- **`rust.yml`, as a job ahead of the build.** Seconds. A pin that disagrees with
  itself makes every test after it a test of an engine nobody chose.
- **`publish.yaml`, before `cargo publish`.** This is the one that matters:
  publishing runs with `--no-verify`, so nothing is built, `build.rs` never
  executes, and the pin was never exercised on the way out. A crates.io version
  cannot be replaced afterwards, only yanked.

`propose_bump` rewrites the third copy too. Without that it would open pull
requests that fail a required check — the automation proposing work it had itself
blocked.

## Verified

Ten cases, against a scratch tree:

| case | result |
| --- | --- |
| three in agreement, stable and rc | passes |
| `build.rs` behind | fails |
| `Cargo.toml` behind — the crate lying to users | fails |
| `v26.7.2.59`, `26.7.0`, `v26.7`, `v26.7.x` | fails |
| `-beta.1`, `-rc.x` | fails |

The test tree carries a decoy `engine` key under `[package.metadata.docs.rs]` to
confirm only `[package.metadata.chdb]` is read, and the bump path's `sed` was run
against the real `Cargo.toml` for both a stable and an rc version to confirm the
neighbouring docs.rs table is untouched.

cc @auxten @wudidapaopao


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add machine-readable engine pin to Cargo.toml and validate all three pin locations in CI
> - Adds a `[package.metadata.chdb]` table with an `engine` key to [Cargo.toml](https://github.com/chdb-io/chdb-rust/pull/38/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542), making the carried chdb-core version machine-readable in the crate metadata.
> - Adds [check-engine-pin.sh](https://github.com/chdb-io/chdb-rust/pull/38/files#diff-2e55bacc931950db350337ac0ad093d2d2911173a4dd9a7123b04b0c6cd3902b), which asserts that the engine pin in `Cargo.toml`, `build.rs`, and `update_libchdb.sh` all agree and match the `vX.Y.Z` or `vX.Y.Z-rc.N` format.
> - Adds a dedicated `engine_pin` CI job in [rust.yml](https://github.com/chdb-io/chdb-rust/pull/38/files#diff-73e17259d77e5fbef83b2bdbbe4dc40a912f807472287f7f45b77e0cbf78792d) that gates the build on pin validation, and runs the same check before publishing in [publish.yaml](https://github.com/chdb-io/chdb-rust/pull/38/files#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388ca).
> - The engine-release workflow in [engine-release-check.yml](https://github.com/chdb-io/chdb-rust/pull/38/files#diff-10bf449fe0ff8be3a11eb50305d79999bd8c47c8e5082ad04554c357e8d9e32a) now also rewrites the `engine` key in `Cargo.toml` when bumping the pin, and uses the script instead of ad-hoc grep checks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 44d7113.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->