### PR TITLE
Say the engine pin names a chdb-core release, not a ClickHouse one

### DIFF
--- a/.github/scripts/check-engine-pin.sh
+++ b/.github/scripts/check-engine-pin.sh
@@ -10,13 +10,15 @@
 # The first two disagreeing means the engine a build links against is not the one
 # the script put there, which surfaces as missing symbols or as behaviour that
 # does not match the version anyone thinks they are running. The third disagreeing
-# is quieter and worse: the crate says it carries one ClickHouse and carries
-# another, and a crates.io version cannot be replaced — only yanked — so it says
-# the wrong thing permanently.
+# is quieter and worse: the crate names one engine and carries another, and a
+# crates.io version cannot be replaced — only yanked — so it says the wrong thing
+# permanently.
 #
-# Only vX.Y.Z and vX.Y.Z-rc.N are accepted. Those are the two shapes chdb-core
-# tags and the two the other bindings can parse, so a pin outside them is either a
-# typo or a tag nothing downstream can consume.
+# Only vX.Y.Z and vX.Y.Z-rc.N are accepted, which is chdb-core's tag shape: X.Y is
+# the ClickHouse minor line the release sits on and Z is chdb-core's own counter.
+# ClickHouse tags its own releases with four fields, so a four-field pin names a
+# tag in the wrong repository rather than a newer engine. Anything else is a typo
+# or a tag the other bindings cannot parse.
 
 set -euo pipefail
 

--- a/.github/workflows/engine-release-check.yml
+++ b/.github/workflows/engine-release-check.yml
@@ -177,7 +177,7 @@ jobs:
             echo "$current → \`$ENGINE_VERSION\` in all three places that carry it:"
             echo "\`update_libchdb.sh\`, \`build.rs\`, and \`engine\` under"
             echo "\`[package.metadata.chdb]\` in \`Cargo.toml\`, which is what tells a user"
-            echo "of the published crate which ClickHouse is inside it."
+            echo "of the published crate which engine is inside it."
             echo
             echo "$RUN_URL"
             echo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,11 +54,17 @@ name = "arrow_stream_roundtrip"
 required-features = ["arrow"]
 
 [package.metadata.chdb]
-# The chdb-core release this crate builds against. The crate version above says
-# nothing about it — 1.4.0 is this crate's own numbering — so without this there
-# is no way to tell which ClickHouse a published version carries short of reading
-# build.rs at the matching tag. Here it travels with the package and can be read
-# from `cargo metadata` or the crates.io API.
+# The chdb-core release this crate builds against. This is a chdb-core release
+# number, not a ClickHouse one: X.Y is the ClickHouse minor line the release sits
+# on and Z is chdb-core's own counter, so v26.7.0 carries some ClickHouse 26.7
+# rather than a ClickHouse 26.7.0. The chdb-core release notes for the tag name
+# the exact upstream build.
+#
+# The crate version above is unrelated — 1.4.0 is this crate's own numbering — so
+# without this key there is no way to tell which engine a published version
+# carries short of reading build.rs at the matching tag. Here it travels with the
+# package, readable through `cargo metadata`, the .crate archive or the docs.rs
+# source view; the crates.io API does not expose it.
 #
 # .github/scripts/check-engine-pin.sh keeps it in step with build.rs and
 # update_libchdb.sh, which are what actually fetch the engine.


### PR DESCRIPTION
chdb-core's tag naming is being made explicit: **`X.Y` is the ClickHouse line the
release sits on, `Z` is chdb-core's own count of kernel changes on that line**
(chdb-io/chdb-core#184). This checks what that means for chdb-rust.

## Shape: nothing to change

`check-engine-pin.sh` was already written for exactly the two shapes the new rule
produces. Run against a scratch tree:

| pin | result |
| --- | --- |
| `v26.7.0`, `v26.7.1-rc.1`, `v26.7.2-rc.2`, `v26.7.3` | pass |
| `v26.7.99` (counter ceiling), `v26.10.0` (two-digit minor) | pass |
| `v26.5.1-rc.3` (historical) | pass |
| `v26.7.2.59` | fails — four fields name a ClickHouse tag, not a chdb-core one |
| `v26.7`, `v26.7.0-beta.1` | fails |

The bump automation is fine too: the three `sed` expressions were run against the
real files for `v26.7.0 → v26.7.3` (a jump), `→ v26.7.2-rc.2` (an rc) and
`→ v27.0.0`, each hitting exactly one line per file, leaving the neighbouring
`[package.metadata.docs.rs]` table alone, and the pin check passing afterwards.

## Semantics: three comments were lying

They described the pin as naming *which ClickHouse* — under the new rule that is
wrong, and misleadingly so. `v26.7.0` carries ClickHouse **26.7.2.59**; upstream
has no 26.7.0 at all. A reader of `engine = "v26.7.0"` plus the old comment would
take the third field for an upstream patch number.

Fixed in `Cargo.toml`, `check-engine-pin.sh`, and the pull request body that
`propose_bump` generates. The pin is now described as what it is: a chdb-core
release number, where `X.Y` is the ClickHouse line and `Z` is chdb-core's counter,
with the release notes naming the exact upstream build.

Also corrected: the comment claimed this key is readable through the crates.io
API. It is not — a version object there carries `checksum`, `features`, `links`
and so on, with no `metadata`. It *is* readable through `cargo metadata`, the
`.crate` archive, and the docs.rs source view.

## Two things deliberately not done

**Recording the exact upstream version** (`26.7.2.59`) was considered and
rejected: there is no reliable machine-readable source for it. All three
candidates lie at `v26.7.0` —

| source | says | truth |
| --- | --- | --- |
| `autogenerated_versions.txt` `VERSION_STRING` | 26.7.2.1 | 26.7.2.59 |
| `VERSION_GITHASH` via `git describe` | v26.7.1.1-new-12226-g… | `1399e128` |
| `chdb.h` `CHDB_VERSION` | 26.5.1-rc.3 | — |

Only the release notes have it, in prose. Recording it would mean hand-copying a
number that the pin check cannot verify and `propose_bump` cannot fill — a fourth
place to fall out of step, in a repository that just spent a PR establishing that
three must agree. `X.Y` already tells a user which ClickHouse line they have, and
the comments now say so.

**Tying the crate version to the engine.** `1.4.0+chdb-core-26.7.0` is a real
option in this ecosystem (`curl-sys 0.4.90+curl-8.21.0`, `zstd-sys
2.0.16+zstd.1.5.7`), but cargo ignores build metadata when resolving, so the gain
is cosmetic while the cost is that every pin move would force a release — losing
the property that the pin can move independently. Making the crate version *track*
the engine would be worse: an engine minor bump would read as a breaking major to
cargo, and chdb-rust's own API breaks would have nowhere left to live.

## Known, not new

`propose_bump` compares pins for equality, not for order, so if chdb-core ever
publishes on an older line it would propose a downgrade. That predates this change,
the pull request title says plainly which direction it moves, and adoption goes
through review — adding a version comparison would mean hand-writing rc-aware
semver ordering in shell, which is a larger new surface than the problem.

## Verified after the change

`check-engine-pin.sh` passes, `bash -n` clean, `cargo metadata --no-deps` reads
`{'chdb': {'engine': 'v26.7.0'}}`, all three workflow YAMLs parse, and the shape
matrix and bump simulation were re-run against the edited files.

cc @auxten @wudidapaopao


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update comments to call the engine pin a chdb-core release, not a ClickHouse one
> Clarifies terminology in comments and generated workflow messages to distinguish chdb-core release versions from ClickHouse versions. No executable code or configuration values are changed.
>
> - Updates comments in [check-engine-pin.sh](https://github.com/chdb-io/chdb-rust/pull/39/files#diff-2e55bacc931950db350337ac0ad093d2d2911173a4dd9a7123b04b0c6cd3902b) to explain that the engine pin tag format (`vX.Y.Z`) is chdb-core's, where `X.Y` maps to a ClickHouse minor version and `Z` is chdb-core's own counter.
> - Updates comments in [Cargo.toml](https://github.com/chdb-io/chdb-rust/pull/39/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542) `[package.metadata.chdb]` to clarify the same version mapping.
> - Changes the phrase "which ClickHouse is inside it" to "which engine is inside it" in the generated PR/issue body in [engine-release-check.yml](https://github.com/chdb-io/chdb-rust/pull/39/files#diff-10bf449fe0ff8be3a11eb50305d79999bd8c47c8e5082ad04554c357e8d9e32a).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 50ef9f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->