### PR TITLE
Make static linking a supported option, and stop guessing which engine is linked

### DIFF
--- a/.github/scripts/check-static-link.sh
+++ b/.github/scripts/check-static-link.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+#
+# Asserts that a test binary carries the engine rather than loading it.
+#
+# `--features static` states an intention; it does not establish an outcome.
+# `cargo:rustc-link-lib=static=chdb` reaches the linker as a plain `-lchdb` for
+# any target that compiles the crate directly instead of consuming its rlib, and
+# a linker offered both artifacts can take the dynamic one. That produced a test
+# binary of 1.5 MB with a dynamic dependency on libchdb — statically linked
+# according to the feature flag, dynamically linked according to the loader —
+# and it passed the whole suite, because the machine happened to have the
+# library. So the static job checks the property instead of trusting the flag.
+#
+# Two checks per binary:
+#
+#   1. no dynamic dependency on libchdb
+#   2. the C API is defined inside the binary
+#
+# The first can pass on its own for a binary that finds libchdb through a
+# mechanism the check does not read, such as a dlopen. The second can pass on
+# its own for a binary that also carries a dynamic reference. Together they say
+# the engine is in this file and is not being loaded from anywhere else.
+#
+# Usage: check-static-link.sh <binary>...
+
+set -eu
+
+if [ "$#" -eq 0 ]; then
+	echo "usage: $0 <binary>..." >&2
+	exit 2
+fi
+
+case "$(uname -s)" in
+Darwin) platform=macos ;;
+Linux) platform=linux ;;
+*)
+	echo "unsupported platform $(uname -s)" >&2
+	exit 2
+	;;
+esac
+
+# One function from the C API that every test reaches, so neither -dead_strip nor
+# --gc-sections can have dropped it. The macOS toolchain prefixes symbols with an
+# underscore.
+symbol=chdb_connect
+
+failed=0
+
+for bin in "$@"; do
+	echo "== $bin"
+
+	if [ ! -f "$bin" ]; then
+		echo "   FAIL: no such file"
+		failed=1
+		continue
+	fi
+
+	case "$platform" in
+	macos) dynamic=$(otool -L "$bin" | tail -n +2 | grep -i libchdb || true) ;;
+	linux) dynamic=$(objdump -p "$bin" | grep NEEDED | grep -i libchdb || true) ;;
+	esac
+
+	if [ -n "$dynamic" ]; then
+		echo "   FAIL: loads libchdb at run time"
+		printf '%s\n' "$dynamic" | sed 's/^/     /'
+		failed=1
+	else
+		echo "   ok: no dynamic libchdb dependency"
+	fi
+
+	if nm "$bin" 2>/dev/null | grep -Eq "[[:space:]][Tt][[:space:]]_?${symbol}\$"; then
+		echo "   ok: ${symbol} is defined here"
+	else
+		echo "   FAIL: ${symbol} is not defined here, so the engine is elsewhere"
+		nm "$bin" 2>/dev/null | grep -E "[[:space:]]_?${symbol}\$" | sed 's/^/     /' || true
+		failed=1
+	fi
+
+	echo "   size: $(wc -c <"$bin" | tr -d ' ') bytes"
+done
+
+if [ "$failed" -ne 0 ]; then
+	echo "the engine is not statically linked into every test binary" >&2
+	exit 1
+fi
+
+echo "every test binary carries the engine"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,13 +34,94 @@ jobs:
           sudo ldconfig
     - name: Check formatting
       run: cargo fmt --check
+    # Default features only. --all-features enables `static`, which downloads a
+    # few hundred megabytes of archive that clippy then does not link; that
+    # belongs in the job that links it.
     - name: Check clippy
-      run: cargo clippy --all-targets --all-features -- --deny warnings
+      run: cargo clippy --all-targets -- --deny warnings
     - name: Build
       run: cargo build --verbose
       env:
         RUST_BACKTRACE: full
     - name: Run tests
       run: cargo test -- --test-threads=1
+      env:
+        RUST_BACKTRACE: full
+
+  # Static linking, built and run rather than merely compiled. Until this job
+  # existed the only step that enabled the feature was a `clippy --all-features`
+  # run, and clippy does not link: the archive was downloaded and nothing was
+  # learned from it, while the build and test steps that followed ran against
+  # the default dynamic build. That clippy run now lives here, where the archive
+  # is on disk for a reason.
+  #
+  # No libchdb is installed on these runners, deliberately. build.rs downloads
+  # the static archive and there is no dynamic library anywhere for the link to
+  # reach instead, which is half of what check-static-link.sh then confirms.
+  #
+  # Both cells take rustc's default macOS deployment target, and one more cell
+  # belongs here that is not here yet. 12.0 is where the linker starts emitting
+  # chained fixups, which is the mechanism that can bind a call inside the
+  # archive to the system C++ runtime instead of the copy the archive carries;
+  # below 12.0 there are none, so this job establishes that the tests ran
+  # against the archive but says nothing about that binding. Measured against
+  # the currently pinned engine: at the default 11.0 the suite passes, at 12.0 it
+  # hangs partway through and has to be killed. So the cell would be red for a
+  # reason that is not this repository's to fix - it is chdb-io/chdb-core#198,
+  # which bakes the visibility gate into the archive at compile time. Add
+  # `MACOSX_DEPLOYMENT_TARGET: "12.0"` as a matrix dimension when the pin moves
+  # to a release carrying that fix, and give each value its own
+  # CARGO_TARGET_DIR: the variable is not part of cargo's fingerprint, so
+  # changing it does not relink, and two cells sharing a target directory would
+  # test whichever binary was built first.
+  static:
+    needs: engine_pin
+    strategy:
+      # One platform failing should not hide the other's result: the two link
+      # with different linkers and only one of them has ever had this problem.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Check clippy with every feature
+      run: cargo clippy --all-targets --all-features -- --deny warnings
+
+    - name: Build the tests
+      run: |
+        cargo test --features static --no-run --message-format=json > artifacts.json
+        jq -r 'select(.reason == "compiler-artifact" and .profile.test == true and .executable != null)
+               | .executable' artifacts.json > test-binaries.txt
+        if [ ! -s test-binaries.txt ]; then
+          echo "::error::cargo reported no test binaries, so there is nothing to check"
+          exit 1
+        fi
+        echo "built $(wc -l < test-binaries.txt) test binaries"
+      env:
+        RUST_BACKTRACE: full
+
+    - name: Check every test binary carries the engine
+      run: xargs .github/scripts/check-static-link.sh < test-binaries.txt
+
+    # The files that were just checked, run directly. `cargo test` would be
+    # equivalent for as long as nothing relinks in between; running the list
+    # removes the "for as long as".
+    - name: Run tests
+      run: |
+        while read -r binary; do
+          echo "== $binary"
+          "$binary" --test-threads=1
+        done < test-binaries.txt
+      env:
+        RUST_BACKTRACE: full
+
+    # `cargo test` would have run these; running the checked binaries directly
+    # does not. They are outside the carried-engine check because rustdoc builds
+    # and discards its own binaries, but leaving them out would make this job
+    # cover less than the dynamic one. Two seconds, measured.
+    - name: Run doc tests
+      run: cargo test --features static --doc
       env:
         RUST_BACKTRACE: full

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -108,12 +108,19 @@ jobs:
     # The files that were just checked, run directly. `cargo test` would be
     # equivalent for as long as nothing relinks in between; running the list
     # removes the "for as long as".
+    #
+    # The list is read on fd 3 and each binary gets /dev/null for stdin, and both
+    # halves matter. A `while read ... done < file` loop hands the child whatever
+    # is left of the file, and chdb reads a non-empty stdin as external query
+    # data, so a query carrying inlined data is then rejected with "Processing
+    # async inserts with both inlined and external data". That failed exactly the
+    # binaries that were not last in the list, which is as confusing as it sounds.
     - name: Run tests
       run: |
-        while read -r binary; do
+        while read -r binary <&3; do
           echo "== $binary"
-          "$binary" --test-threads=1
-        done < test-binaries.txt
+          "$binary" --test-threads=1 < /dev/null
+        done 3< test-binaries.txt
       env:
         RUST_BACKTRACE: full
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,13 @@ required-features = ["arrow"]
 name = "arrow_stream_roundtrip"
 required-features = ["arrow"]
 
+# Its own runner: each case has to be its own process so that the exit code, the
+# exact stdout and a per-case wall-clock limit can all be checked, none of which
+# libtest exposes.
+[[test]]
+name = "runtime_faces"
+harness = false
+
 [package.metadata.chdb]
 # The chdb-core release this crate builds against. This is a chdb-core release
 # number, not a ClickHouse one: X.Y is the ClickHouse minor line the release sits

--- a/README.md
+++ b/README.md
@@ -91,6 +91,90 @@ fall-through to the download, so a build never quietly links a different engine
 than the one asked for. The build re-runs when the library file changes, which is
 what makes iterating against an engine that is still being rebuilt work.
 
+### Where the Engine Is Cached
+
+A downloaded engine is kept outside `target/`, keyed by release tag and platform:
+
+| | |
+| --- | --- |
+| macOS | `~/Library/Caches/chdb-rust/<tag>/<asset>/` |
+| Linux | `${XDG_CACHE_HOME:-~/.cache}/chdb-rust/<tag>/<asset>/` |
+
+`CHDB_ENGINE_CACHE_DIR` moves it, and deleting the directory clears it. Nothing
+is ever evicted — an entry is only added under a key it does not already have —
+so it grows by one engine per release and linkage you build against.
+
+Cargo hands out a fresh `OUT_DIR` per profile and per feature combination, so
+without this the same engine is fetched again for every combination and lost
+entirely to `cargo clean`. Measured in this repository before the cache existed:
+4.9 GB under `target/`, seven copies of two engines.
+
+On CI, cache this directory rather than `target/`. It is keyed by the pinned
+engine, so it only changes when the pin does.
+
+## Linking
+
+Two ways to link the engine, chosen per situation.
+
+| | artifact | at run time |
+| --- | --- | --- |
+| dynamic (default) | 448 KB binary, and a 326 MB `libchdb.so` beside it | the library has to be findable |
+| `--features static` | one file: 490 MB, or 361 MB stripped | nothing to find |
+
+Sizes are a release build of `examples/01_stateless_queries` against chdb-core
+v26.7.0 on macOS arm64; the engine is 432 MB on linux-aarch64. Dynamic gives you
+a small artifact, static gives you one you can copy anywhere.
+
+### A Dynamically Linked Binary Does Not Run On Its Own
+
+`cargo run` and `cargo test` work because Cargo puts an rpath into the binaries
+it is about to run itself. Nothing else does:
+
+```console
+$ ./target/release/my-tool
+dyld[19233]: Library not loaded: @rpath/libchdb.so
+  Referenced from: /path/to/my-tool
+  Reason: no LC_RPATH's found
+```
+
+On Linux the same situation reads `error while loading shared libraries:
+libchdb.so: cannot open shared object file`.
+
+Three ways out, all of which work on both platforms:
+
+1. Install the library where the loader already looks:
+   `./update_libchdb.sh --global` puts it in `/usr/local/lib`, which is on the
+   default search path for both loaders.
+2. Point the loader at it for the run: `DYLD_LIBRARY_PATH` on macOS,
+   `LD_LIBRARY_PATH` on Linux.
+3. Bake an rpath into your own binary, from your own `build.rs`, and ship the
+   library next to the executable:
+
+   ```rust
+   let origin = if cfg!(target_os = "macos") { "@loader_path" } else { "$ORIGIN" };
+   println!("cargo:rustc-link-arg=-Wl,-rpath,{origin}");
+   ```
+
+This is where chdb-rust is behind the other chDB bindings: chdb-python,
+chdb-node and chdb-go all run as soon as they are installed. If "copy it over
+and it runs" is what you need, `--features static` is the shorter path.
+
+### Strip the Symbol Table From a Static Artifact
+
+A static artifact carries a large symbol table that the program never reads at
+run time. Only you can remove it, in your own `Cargo.toml`, because Cargo
+ignores a dependency's `[profile]`:
+
+```toml
+[profile.release]
+strip = "symbols"
+```
+
+Measured on the artifact above: 490 MB down to 361 MB, 26% for one line. The
+engine's own debug information is already gone before it reaches you — chdb-core
+strips the archive when it builds it — so what is left is the symbol table of
+the final link, which is why only the final link can drop it.
+
 ## Which Engine Is Linked
 
 Three accessors, each reporting exactly one versioning scheme. A chdb-core

--- a/README.md
+++ b/README.md
@@ -91,6 +91,39 @@ fall-through to the download, so a build never quietly links a different engine
 than the one asked for. The build re-runs when the library file changes, which is
 what makes iterating against an engine that is still being rebuilt work.
 
+## Which Engine Is Linked
+
+Three accessors, each reporting exactly one versioning scheme. A chdb-core
+release number is not a ClickHouse one — `X.Y` is the ClickHouse minor line the
+release sits on and `Z` is chdb-core's own counter — so the two cannot be
+compared, and none of these answers with the other's number when its own source
+is unavailable.
+
+| | scheme | resolved |
+| --- | --- | --- |
+| `version::EXPECTED_ENGINE_VERSION` | chdb-core | at compile time, `Option<&str>` |
+| `version::engine_version()` | chdb-core | by the linked library |
+| `version::clickhouse_version()` | ClickHouse | by `SELECT version()` |
+
+```rust
+use chdb_rust::version::{clickhouse_version, engine_version, ENGINE_SOURCE};
+
+println!("engine    {}", engine_version()?);       // 26.7.0
+println!("clickhouse {}", clickhouse_version()?);  // 26.7.2.1
+println!("from      {}", ENGINE_SOURCE);           // download: chdb-core v26.7.0
+```
+
+`EXPECTED_ENGINE_VERSION` is `None` whenever the build linked a library it did
+not fetch — a `CHDB_LIB_DIR` build, a copy already installed on the machine. The
+pinned version says nothing about an artifact that came from somewhere else, so
+it reports nothing rather than reporting the pin; `ENGINE_SOURCE` says where the
+library came from. `engine_version()` is the only one that describes the artifact
+actually loaded, which makes it the way to confirm which engine a binary carries.
+
+It needs `chdb_version()`, which arrived in chdb-core v26.7.0; against an older
+library it returns `Error::EngineVersionUnavailable` rather than falling back to
+`SELECT version()`.
+
 ## Testing
 
 Run the test suite:

--- a/README.md
+++ b/README.md
@@ -62,6 +62,35 @@ If you prefer to install `libchdb` manually instead of automatic download:
 ./update_libchdb.sh --local
 ```
 
+### Building Against an Existing libchdb
+
+Two environment variables point the build at an engine this crate did not
+download — a local `chdb-core` build, a system package, a vendored copy:
+
+| Variable | Meaning |
+| --- | --- |
+| `CHDB_LIB_DIR` | directory holding the library to link |
+| `CHDB_INCLUDE_DIR` | directory holding the matching `chdb.h`, when it is not next to the library |
+
+Which file is looked for follows the linkage: `libchdb.a` with
+`--features static`, otherwise `libchdb.so` (which is the name `chdb-core` uses
+on macOS too) or `libchdb.dylib`.
+
+The two are separate because a `chdb-core` build tree does not keep them
+together — `build_static_lib.sh` leaves `libchdb.a` at the repository root while
+the header stays in `programs/local`:
+
+```bash
+CHDB_LIB_DIR=../chdb-core \
+CHDB_INCLUDE_DIR=../chdb-core/programs/local \
+    cargo build --features static
+```
+
+A directory that is set but has no usable library is an error rather than a
+fall-through to the download, so a build never quietly links a different engine
+than the one asked for. The build re-runs when the library file changes, which is
+what makes iterating against an engine that is still being rebuilt work.
+
 ## Testing
 
 Run the test suite:

--- a/build.rs
+++ b/build.rs
@@ -19,54 +19,195 @@ fn main() {
     let out_path = PathBuf::from(&out_dir);
     let libchdb_info = find_libchdb_or_download(&out_path);
     match libchdb_info {
-        Ok((lib_dir, header_path)) => {
-            setup_link_paths(&lib_dir, &header_path);
+        Ok((lib_path, header_path)) => {
+            setup_link_paths(&lib_path, &header_path);
             generate_bindings(&header_path, &out_path);
         }
         Err(e) => {
             eprintln!("Failed to find or download libchdb: {e}");
-            println!("cargo:warning=Failed to find libchdb. Please install manually using './update_libchdb.sh --local' or '--global'");
+            // cargo:warning is what a plain `cargo build` shows; the build
+            // script's own stderr only appears under --verbose or on the second
+            // run. The reason has to go here or the user sees nothing but
+            // "failed to run custom build command".
+            println!("cargo:warning=Failed to find libchdb: {e}");
+            println!("cargo:warning=Install one with './update_libchdb.sh --local' or '--global', or set CHDB_LIB_DIR (plus CHDB_INCLUDE_DIR when the header is not next to the library)");
             std::process::exit(1);
         }
     }
 }
 
+/// Whether the enabled features ask rustc to link the engine statically.
+///
+/// Every place that has to name a file on disk goes through this and
+/// [`lib_file_names`]: discovery, the download's chmod, the link directive and the
+/// rerun-if-changed line all have to agree about which artifact is in play.
+/// Disagreeing is what made `--features static` fail on any machine that already
+/// had a `libchdb.so` — discovery found the dynamic library, skipped the download,
+/// and rustc was then asked for a static one that had never been fetched.
+fn is_static() -> bool {
+    env::var_os("CARGO_FEATURE_STATIC").is_some()
+}
+
+/// The names the linked artifact can have, in preference order.
+///
+/// chdb-core ships the dynamic library as `libchdb.so` on macOS as well, so that
+/// name comes first on every platform; `.dylib` is accepted because a locally
+/// built or renamed copy is a reasonable thing to point `CHDB_LIB_DIR` at.
+fn lib_file_names() -> &'static [&'static str] {
+    if is_static() {
+        &["libchdb.a"]
+    } else {
+        &["libchdb.so", "libchdb.dylib"]
+    }
+}
+
+/// The artifact for the current linkage in `dir`, if there is one.
+fn find_lib_in(dir: &Path) -> Option<PathBuf> {
+    lib_file_names()
+        .iter()
+        .map(|name| dir.join(name))
+        .find(|path| path.exists())
+}
+
+/// A directory named by an environment variable. Empty counts as unset, matching
+/// how `${VAR:-default}` behaves in update_libchdb.sh.
+fn env_dir(var: &str) -> Option<PathBuf> {
+    env::var(var)
+        .ok()
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+/// Resolves the engine to build against, as `(artifact, header)`.
+///
+/// In order: whatever `CHDB_LIB_DIR` / `CHDB_INCLUDE_DIR` name, then a copy
+/// already on the machine, then a download of the pinned engine.
 fn find_libchdb_or_download(
     out_dir: &Path,
 ) -> Result<(PathBuf, PathBuf), Box<dyn std::error::Error>> {
-    if let Some((lib_dir, header_path)) = find_existing_libchdb() {
-        return Ok((lib_dir, header_path));
+    // Both are read here rather than inside the branches below, so the build
+    // re-runs when either changes even on the paths that ignore them.
+    println!("cargo:rerun-if-env-changed=CHDB_LIB_DIR");
+    println!("cargo:rerun-if-env-changed=CHDB_INCLUDE_DIR");
+    let header_override = header_from_env()?;
+
+    if let Some(lib_dir) = env_dir("CHDB_LIB_DIR") {
+        return libchdb_from_lib_dir(&lib_dir, header_override);
+    }
+
+    if let Some((lib_path, header_path)) = find_existing_libchdb() {
+        return Ok((lib_path, header_override.unwrap_or(header_path)));
     }
 
     println!("cargo:warning=libchdb not found locally, attempting to download...");
     download_libchdb_to_out_dir(out_dir)?;
-    let lib_dir = out_dir.to_path_buf();
-    let header_path = out_dir.join("chdb.h");
+
+    let lib_path = find_lib_in(out_dir).ok_or_else(|| {
+        format!(
+            "the downloaded archive contains none of {:?}, which the {} linkage needs",
+            lib_file_names(),
+            linkage_name()
+        )
+    })?;
+    let header_path = header_override.unwrap_or_else(|| out_dir.join("chdb.h"));
 
     if !header_path.exists() {
         return Err("Header file not found after download".into());
     }
 
-    Ok((lib_dir, header_path))
+    Ok((lib_path, header_path))
+}
+
+fn linkage_name() -> &'static str {
+    if is_static() {
+        "static"
+    } else {
+        "dynamic"
+    }
+}
+
+/// The header named by `CHDB_INCLUDE_DIR`, if it is set.
+///
+/// Separate from `CHDB_LIB_DIR` because a chdb-core build tree does not keep the
+/// two together: `chdb/build/build_static_lib.sh` leaves `libchdb.a` at the
+/// repository root while the header stays at `programs/local/chdb.h`. Requiring
+/// them to be adjacent would mean copying a gigabyte-sized archive around to
+/// build against one.
+fn header_from_env() -> Result<Option<PathBuf>, Box<dyn std::error::Error>> {
+    let Some(include_dir) = env_dir("CHDB_INCLUDE_DIR") else {
+        return Ok(None);
+    };
+    let header_path = include_dir.join("chdb.h");
+    if !header_path.exists() {
+        return Err(format!(
+            "CHDB_INCLUDE_DIR is {} but there is no chdb.h in it",
+            include_dir.display()
+        )
+        .into());
+    }
+    Ok(Some(header_path))
+}
+
+/// The engine under `CHDB_LIB_DIR`.
+///
+/// A directory that is set but unusable is an error, never a fall-through to the
+/// download. Quietly fetching the pinned engine instead would produce a green
+/// build that tested a different engine than the one asked for — the failure this
+/// hatch exists to let people investigate is exactly the kind that a substituted
+/// artifact hides.
+fn libchdb_from_lib_dir(
+    lib_dir: &Path,
+    header_override: Option<PathBuf>,
+) -> Result<(PathBuf, PathBuf), Box<dyn std::error::Error>> {
+    let lib_path = find_lib_in(lib_dir).ok_or_else(|| {
+        format!(
+            "CHDB_LIB_DIR is {} but it contains none of {:?}, which the {} linkage needs",
+            lib_dir.display(),
+            lib_file_names(),
+            linkage_name()
+        )
+    })?;
+
+    let header_path = match header_override {
+        Some(header_path) => header_path,
+        None => {
+            let adjacent = lib_dir.join("chdb.h");
+            if !adjacent.exists() {
+                return Err(format!(
+                    "found {} but no chdb.h next to it; set CHDB_INCLUDE_DIR to the directory \
+                     holding the matching header (a chdb-core build tree keeps it in \
+                     programs/local)",
+                    lib_path.display()
+                )
+                .into());
+            }
+            adjacent
+        }
+    };
+
+    println!(
+        "cargo:warning=using libchdb from CHDB_LIB_DIR: {} (header {})",
+        lib_path.display(),
+        header_path.display()
+    );
+    Ok((lib_path, header_path))
 }
 
 fn find_existing_libchdb() -> Option<(PathBuf, PathBuf)> {
-    if Path::new("./libchdb.so").exists() && Path::new("./chdb.h").exists() {
-        return Some((PathBuf::from("."), PathBuf::from("./chdb.h")));
+    if let Some(lib_path) = find_lib_in(Path::new(".")) {
+        if Path::new("./chdb.h").exists() {
+            return Some((lib_path, PathBuf::from("./chdb.h")));
+        }
     }
 
     // Check system installation
     let system_lib_path = Path::new("/usr/local/lib");
     let system_header_path = Path::new("/usr/local/include/chdb.h");
 
-    if system_header_path.exists()
-        && (system_lib_path.join("libchdb.so").exists()
-            || system_lib_path.join("libchdb.dylib").exists())
-    {
-        return Some((
-            system_lib_path.to_path_buf(),
-            system_header_path.to_path_buf(),
-        ));
+    if system_header_path.exists() {
+        if let Some(lib_path) = find_lib_in(system_lib_path) {
+            return Some((lib_path, system_header_path.to_path_buf()));
+        }
     }
 
     None
@@ -109,13 +250,7 @@ fn download_libchdb_to_out_dir(out_dir: &Path) -> Result<(), Box<dyn std::error:
     fs::remove_file(&temp_archive)?;
 
     if cfg!(unix) {
-        let lib_path = if std::env::var("CARGO_FEATURE_STATIC").is_ok() {
-            out_dir.join("libchdb.a")
-        } else {
-            out_dir.join("libchdb.so")
-        };
-
-        if lib_path.exists() {
+        if let Some(lib_path) = find_lib_in(out_dir) {
             let _ = Command::new("chmod")
                 .args(["+x", lib_path.to_str().unwrap()])
                 .output();
@@ -133,9 +268,7 @@ fn target_platform() -> (String, String) {
 }
 
 fn get_platform_string() -> Result<String, &'static str> {
-    // Check if the static feature is enabled to decide which filename to download
-    let is_static = std::env::var("CARGO_FEATURE_STATIC").is_ok();
-    let ext = if is_static {
+    let ext = if is_static() {
         "-static.tar.gz"
     } else {
         ".tar.gz"
@@ -151,8 +284,11 @@ fn get_platform_string() -> Result<String, &'static str> {
     }
 }
 
-fn lib_exports_symbol(lib_dir: &Path, symbol: &str) -> bool {
-    let lib_path = lib_dir.join("libchdb.so");
+/// Whether the linked artifact exports `symbol`.
+///
+/// `nm -D` reads a dynamic symbol table, so this only ever answers yes for the
+/// dynamic library; a static archive and macOS have none to read.
+fn lib_exports_symbol(lib_path: &Path, symbol: &str) -> bool {
     if !lib_path.exists() {
         return false;
     }
@@ -174,14 +310,13 @@ fn header_declares_direct_insert(header_path: &Path) -> bool {
         .unwrap_or(false)
 }
 
-fn setup_link_paths(lib_dir: &Path, header_path: &Path) {
+fn setup_link_paths(lib_path: &Path, header_path: &Path) {
+    let lib_dir = lib_path.parent().unwrap_or(Path::new("."));
     println!("cargo:rustc-link-search=native={}", lib_dir.display());
     println!("cargo:rustc-link-search=native=./");
     println!("cargo:rustc-link-search=native=/usr/local/lib");
 
-    let is_static = std::env::var("CARGO_FEATURE_STATIC").is_ok();
-
-    if is_static {
+    if is_static() {
         println!("cargo:rustc-link-lib=static=chdb");
         match target_platform().0.as_str() {
             "linux" => {
@@ -201,7 +336,7 @@ fn setup_link_paths(lib_dir: &Path, header_path: &Path) {
     }
 
     if header_declares_direct_insert(header_path)
-        && lib_exports_symbol(lib_dir, "chdb_insert_arrow_array")
+        && lib_exports_symbol(lib_path, "chdb_insert_arrow_array")
     {
         println!("cargo:rustc-cfg=direct_arrow_insert");
     }
@@ -209,12 +344,11 @@ fn setup_link_paths(lib_dir: &Path, header_path: &Path) {
     println!("cargo:rerun-if-changed=wrapper.h");
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed={}", header_path.display());
-    if lib_dir.join("libchdb.so").exists() {
-        println!(
-            "cargo:rerun-if-changed={}",
-            lib_dir.join("libchdb.so").display()
-        );
-    }
+    // The artifact that is actually linked, rather than a fixed libchdb.so. When
+    // building against a local chdb-core tree the engine is rebuilt underneath a
+    // build script that has no other reason to re-run, and without this line the
+    // tests keep exercising the previous engine while reporting on the new one.
+    println!("cargo:rerun-if-changed={}", lib_path.display());
 }
 
 fn generate_bindings(header_path: &Path, out_dir: &Path) {

--- a/build.rs
+++ b/build.rs
@@ -85,13 +85,21 @@ fn is_static() -> bool {
 /// The names the linked artifact can have, in preference order.
 ///
 /// chdb-core ships the dynamic library as `libchdb.so` on macOS as well, so that
-/// name comes first on every platform; `.dylib` is accepted because a locally
-/// built or renamed copy is a reasonable thing to point `CHDB_LIB_DIR` at.
+/// name comes first there too; `.dylib` is accepted only on macOS, because a
+/// locally built or renamed copy is a reasonable thing to point `CHDB_LIB_DIR`
+/// at and Apple's linker will find it. Elsewhere `-lchdb` reaches a linker that
+/// does not search that name, so accepting it would turn "no engine here" into a
+/// missing-library link error further along.
+///
+/// Keyed on the target rather than the host: which linker sees `-lchdb` is a
+/// property of what is being built, not of what is building it.
 fn lib_file_names() -> &'static [&'static str] {
     if is_static() {
         &["libchdb.a"]
-    } else {
+    } else if target_platform().0 == "macos" {
         &["libchdb.so", "libchdb.dylib"]
+    } else {
+        &["libchdb.so"]
     }
 }
 
@@ -105,9 +113,13 @@ fn find_lib_in(dir: &Path) -> Option<PathBuf> {
 
 /// A directory named by an environment variable. Empty counts as unset, matching
 /// how `${VAR:-default}` behaves in update_libchdb.sh.
+///
+/// `var_os` rather than `var`: a path is bytes and need not be UTF-8, and
+/// `env::var` reports a non-UTF-8 value as an error, which would read here as
+/// "unset" — the build would then quietly resolve some other engine than the one
+/// it was pointed at, which is the outcome this hatch exists to rule out.
 fn env_dir(var: &str) -> Option<PathBuf> {
-    env::var(var)
-        .ok()
+    env::var_os(var)
         .filter(|value| !value.is_empty())
         .map(PathBuf::from)
 }
@@ -463,8 +475,11 @@ fn get_platform_string() -> Result<String, &'static str> {
 
 /// Whether the linked artifact exports `symbol`.
 ///
-/// `nm -D` reads a dynamic symbol table, so this only ever answers yes for the
-/// dynamic library; a static archive and macOS have none to read.
+/// `nm -D` asks for an ELF dynamic symbol table: it answers only for a dynamic
+/// library on a platform that has one. Measured on macOS, Apple's nm rejects the
+/// flag outright for both `libchdb.so` and `libchdb.a`, so this is false there
+/// whatever the artifact contains. Only `direct_arrow_insert` consults it, and
+/// that cfg is gated first on a header declaration no released header carries.
 fn lib_exports_symbol(lib_path: &Path, symbol: &str) -> bool {
     if !lib_path.exists() {
         return false;

--- a/build.rs
+++ b/build.rs
@@ -25,7 +25,7 @@ fn main() {
     match libchdb_info {
         Ok(engine) => {
             publish_engine_provenance(engine.version.as_deref(), &engine.source);
-            setup_link_paths(&engine.lib_path, &engine.header_path);
+            setup_link_paths(&engine.lib_path, &engine.header_path, &out_path);
             generate_bindings(&engine.header_path, &out_path);
         }
         Err(e) => {
@@ -372,13 +372,48 @@ fn header_declares(header_path: &Path, symbol: &str) -> bool {
         .unwrap_or(false)
 }
 
-fn setup_link_paths(lib_path: &Path, header_path: &Path) {
+/// A directory holding nothing but the archive, so no dynamic library can be
+/// picked in its place.
+///
+/// `cargo:rustc-link-lib=static=chdb` reaches the linker as a plain `-lchdb`
+/// whenever the crate is compiled directly rather than consumed as an rlib —
+/// `cargo test --lib` is the case in this repository. Apple's linker then
+/// searches the `-L` directories and takes a `libchdb.so` found alongside the
+/// archive, which is how `--features static` produced a 1.5 MB binary with a
+/// dynamic dependency on libchdb: statically linked according to the feature
+/// flag, dynamically linked according to `otool -L`. Any directory that can hold
+/// both artifacts is ambiguous, and a chdb-core build tree holds both.
+///
+/// A symlink rather than a copy: the archive is around a gigabyte.
+fn isolate_archive(lib_path: &Path, out_dir: &Path) -> Option<PathBuf> {
+    let dir = out_dir.join("static-link");
+    fs::create_dir_all(&dir).ok()?;
+    let link = dir.join("libchdb.a");
+    let target = lib_path.canonicalize().ok()?;
+
+    if fs::read_link(&link).is_ok_and(|existing| existing == target) {
+        return Some(dir);
+    }
+    let _ = fs::remove_file(&link);
+
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&target, &link).ok()?;
+    #[cfg(not(unix))]
+    fs::copy(&target, &link).ok()?;
+
+    Some(dir)
+}
+
+fn setup_link_paths(lib_path: &Path, header_path: &Path, out_dir: &Path) {
     let lib_dir = lib_path.parent().unwrap_or(Path::new("."));
-    println!("cargo:rustc-link-search=native={}", lib_dir.display());
-    println!("cargo:rustc-link-search=native=./");
-    println!("cargo:rustc-link-search=native=/usr/local/lib");
 
     if is_static() {
+        // Only the isolated directory: ./ and /usr/local/lib are exactly the
+        // places a stray libchdb.so lives, and here they would shadow the
+        // archive rather than help find it.
+        let search_dir =
+            isolate_archive(lib_path, out_dir).unwrap_or_else(|| lib_dir.to_path_buf());
+        println!("cargo:rustc-link-search=native={}", search_dir.display());
         println!("cargo:rustc-link-lib=static=chdb");
         match target_platform().0.as_str() {
             "linux" => {
@@ -394,6 +429,9 @@ fn setup_link_paths(lib_path: &Path, header_path: &Path) {
             _ => {}
         }
     } else {
+        println!("cargo:rustc-link-search=native={}", lib_dir.display());
+        println!("cargo:rustc-link-search=native=./");
+        println!("cargo:rustc-link-search=native=/usr/local/lib");
         println!("cargo:rustc-link-lib=chdb");
     }
 

--- a/build.rs
+++ b/build.rs
@@ -10,8 +10,12 @@ const CHDB_ENGINE_PIN: &str = "v26.7.0";
 
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(direct_arrow_insert)");
+    println!("cargo::rustc-check-cfg=cfg(has_chdb_version)");
 
     if env::var("DOCS_RS").is_ok() {
+        // docs.rs links no engine, but the version accessors still have to
+        // compile, and they read their provenance out of the environment.
+        publish_engine_provenance(None, "none: docs.rs build");
         return;
     }
 
@@ -19,9 +23,10 @@ fn main() {
     let out_path = PathBuf::from(&out_dir);
     let libchdb_info = find_libchdb_or_download(&out_path);
     match libchdb_info {
-        Ok((lib_path, header_path)) => {
-            setup_link_paths(&lib_path, &header_path);
-            generate_bindings(&header_path, &out_path);
+        Ok(engine) => {
+            publish_engine_provenance(engine.version.as_deref(), &engine.source);
+            setup_link_paths(&engine.lib_path, &engine.header_path);
+            generate_bindings(&engine.header_path, &out_path);
         }
         Err(e) => {
             eprintln!("Failed to find or download libchdb: {e}");
@@ -34,6 +39,35 @@ fn main() {
             std::process::exit(1);
         }
     }
+}
+
+/// The engine this build resolved, and how.
+struct Engine {
+    /// The artifact rustc is asked to link.
+    lib_path: PathBuf,
+    /// The header bindgen reads. It can come from `CHDB_INCLUDE_DIR` and so does
+    /// not necessarily sit next to `lib_path`.
+    header_path: PathBuf,
+    /// The chdb-core release, without the leading `v`, when this build fetched it
+    /// and therefore knows which one it is. `None` for a library the build was
+    /// handed rather than downloaded.
+    version: Option<String>,
+    /// Where the library came from, for `chdb_rust::version::ENGINE_SOURCE`.
+    source: String,
+}
+
+/// Hands the resolved provenance to the crate as two `env!`-readable values.
+///
+/// The expected version is deliberately empty rather than the pin whenever the
+/// build did not fetch the engine itself. A constant that reports the pin while
+/// the artifact came from somewhere else is worse than no constant at all: it
+/// reads as a fact about the linked library and is not one.
+fn publish_engine_provenance(version: Option<&str>, source: &str) {
+    println!(
+        "cargo:rustc-env=CHDB_EXPECTED_ENGINE_VERSION={}",
+        version.unwrap_or_default()
+    );
+    println!("cargo:rustc-env=CHDB_ENGINE_SOURCE={source}");
 }
 
 /// Whether the enabled features ask rustc to link the engine statically.
@@ -78,13 +112,11 @@ fn env_dir(var: &str) -> Option<PathBuf> {
         .map(PathBuf::from)
 }
 
-/// Resolves the engine to build against, as `(artifact, header)`.
+/// Resolves the engine to build against.
 ///
 /// In order: whatever `CHDB_LIB_DIR` / `CHDB_INCLUDE_DIR` name, then a copy
 /// already on the machine, then a download of the pinned engine.
-fn find_libchdb_or_download(
-    out_dir: &Path,
-) -> Result<(PathBuf, PathBuf), Box<dyn std::error::Error>> {
+fn find_libchdb_or_download(out_dir: &Path) -> Result<Engine, Box<dyn std::error::Error>> {
     // Both are read here rather than inside the branches below, so the build
     // re-runs when either changes even on the paths that ignore them.
     println!("cargo:rerun-if-env-changed=CHDB_LIB_DIR");
@@ -96,11 +128,17 @@ fn find_libchdb_or_download(
     }
 
     if let Some((lib_path, header_path)) = find_existing_libchdb() {
-        return Ok((lib_path, header_override.unwrap_or(header_path)));
+        let source = format!("local: {}", lib_path.display());
+        return Ok(Engine {
+            lib_path,
+            header_path: header_override.unwrap_or(header_path),
+            version: None,
+            source,
+        });
     }
 
     println!("cargo:warning=libchdb not found locally, attempting to download...");
-    download_libchdb_to_out_dir(out_dir)?;
+    let version = download_libchdb_to_out_dir(out_dir)?;
 
     let lib_path = find_lib_in(out_dir).ok_or_else(|| {
         format!(
@@ -115,7 +153,14 @@ fn find_libchdb_or_download(
         return Err("Header file not found after download".into());
     }
 
-    Ok((lib_path, header_path))
+    Ok(Engine {
+        source: format!("download: chdb-core {version}"),
+        // The tag is the only place a `v` belongs. Everything downstream compares
+        // versions by plain string equality, which needs one spelling.
+        version: Some(version.trim_start_matches('v').to_string()),
+        lib_path,
+        header_path,
+    })
 }
 
 fn linkage_name() -> &'static str {
@@ -158,7 +203,7 @@ fn header_from_env() -> Result<Option<PathBuf>, Box<dyn std::error::Error>> {
 fn libchdb_from_lib_dir(
     lib_dir: &Path,
     header_override: Option<PathBuf>,
-) -> Result<(PathBuf, PathBuf), Box<dyn std::error::Error>> {
+) -> Result<Engine, Box<dyn std::error::Error>> {
     let lib_path = find_lib_in(lib_dir).ok_or_else(|| {
         format!(
             "CHDB_LIB_DIR is {} but it contains none of {:?}, which the {} linkage needs",
@@ -190,7 +235,12 @@ fn libchdb_from_lib_dir(
         lib_path.display(),
         header_path.display()
     );
-    Ok((lib_path, header_path))
+    Ok(Engine {
+        source: format!("CHDB_LIB_DIR: {}", lib_path.display()),
+        version: None,
+        lib_path,
+        header_path,
+    })
 }
 
 fn find_existing_libchdb() -> Option<(PathBuf, PathBuf)> {
@@ -213,17 +263,24 @@ fn find_existing_libchdb() -> Option<(PathBuf, PathBuf)> {
     None
 }
 
-fn download_libchdb_to_out_dir(out_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
-    let platform = get_platform_string()?;
-    // CHDB_ENGINE_VERSION overrides the pin, so a build can be pointed at one
-    // specific engine. Empty counts as unset, matching what `${VAR:-default}` in
-    // update_libchdb.sh does — otherwise an empty value here builds a URL with
-    // no version segment while the shell script quietly uses the pin.
+/// The chdb-core tag to download, `v` and all.
+///
+/// CHDB_ENGINE_VERSION overrides the pin, so a build can be pointed at one
+/// specific engine. Empty counts as unset, matching what `${VAR:-default}` in
+/// update_libchdb.sh does — otherwise an empty value here builds a URL with no
+/// version segment while the shell script quietly uses the pin.
+fn engine_tag_to_download() -> String {
     println!("cargo:rerun-if-env-changed=CHDB_ENGINE_VERSION");
-    let version = env::var("CHDB_ENGINE_VERSION")
+    env::var("CHDB_ENGINE_VERSION")
         .ok()
         .filter(|v| !v.is_empty())
-        .unwrap_or_else(|| CHDB_ENGINE_PIN.to_string());
+        .unwrap_or_else(|| CHDB_ENGINE_PIN.to_string())
+}
+
+/// Downloads and unpacks the engine, returning the tag it fetched.
+fn download_libchdb_to_out_dir(out_dir: &Path) -> Result<String, Box<dyn std::error::Error>> {
+    let platform = get_platform_string()?;
+    let version = engine_tag_to_download();
     let url =
         format!("https://github.com/chdb-io/chdb-core/releases/download/{version}/{platform}");
 
@@ -258,7 +315,7 @@ fn download_libchdb_to_out_dir(out_dir: &Path) -> Result<(), Box<dyn std::error:
     }
 
     println!("cargo:warning=libchdb downloaded successfully to OUT_DIR");
-    Ok(())
+    Ok(version)
 }
 
 fn target_platform() -> (String, String) {
@@ -304,9 +361,14 @@ fn lib_exports_symbol(lib_path: &Path, symbol: &str) -> bool {
     }
 }
 
-fn header_declares_direct_insert(header_path: &Path) -> bool {
+/// Whether the header mentions `symbol`.
+///
+/// Coarse on purpose: what matters is whether bindgen will have produced a
+/// declaration to call, and a header that names the symbol at all is a header
+/// bindgen saw it in.
+fn header_declares(header_path: &Path, symbol: &str) -> bool {
     fs::read_to_string(header_path)
-        .map(|s| s.contains("chdb_insert_arrow_array"))
+        .map(|contents| contents.contains(symbol))
         .unwrap_or(false)
 }
 
@@ -335,10 +397,17 @@ fn setup_link_paths(lib_path: &Path, header_path: &Path) {
         println!("cargo:rustc-link-lib=chdb");
     }
 
-    if header_declares_direct_insert(header_path)
+    if header_declares(header_path, "chdb_insert_arrow_array")
         && lib_exports_symbol(lib_path, "chdb_insert_arrow_array")
     {
         println!("cargo:rustc-cfg=direct_arrow_insert");
+    }
+
+    // chdb_version() arrived in chdb-core v26.7.0. Older engines have no way to
+    // report their own release, and calling a symbol they do not export would
+    // not link, so the accessor is compiled out instead.
+    if header_declares(header_path, "chdb_version") {
+        println!("cargo:rustc-cfg=has_chdb_version");
     }
 
     println!("cargo:rerun-if-changed=wrapper.h");

--- a/build.rs
+++ b/build.rs
@@ -137,20 +137,20 @@ fn find_libchdb_or_download(out_dir: &Path) -> Result<Engine, Box<dyn std::error
         });
     }
 
-    println!("cargo:warning=libchdb not found locally, attempting to download...");
-    let version = download_libchdb_to_out_dir(out_dir)?;
+    println!("cargo:warning=libchdb not found locally, fetching it");
+    let (engine_dir, version) = fetch_engine(out_dir)?;
 
-    let lib_path = find_lib_in(out_dir).ok_or_else(|| {
+    let lib_path = find_lib_in(&engine_dir).ok_or_else(|| {
         format!(
-            "the downloaded archive contains none of {:?}, which the {} linkage needs",
+            "the archive contains none of {:?}, which the {} linkage needs",
             lib_file_names(),
             linkage_name()
         )
     })?;
-    let header_path = header_override.unwrap_or_else(|| out_dir.join("chdb.h"));
+    let header_path = header_override.unwrap_or_else(|| engine_dir.join("chdb.h"));
 
     if !header_path.exists() {
-        return Err("Header file not found after download".into());
+        return Err(format!("no chdb.h in {}", engine_dir.display()).into());
     }
 
     Ok(Engine {
@@ -277,12 +277,133 @@ fn engine_tag_to_download() -> String {
         .unwrap_or_else(|| CHDB_ENGINE_PIN.to_string())
 }
 
-/// Downloads and unpacks the engine, returning the tag it fetched.
-fn download_libchdb_to_out_dir(out_dir: &Path) -> Result<String, Box<dyn std::error::Error>> {
-    let platform = get_platform_string()?;
-    let version = engine_tag_to_download();
-    let url =
-        format!("https://github.com/chdb-io/chdb-core/releases/download/{version}/{platform}");
+/// Written last inside a cache entry, so an entry is complete or absent and
+/// never half-unpacked.
+const CACHE_STAMP: &str = ".chdb-engine-complete";
+
+/// Where fetched engines are kept, outside `target/`.
+///
+/// An engine depends on the release tag and the platform and changes rarely, but
+/// `OUT_DIR` is handed out per profile and per feature combination: switch
+/// profile or enable one more feature and it is fetched again, and `cargo clean`
+/// discards every copy. Measured in this repository before the cache existed:
+/// 4.9 GB under target/, seven copies of the same two engines.
+///
+/// `CHDB_ENGINE_CACHE_DIR` moves it. Deleting the directory clears it — nothing
+/// here evicts, because an entry is only ever added under a key it does not
+/// already have.
+fn engine_cache_root() -> Option<PathBuf> {
+    println!("cargo:rerun-if-env-changed=CHDB_ENGINE_CACHE_DIR");
+    if let Some(dir) = env_dir("CHDB_ENGINE_CACHE_DIR") {
+        return Some(dir);
+    }
+
+    // Two paths are not worth a build dependency: build dependencies are
+    // compiled before anything else in the graph.
+    let home = env_dir("HOME")?;
+    Some(if cfg!(target_os = "macos") {
+        home.join("Library/Caches/chdb-rust")
+    } else {
+        env_dir("XDG_CACHE_HOME")
+            .unwrap_or_else(|| home.join(".cache"))
+            .join("chdb-rust")
+    })
+}
+
+/// The unpacked engine directory, plus the tag it holds.
+///
+/// The shared cache when one is usable, `OUT_DIR` when it is not: an unwritable
+/// cache directory should cost a build time, not break it.
+fn fetch_engine(out_dir: &Path) -> Result<(PathBuf, String), Box<dyn std::error::Error>> {
+    let tag = engine_tag_to_download();
+    let asset = get_platform_string()?;
+
+    if let Some(root) = engine_cache_root() {
+        match cached_engine(&tag, &asset, &root) {
+            Ok(dir) => return Ok((dir, tag)),
+            Err(e) => {
+                println!("cargo:warning=engine cache at {} unusable ({e}); unpacking into OUT_DIR instead", root.display());
+            }
+        }
+    }
+
+    download_and_unpack(&tag, &asset, out_dir)?;
+    Ok((out_dir.to_path_buf(), tag))
+}
+
+/// The cache entry for this tag and asset, filling it if it is not there.
+///
+/// The key is the release tag and the asset name, which together are the version,
+/// the platform and the linkage — everything the downloaded bytes depend on.
+///
+/// Filling goes through a sibling directory and one rename, so an interrupted
+/// build leaves nothing a later build can mistake for an engine. A concurrent
+/// build that gets there first wins: its copy came from the same URL.
+fn cached_engine(
+    tag: &str,
+    asset: &str,
+    cache_root: &Path,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let key = asset.trim_end_matches(".tar.gz");
+    let entry = cache_root.join(tag).join(key);
+
+    if entry.join(CACHE_STAMP).exists() {
+        println!(
+            "cargo:warning=using the cached engine at {}",
+            entry.display()
+        );
+        return Ok(entry);
+    }
+
+    let parent = cache_root.join(tag);
+    let staging = parent.join(format!("{key}.incomplete.{}", std::process::id()));
+    fs::create_dir_all(&parent)?;
+    let _ = fs::remove_dir_all(&staging);
+    fs::create_dir_all(&staging)?;
+
+    if let Err(e) = fill_cache_entry(tag, asset, &staging) {
+        // A failed fetch of a few hundred megabytes should not leave a few
+        // hundred megabytes behind. The next build would not mistake it for an
+        // engine — there is no stamp in it — but it would never clean it up
+        // either.
+        let _ = fs::remove_dir_all(&staging);
+        let _ = fs::remove_dir(&parent);
+        return Err(e);
+    }
+
+    match fs::rename(&staging, &entry) {
+        Ok(()) => {}
+        Err(_) if entry.join(CACHE_STAMP).exists() => {
+            let _ = fs::remove_dir_all(&staging);
+        }
+        Err(e) => {
+            let _ = fs::remove_dir_all(&staging);
+            return Err(e.into());
+        }
+    }
+
+    println!("cargo:warning=cached the engine at {}", entry.display());
+    Ok(entry)
+}
+
+/// Unpacks the engine into a staging directory and stamps it complete.
+fn fill_cache_entry(
+    tag: &str,
+    asset: &str,
+    staging: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    download_and_unpack(tag, asset, staging)?;
+    fs::write(staging.join(CACHE_STAMP), tag)?;
+    Ok(())
+}
+
+/// Downloads `asset` from release `tag` and unpacks it into `dest`.
+fn download_and_unpack(
+    tag: &str,
+    asset: &str,
+    dest: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let url = format!("https://github.com/chdb-io/chdb-core/releases/download/{tag}/{asset}");
 
     println!("cargo:warning=Downloading libchdb from: {url}");
 
@@ -296,26 +417,25 @@ fn download_libchdb_to_out_dir(out_dir: &Path) -> Result<String, Box<dyn std::er
         return Err(format!("Download failed with status: {}", response.status()).into());
     }
 
-    let temp_archive = out_dir.join("libchdb.tar.gz");
-    let mut dest = fs::File::create(&temp_archive)?;
-    response.copy_to(&mut dest)?;
+    let temp_archive = dest.join("libchdb.tar.gz");
+    let mut archive_file = fs::File::create(&temp_archive)?;
+    response.copy_to(&mut archive_file)?;
 
     println!("cargo:warning=Unpacking libchdb...");
     let file = fs::File::open(&temp_archive)?;
     let mut archive = tar::Archive::new(flate2::read::GzDecoder::new(file));
-    archive.unpack(out_dir)?;
+    archive.unpack(dest)?;
     fs::remove_file(&temp_archive)?;
 
     if cfg!(unix) {
-        if let Some(lib_path) = find_lib_in(out_dir) {
+        if let Some(lib_path) = find_lib_in(dest) {
             let _ = Command::new("chmod")
                 .args(["+x", lib_path.to_str().unwrap()])
                 .output();
         }
     }
 
-    println!("cargo:warning=libchdb downloaded successfully to OUT_DIR");
-    Ok(version)
+    Ok(())
 }
 
 fn target_platform() -> (String, String) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,6 +39,14 @@ pub enum Error {
     /// The data contains invalid UTF-8 sequences.
     #[error("Non UTF-8 sequence: {0}")]
     NonUtf8Sequence(FromUtf8Error),
+    /// The linked library cannot report which chdb-core release it is.
+    ///
+    /// `chdb_version()` arrived in chdb-core v26.7.0; an older library does not
+    /// export it, so there is nothing to call. Deliberately not answered with
+    /// `SELECT version()`, which reports a ClickHouse version — a different
+    /// scheme, and so not a substitute.
+    #[error("the linked libchdb does not export chdb_version(); it predates chdb-core v26.7.0")]
+    EngineVersionUnavailable,
     /// A query execution error occurred.
     ///
     /// This contains the error message from the underlying chDB library,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@
 //! - **Multiple output formats**: JSON, CSV, TabSeparated, and more
 //! - **Arrow bulk insert** (feature `arrow`, on by default): [`insert_record_batch`](arrow_insert::insert_record_batch) via `ArrowStream('name')`. Use [`chdb_rust::arrow`](arrow) types so your Arrow version matches the crate.
 //! - **Thread-safe**: Connections and results can be safely sent between threads
+//! - **Version accessors** ([`version`]): which chdb-core release is linked, where it came from, and which ClickHouse it carries
 //!
 //! ## Examples
 //!
@@ -71,6 +72,7 @@ pub mod format;
 pub mod log_level;
 pub mod query_result;
 pub mod session;
+pub mod version;
 
 #[cfg(test)]
 mod test_utils;

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,93 @@
+//! Which engine this build carries.
+//!
+//! Three accessors, each reporting exactly one versioning scheme. Nothing here
+//! falls back to another scheme when its own source is unavailable: a chdb-core
+//! release number and a ClickHouse version number cannot be compared, so
+//! answering one question with the other number is worse than answering with an
+//! error.
+//!
+//! | | scheme | resolved | example |
+//! | --- | --- | --- | --- |
+//! | [`EXPECTED_ENGINE_VERSION`] | chdb-core | at compile time | `26.7.0` |
+//! | [`engine_version`] | chdb-core | by the linked library | `26.7.0` |
+//! | [`clickhouse_version`] | ClickHouse | by a query | `26.5.1.1` |
+//!
+//! A chdb-core release number is not a ClickHouse one: `X.Y` is the ClickHouse
+//! minor line the release sits on and `Z` is chdb-core's own counter, so the two
+//! agree on the first two fields at most.
+
+use crate::error::{Error, Result};
+
+/// The chdb-core release this build fetched, without the leading `v`.
+///
+/// `None` when the build linked a library it did not fetch — a `CHDB_LIB_DIR`
+/// build, a copy already installed on the machine, a docs.rs build. The pinned
+/// version says nothing about an artifact that came from somewhere else, so this
+/// reports nothing rather than reporting the pin. [`ENGINE_SOURCE`] says where
+/// the library came from, and [`engine_version`] asks the library itself.
+///
+/// ```no_run
+/// use chdb_rust::version::{engine_version, EXPECTED_ENGINE_VERSION};
+///
+/// // A build that fetched its own engine can check the two agree.
+/// if let Some(expected) = EXPECTED_ENGINE_VERSION {
+///     assert_eq!(expected, engine_version()?);
+/// }
+/// # Ok::<(), chdb_rust::error::Error>(())
+/// ```
+pub const EXPECTED_ENGINE_VERSION: Option<&str> = {
+    let declared = env!("CHDB_EXPECTED_ENGINE_VERSION");
+    if declared.is_empty() {
+        None
+    } else {
+        Some(declared)
+    }
+};
+
+/// Where the linked library came from, as the build script resolved it.
+///
+/// One of `download: chdb-core <tag>`, `CHDB_LIB_DIR: <path>`,
+/// `local: <path>`, or `none: docs.rs build`. Diagnostic only — the shape is not
+/// part of the API.
+pub const ENGINE_SOURCE: &str = env!("CHDB_ENGINE_SOURCE");
+
+/// The chdb-core release the linked library reports, without the leading `v`.
+///
+/// This is the only accessor that describes the artifact actually loaded, which
+/// is what makes it the way to tell which engine a binary carries when the build
+/// did not fetch it.
+///
+/// # Errors
+///
+/// Returns [`Error::EngineVersionUnavailable`] when the library predates
+/// `chdb_version()`, which arrived in chdb-core v26.7.0.
+pub fn engine_version() -> Result<&'static str> {
+    #[cfg(has_chdb_version)]
+    {
+        // SAFETY: chdb_version() takes no arguments and returns a pointer to a
+        // string constant in the library, valid for as long as it is loaded.
+        let raw = unsafe { crate::bindings::chdb_version() };
+        if raw.is_null() {
+            return Err(Error::InvalidData(
+                "chdb_version() returned NULL".to_string(),
+            ));
+        }
+        unsafe { std::ffi::CStr::from_ptr(raw) }
+            .to_str()
+            .map_err(|e| Error::InvalidData(format!("chdb_version() is not UTF-8: {e}")))
+    }
+    #[cfg(not(has_chdb_version))]
+    {
+        Err(Error::EngineVersionUnavailable)
+    }
+}
+
+/// The ClickHouse version the linked engine reports, as `SELECT version()` gives
+/// it.
+///
+/// Opens a temporary in-memory connection, the same as [`crate::execute`]. Use
+/// `SELECT version()` on a connection you already hold if you have one.
+pub fn clickhouse_version() -> Result<String> {
+    let result = crate::execute("SELECT version()", None)?;
+    Ok(result.data_utf8()?.trim().to_string())
+}

--- a/tests/runtime_faces.rs
+++ b/tests/runtime_faces.rs
@@ -1,0 +1,581 @@
+//! The runtime surfaces a duplicated C++ runtime breaks.
+//!
+//! Static linking puts a copy of the C++ standard library inside the artifact.
+//! If its symbols are visible, the loader may resolve a call made inside the
+//! engine to a different implementation — the system's libc++ — and then one
+//! copy constructs an object the other destroys. Nothing about that is visible
+//! at link time, and `SELECT 1` passes straight through it: the failure needs a
+//! query that touches the state the two copies disagree about.
+//!
+//! Four groups, ten cases. Each group is a different piece of shared state:
+//! standard library globals (locale, the stream objects, the filesystem
+//! character conversions), type identity (the `typeinfo` addresses that decide
+//! whether a `catch` matches), the allocator and thread-local storage (which
+//! side of the language boundary allocated the memory being freed), and process
+//! exit (globals are destroyed when no query is running and there is nowhere to
+//! report an error).
+//!
+//! # Why each case is its own process
+//!
+//! The four things that have to be checked are properties of a process, not of
+//! an assertion: the exit code must be 0, stdout must match exactly, a
+//! wall-clock limit must be enforced, and stderr must reach the log. A hang is
+//! the central failure mode here, and one hung case inside a shared test binary
+//! takes every other case with it — so the parent runs each case as a child,
+//! bounds it, and compares what it printed.
+//!
+//! Run one case directly with `cargo test --test runtime_faces -- <name>`.
+//! Unrecognised flags are ignored, so the runner tolerates being handed
+//! `--test-threads=1` by CI.
+
+use std::fmt::Write as _;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use chdb_rust::connection::Connection;
+use chdb_rust::error::Error;
+use chdb_rust::format::OutputFormat;
+use chdb_rust::session::SessionBuilder;
+
+/// Names the case a child process should run. Its presence is what tells a
+/// process it is a child.
+const CASE_ENV: &str = "CHDB_RUNTIME_CASE";
+
+/// Per-case wall-clock limit. Generous on purpose: this bounds a hang, it does
+/// not measure performance, and a loaded CI runner starting a several-hundred
+/// megabyte binary is slow for reasons that are not interesting here.
+const CASE_LIMIT: Duration = Duration::from_secs(60);
+
+struct Case {
+    name: &'static str,
+    /// What the case must print, byte for byte.
+    expect: &'static str,
+    run: fn(),
+}
+
+fn cases() -> Vec<Case> {
+    let mut cases = vec![
+        // --- Group 1: globals in the standard library -----------------------
+        // The locale and the iostream globals must exist once per process. Two
+        // copies means state set in one is invisible to the other, and the
+        // symptom is output that is subtly wrong rather than absent.
+        Case {
+            name: "locale_formatting",
+            expect: "1.23 million|117.74 MiB|-1.5|1234.5678\n",
+            run: locale_formatting,
+        },
+        Case {
+            name: "wide_character_output",
+            expect: "日本語テキスト|3|éfac|Ελλ\n",
+            run: wide_character_output,
+        },
+        // std::filesystem and the character conversions it goes through.
+        Case {
+            name: "non_ascii_path",
+            expect: "created|3|6\n",
+            run: non_ascii_path,
+        },
+        // Regular expressions consult the locale internally.
+        Case {
+            name: "regexp_functions",
+            expect: "1|a·b·c|1,2,3\n",
+            run: regexp_functions,
+        },
+        // --- Group 2: type identity -----------------------------------------
+        // C++ decides type identity by comparing typeinfo addresses. Split
+        // those and `catch` stops matching: an engine exception passes through
+        // every handler and terminates the process.
+        Case {
+            name: "caught_engine_errors",
+            expect:
+                "syntax=Code: 62|divide=Code: 153|mismatch=Code: 43|rethrown=Code: 62|alive=1\n",
+            run: caught_engine_errors,
+        },
+        // A path dense with virtual dispatch: a table written to disk and read
+        // back through the storage layer.
+        Case {
+            name: "session_disk_roundtrip",
+            expect: "rows=50000|sum=1249975000|parts>=1\n",
+            run: session_disk_roundtrip,
+        },
+        // --- Group 3: the allocator and thread-local storage ----------------
+        // The engine allocates the result buffer and we free it. If operator
+        // new and operator delete are not the same copy, this aborts.
+        Case {
+            name: "large_result_buffer",
+            expect: "bytes=1288890|lines=200000|last=199999\n",
+            run: large_result_buffer,
+        },
+        Case {
+            name: "concurrent_connections",
+            expect: "0=1000|1=1000|2=1000|3=1000\n",
+            run: concurrent_connections,
+        },
+        // --- Group 4: process exit ------------------------------------------
+        // Everything above happens while a query is running. Globals are
+        // destroyed after the last one returns, where there is no query to fail
+        // and nowhere to report an error: the symptom is a process that will not
+        // exit, or exits non-zero having printed every correct answer.
+        Case {
+            name: "exit_after_close",
+            expect: "first=1|second=2\n",
+            run: exit_after_close,
+        },
+    ];
+
+    // The release callback in the Arrow C Data Interface frees memory that was
+    // allocated on the other side of the boundary, which is the same hazard in
+    // the opposite direction.
+    #[cfg(feature = "arrow")]
+    cases.push(Case {
+        name: "arrow_release_callback",
+        expect: "inserted=4|sum=100|released\n",
+        run: arrow_release_callback,
+    });
+
+    cases
+}
+
+// ---------------------------------------------------------------------------
+// Cases
+// ---------------------------------------------------------------------------
+
+/// One row, CSV, pipe-joined, with no trailing separator.
+fn scalar_row(sql: &str) -> String {
+    let conn = Connection::open_in_memory().expect("connect");
+    let result = conn.query(sql, OutputFormat::TabSeparated).expect(sql);
+    let text = result.data_utf8().expect("utf-8");
+    text.trim_end_matches('\n').replace('\t', "|")
+}
+
+fn locale_formatting() {
+    // Numbers through the engine's formatting paths: a word scale, a binary
+    // scale, a negative float and a fixed-point decimal.
+    println!(
+        "{}",
+        scalar_row(
+            "SELECT formatReadableQuantity(1234567), \
+                    formatReadableSize(123456789), \
+                    toString(-1.5), \
+                    toString(toDecimal64(1234.5678, 4))"
+        )
+    );
+}
+
+fn wide_character_output() {
+    // Text that comes out wrong in a recognisable way if the character tables
+    // or the stream globals are duplicated: literal multi-byte output, a
+    // codepoint count over astral characters, and two operations that have to
+    // respect codepoint boundaries rather than byte boundaries.
+    //
+    // No case mapping here: upperUTF8 and lowerUTF8 need ICU and this engine is
+    // built without it (`Function with name `upperUTF8` does not exist`).
+    println!(
+        "{}",
+        scalar_row(concat!(
+            "SELECT '日本語テキスト', ",
+            "lengthUTF8('🦀🦀🦀'), ",
+            "reverseUTF8('café'), ",
+            "substringUTF8('Ελληνικά', 1, 3)"
+        ))
+    );
+}
+
+fn non_ascii_path() {
+    // A data directory the engine has to hand to std::filesystem and convert.
+    let dir = scratch_dir("数据-café-Ω");
+    let session = SessionBuilder::new()
+        .with_data_path(&dir)
+        .with_auto_cleanup(true)
+        .build()
+        .expect("session on a non-ASCII path");
+
+    session
+        .execute("CREATE DATABASE IF NOT EXISTS d", None)
+        .expect("create database");
+    session
+        .execute(
+            "CREATE TABLE IF NOT EXISTS d.t (x UInt32) ENGINE = MergeTree ORDER BY x",
+            None,
+        )
+        .expect("create table");
+    session
+        .execute("INSERT INTO d.t VALUES (1), (2), (3)", None)
+        .expect("insert");
+
+    let created = if dir.exists() { "created" } else { "missing" };
+    let counted = session
+        .execute("SELECT count(), sum(x) FROM d.t", None)
+        .expect("read back")
+        .data_utf8()
+        .expect("utf-8")
+        .trim_end_matches('\n')
+        .replace('\t', "|");
+
+    println!("{created}|{counted}");
+}
+
+fn regexp_functions() {
+    // concat! rather than a continued string: inside a raw string a backslash
+    // before a newline is just a backslash, and it lands in the SQL.
+    println!(
+        "{}",
+        scalar_row(concat!(
+            r"SELECT match('café-2026', '^caf.-\\d{4}$'), ",
+            r"replaceRegexpAll('aXbXc', 'X', '·'), ",
+            r"arrayStringConcat(extractAll('日本1語2テキスト3', '\\d'), ',')"
+        ))
+    );
+}
+
+/// The leading `Code: N` of an engine error, without the message or the version
+/// that follows it — those move between releases, the code does not.
+fn error_code(error: &Error) -> String {
+    let text = error.to_string();
+    match text.find('.') {
+        Some(end) if text.starts_with("Code: ") => text[..end].to_string(),
+        _ => format!("unexpected error shape: {text}"),
+    }
+}
+
+/// Turns an engine error into a different variant of our own, from a frame the
+/// caller has to unwind through.
+fn wrap_engine_error(conn: &Connection) -> Result<(), Error> {
+    conn.query("SELECT FROM WHERE", OutputFormat::TabSeparated)
+        .map(|_| ())
+        .map_err(|e| Error::InvalidData(e.to_string()))
+}
+
+fn caught_engine_errors() {
+    let conn = Connection::open_in_memory().expect("connect");
+
+    let mut line = String::new();
+    for (label, sql) in [
+        ("syntax", "SELECT FROM WHERE"),
+        ("divide", "SELECT intDiv(1, 0)"),
+        ("mismatch", "SELECT [1, 2, 3] + 1"),
+    ] {
+        let error = conn
+            .query(sql, OutputFormat::TabSeparated)
+            .expect_err(sql)
+            .to_string();
+        let code = error_code(&Error::QueryError(error));
+        write!(line, "{label}={code}|").expect("write");
+    }
+
+    // One error caught, wrapped and propagated out of another frame, so an
+    // exception has to survive being handled rather than only being thrown.
+    let rethrown = wrap_engine_error(&conn).expect_err("rethrow");
+    let inner = match &rethrown {
+        Error::InvalidData(text) => error_code(&Error::QueryError(text.clone())),
+        other => format!("unexpected: {other}"),
+    };
+    write!(line, "rethrown={inner}|").expect("write");
+
+    // The connection has to still work after all of that.
+    let alive = scalar_row_on(&conn, "SELECT 1");
+    println!("{line}alive={alive}");
+}
+
+fn scalar_row_on(conn: &Connection, sql: &str) -> String {
+    conn.query(sql, OutputFormat::TabSeparated)
+        .expect(sql)
+        .data_utf8()
+        .expect("utf-8")
+        .trim_end_matches('\n')
+        .replace('\t', "|")
+}
+
+fn session_disk_roundtrip() {
+    let dir = scratch_dir("disk-roundtrip");
+    let session = SessionBuilder::new()
+        .with_data_path(&dir)
+        .with_auto_cleanup(true)
+        .build()
+        .expect("session");
+
+    session
+        .execute("CREATE DATABASE IF NOT EXISTS d", None)
+        .expect("create database");
+    session
+        .execute(
+            "CREATE TABLE d.t (x UInt32, s String) ENGINE = MergeTree ORDER BY x",
+            None,
+        )
+        .expect("create table");
+    session
+        .execute(
+            "INSERT INTO d.t SELECT number, toString(number) FROM numbers(50000)",
+            None,
+        )
+        .expect("insert");
+
+    let counted = session
+        .execute("SELECT count(), sum(x) FROM d.t", None)
+        .expect("aggregate")
+        .data_utf8()
+        .expect("utf-8")
+        .trim_end_matches('\n')
+        .replace('\t', "|");
+
+    // Written through the storage layer rather than held in memory.
+    let parts: u64 = session
+        .execute(
+            "SELECT count() FROM system.parts WHERE database = 'd' AND table = 't' AND active",
+            None,
+        )
+        .expect("system.parts")
+        .data_utf8()
+        .expect("utf-8")
+        .trim()
+        .parse()
+        .expect("part count");
+
+    let (rows, sum) = counted.split_once('|').expect("two columns");
+    println!(
+        "rows={rows}|sum={sum}|parts{}",
+        if parts >= 1 { ">=1" } else { "=0" }
+    );
+}
+
+fn large_result_buffer() {
+    // Megabytes of result, allocated by the engine and freed by us.
+    //
+    // 1288890 bytes is the whole answer, not an observation: the decimal digits
+    // of 0..199999 are 10*1 + 90*2 + 900*3 + 9000*4 + 90000*5 + 100000*6 =
+    // 1088890, plus one newline per row.
+    let conn = Connection::open_in_memory().expect("connect");
+    let result = conn
+        .query("SELECT number FROM numbers(200000)", OutputFormat::CSV)
+        .expect("query");
+
+    let bytes = result.data_ref().len();
+    let text = result.data_utf8().expect("utf-8");
+    let lines = text.lines().count();
+    let last = text.lines().next_back().unwrap_or_default().to_string();
+
+    drop(result);
+    drop(conn);
+
+    println!("bytes={bytes}|lines={lines}|last={last}");
+}
+
+fn concurrent_connections() {
+    // A connection per thread, running at the same time. Thread-local storage
+    // that exists twice gets its initialisation order wrong here.
+    let handles: Vec<_> = (0..4)
+        .map(|id| {
+            std::thread::spawn(move || {
+                let conn = Connection::open_in_memory().expect("connect");
+                let counted = scalar_row_on(&conn, "SELECT count() FROM numbers(1000)");
+                format!("{id}={counted}")
+            })
+        })
+        .collect();
+
+    let mut answers: Vec<String> = handles
+        .into_iter()
+        .map(|handle| handle.join().expect("thread"))
+        .collect();
+    answers.sort();
+    println!("{}", answers.join("|"));
+}
+
+fn exit_after_close() {
+    // Connect, query, close. Twice. Then return from main and let the globals
+    // be destroyed with no query in flight.
+    let mut line = String::new();
+    for (label, sql) in [("first", "SELECT 1"), ("second", "SELECT 2")] {
+        let conn = Connection::open_in_memory().expect("connect");
+        let value = scalar_row_on(&conn, sql);
+        drop(conn);
+        if !line.is_empty() {
+            line.push('|');
+        }
+        write!(line, "{label}={value}").expect("write");
+    }
+    println!("{line}");
+}
+
+#[cfg(feature = "arrow")]
+fn arrow_release_callback() {
+    use chdb_rust::arrow::array::{Int32Array, RecordBatch};
+    use chdb_rust::arrow::datatypes::{DataType, Field, Schema};
+    use chdb_rust::InsertOptions;
+    use std::sync::Arc;
+
+    let dir = scratch_dir("arrow-release");
+    let session = SessionBuilder::new()
+        .with_data_path(&dir)
+        .with_auto_cleanup(true)
+        .build()
+        .expect("session");
+
+    session
+        .execute("CREATE DATABASE IF NOT EXISTS d", None)
+        .expect("create database");
+    session
+        .execute(
+            "CREATE TABLE d.t (x Int32) ENGINE = MergeTree ORDER BY x",
+            None,
+        )
+        .expect("create table");
+
+    let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int32, false)]));
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![Arc::new(Int32Array::from(vec![10, 20, 30, 40]))],
+    )
+    .expect("batch");
+
+    // The batch crosses into the engine through the C Data Interface, and the
+    // release callback the engine invokes frees memory this side allocated.
+    let rows = batch.num_rows();
+    chdb_rust::insert_record_batch(
+        session.connection(),
+        "d.t",
+        "release_probe",
+        batch,
+        InsertOptions::default(),
+    )
+    .expect("insert");
+
+    let sum = scalar_row_on(session.connection(), "SELECT sum(x) FROM d.t");
+    println!("inserted={rows}|sum={sum}|released");
+}
+
+/// A scratch directory named `suffix`, removed if a previous run left one.
+fn scratch_dir(suffix: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("chdb-runtime-{}-{suffix}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    dir
+}
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+fn main() {
+    match std::env::var(CASE_ENV) {
+        Ok(name) => run_one(&name),
+        Err(_) => run_all(),
+    }
+}
+
+/// Child: run the named case and let its output and exit status be the answer.
+fn run_one(name: &str) {
+    let cases = cases();
+    let case = cases
+        .iter()
+        .find(|case| case.name == name)
+        .unwrap_or_else(|| panic!("no case named {name}"));
+    (case.run)();
+    std::io::stdout().flush().expect("flush");
+}
+
+/// Parent: run every case as a child and check the four properties.
+fn run_all() {
+    // Anything starting with `-` is somebody else's flag — CI hands this binary
+    // `--test-threads=1`. A bare word selects a subset by substring.
+    let filter = std::env::args().skip(1).find(|arg| !arg.starts_with('-'));
+
+    let exe = std::env::current_exe().expect("current_exe");
+    let cases = cases();
+    let selected: Vec<&Case> = cases
+        .iter()
+        .filter(|case| filter.as_deref().is_none_or(|f| case.name.contains(f)))
+        .collect();
+
+    println!("running {} runtime cases", selected.len());
+
+    let mut failures = Vec::new();
+    for case in &selected {
+        match run_child(&exe, case) {
+            Ok(elapsed) => println!("  {} ... ok ({} ms)", case.name, elapsed.as_millis()),
+            Err(reason) => {
+                println!("  {} ... FAILED", case.name);
+                failures.push((case.name, reason));
+            }
+        }
+    }
+
+    if failures.is_empty() {
+        println!("all {} runtime cases passed", selected.len());
+        return;
+    }
+
+    println!("\nfailures:");
+    for (name, reason) in &failures {
+        println!("\n---- {name} ----\n{reason}");
+    }
+    std::process::exit(1);
+}
+
+/// Runs one case in a child process and checks its exit status, its stdout and
+/// its wall-clock time.
+fn run_child(exe: &Path, case: &Case) -> Result<Duration, String> {
+    let stdout_path = std::env::temp_dir().join(format!(
+        "chdb-runtime-{}-{}.out",
+        std::process::id(),
+        case.name
+    ));
+    let stdout_file =
+        std::fs::File::create(&stdout_path).map_err(|e| format!("cannot capture stdout: {e}"))?;
+
+    // stdout to a file rather than a pipe, so a case that writes more than a
+    // pipe holds cannot deadlock against a parent that is not reading it yet.
+    // stderr is inherited: the diagnostics are there, and swallowing them is
+    // how a failure here becomes unexplainable.
+    let mut child = Command::new(exe)
+        .env(CASE_ENV, case.name)
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(stdout_file))
+        .stderr(Stdio::inherit())
+        .spawn()
+        .map_err(|e| format!("cannot spawn: {e}"))?;
+
+    let started = Instant::now();
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if started.elapsed() >= CASE_LIMIT {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(format!(
+                        "still running after {} s, killed. A case that does not \
+                         return is the failure this suite exists to catch.",
+                        CASE_LIMIT.as_secs()
+                    ));
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            Err(e) => return Err(format!("cannot wait: {e}")),
+        }
+    };
+    let elapsed = started.elapsed();
+
+    let actual = std::fs::read_to_string(&stdout_path)
+        .map_err(|e| format!("cannot read captured stdout: {e}"))?;
+    let _ = std::fs::remove_file(&stdout_path);
+
+    // Exit status first: a correct answer from a process that then died is not a
+    // pass, and it is the shape process-exit faults take.
+    if !status.success() {
+        return Err(format!(
+            "exited with {status}\n  stdout was: {actual:?}\n  expected:   {:?}",
+            case.expect
+        ));
+    }
+
+    if actual != case.expect {
+        return Err(format!(
+            "stdout does not match\n  expected: {:?}\n  actual:   {:?}",
+            case.expect, actual
+        ));
+    }
+
+    Ok(elapsed)
+}

--- a/tests/runtime_faces.rs
+++ b/tests/runtime_faces.rs
@@ -29,7 +29,9 @@
 //! `--test-threads=1` by CI.
 
 use std::fmt::Write as _;
-use std::io::Write as _;
+use std::io::{Read as _, Write as _};
+#[cfg(unix)]
+use std::os::unix::process::CommandExt as _;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
@@ -516,25 +518,51 @@ fn run_all() {
 /// Runs one case in a child process and checks its exit status, its stdout and
 /// its wall-clock time.
 fn run_child(exe: &Path, case: &Case) -> Result<Duration, String> {
-    let stdout_path = std::env::temp_dir().join(format!(
-        "chdb-runtime-{}-{}.out",
-        std::process::id(),
-        case.name
-    ));
-    let stdout_file =
-        std::fs::File::create(&stdout_path).map_err(|e| format!("cannot capture stdout: {e}"))?;
-
-    // stdout to a file rather than a pipe, so a case that writes more than a
-    // pipe holds cannot deadlock against a parent that is not reading it yet.
-    // stderr is inherited: the diagnostics are there, and swallowing them is
-    // how a failure here becomes unexplainable.
-    let mut child = Command::new(exe)
+    // stdout through a pipe drained by its own thread. A case that writes more
+    // than the pipe holds cannot block against a parent that is not reading it
+    // yet, and nothing here depends on a writable temp directory. stderr is
+    // inherited: the diagnostics are there, and swallowing them is how a failure
+    // becomes unexplainable.
+    let mut command = Command::new(exe);
+    command
         .env(CASE_ENV, case.name)
         .stdin(Stdio::null())
-        .stdout(Stdio::from(stdout_file))
-        .stderr(Stdio::inherit())
-        .spawn()
-        .map_err(|e| format!("cannot spawn: {e}"))?;
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit());
+
+    // Force the standard library onto its fork/exec path.
+    //
+    // A statically linked artifact resolves posix_spawn and the whole
+    // posix_spawn_file_actions_* family against the engine's archive, which
+    // carries ClickHouse's glibc-compatibility shims. That posix_spawn
+    // deliberately ignores file actions - its own source says so: "callers are
+    // compiled against glibc's <spawn.h> ... walking it as `struct fdop` would
+    // dereference garbage. Posix_spawn callers that need file actions must avoid
+    // this stub or fall back to fork+exec". The standard library records a dup2
+    // action and calls it anyway, so the redirection is dropped without an
+    // error and the child writes to whatever stdout this process had. Measured
+    // on linux/aarch64 against libchdb.a v26.7.0: the case output appeared on
+    // the parent's stdout and the capture came back empty.
+    //
+    // A pre_exec closure is what makes the standard library skip the posix_spawn
+    // fast path. The fork/exec path calls dup2 directly, and that symbol the
+    // archive does not define.
+    //
+    // SAFETY: the closure allocates nothing, takes no locks and only returns
+    // Ok, which is all that is allowed between fork and exec.
+    #[cfg(unix)]
+    unsafe {
+        command.pre_exec(|| Ok(()));
+    }
+
+    let mut child = command.spawn().map_err(|e| format!("cannot spawn: {e}"))?;
+
+    let mut pipe = child.stdout.take().ok_or("stdout was not piped")?;
+    let reader = std::thread::spawn(move || {
+        let mut captured = Vec::new();
+        let _ = pipe.read_to_end(&mut captured);
+        captured
+    });
 
     let started = Instant::now();
     let status = loop {
@@ -557,9 +585,12 @@ fn run_child(exe: &Path, case: &Case) -> Result<Duration, String> {
     };
     let elapsed = started.elapsed();
 
-    let actual = std::fs::read_to_string(&stdout_path)
-        .map_err(|e| format!("cannot read captured stdout: {e}"))?;
-    let _ = std::fs::remove_file(&stdout_path);
+    // The child is gone, so the write end of the pipe is closed and the reader
+    // has seen EOF.
+    let captured = reader.join().map_err(|_| "the capture thread panicked")?;
+    // Lossy rather than an error: output mangled into invalid UTF-8 is one of
+    // the symptoms, and showing it beats refusing to compare it.
+    let actual = String::from_utf8_lossy(&captured);
 
     // Exit status first: a correct answer from a process that then died is not a
     // pass, and it is the shape process-exit faults take.

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -1,0 +1,79 @@
+//! The version accessors, and the invariant that ties the compile-time one to
+//! the run-time one.
+
+use chdb_rust::version::{
+    clickhouse_version, engine_version, ENGINE_SOURCE, EXPECTED_ENGINE_VERSION,
+};
+
+#[test]
+fn engine_version_reports_a_chdb_core_release() {
+    let version = engine_version().unwrap_or_else(|e| panic!("engine from {ENGINE_SOURCE}: {e}"));
+
+    assert!(!version.is_empty(), "engine from {ENGINE_SOURCE}");
+    // The `v` belongs to the release tag and nowhere else: everything compares
+    // these by plain string equality, which needs one spelling.
+    assert!(
+        !version.starts_with('v'),
+        "{version} still carries the tag's v"
+    );
+    assert!(
+        version.starts_with(|c: char| c.is_ascii_digit()),
+        "{version} does not start with a version field"
+    );
+}
+
+#[test]
+fn expected_and_reported_engine_versions_agree() {
+    let Some(expected) = EXPECTED_ENGINE_VERSION else {
+        // The build linked a library it did not fetch, so there is no second
+        // number to compare against. ENGINE_SOURCE says which case this is.
+        return;
+    };
+
+    let reported = engine_version().unwrap_or_else(|e| panic!("engine from {ENGINE_SOURCE}: {e}"));
+    assert_eq!(
+        expected, reported,
+        "the build fetched {expected} but the linked library reports {reported} ({ENGINE_SOURCE})"
+    );
+}
+
+/// The failure this guards against is a constant that describes the pin while
+/// some other artifact is what actually got linked — a claim about the binary
+/// that is not true of the binary.
+#[test]
+fn expected_engine_version_only_speaks_for_a_fetched_library() {
+    if ENGINE_SOURCE.starts_with("download:") {
+        assert!(
+            EXPECTED_ENGINE_VERSION.is_some(),
+            "{ENGINE_SOURCE} fetched an engine, so its release is known"
+        );
+    } else {
+        assert!(
+            EXPECTED_ENGINE_VERSION.is_none(),
+            "{ENGINE_SOURCE} is not a download, so no chdb-core release can be claimed"
+        );
+    }
+}
+
+#[test]
+fn clickhouse_version_reports_the_clickhouse_scheme() {
+    let version = clickhouse_version().expect("SELECT version()");
+    let fields: Vec<&str> = version.split('.').collect();
+
+    assert!(
+        fields.len() >= 3,
+        "{version} does not look like a ClickHouse version"
+    );
+    assert!(
+        fields
+            .iter()
+            .take(3)
+            .all(|field| !field.is_empty() && field.chars().all(|c| c.is_ascii_digit())),
+        "{version} does not look like a ClickHouse version"
+    );
+}
+
+#[test]
+fn engine_source_is_recorded() {
+    assert!(!ENGINE_SOURCE.is_empty());
+}


### PR DESCRIPTION
Part of #40. Everything here is independent of chdb-io/chdb-core#198 — the two
pieces that wait on it, moving the engine pin and the 12.0 macOS
deployment-target matrix cell, are deliberately not in this PR.

**`--features static` was not linking statically.** `rustc-link-lib=static=chdb`
reaches the linker as a plain `-lchdb` for any target that compiles the crate
directly, and the search directories build.rs offered are exactly where a dynamic
libchdb lives. Measured on macOS: a 1.5 MB test binary with a dynamic dependency
on libchdb, passing the whole suite. It now links through a directory holding
nothing but the archive. Discovery had the mirror-image bug — it only looked for
the dynamic library, so on a machine that had one, `--features static` skipped
the download and then asked rustc for an archive nobody fetched.

**CI now links what it claims to test.** A `static` job on Linux and macOS, and
`check-static-link.sh` asserting the property rather than the flag: per test
binary, no dynamic libchdb dependency and `chdb_connect` defined in the file. The
tests run from that same checked list, so nothing can relink in between.

**Three version accessors** (`version` module), one scheme each and no falling
back to another: `EXPECTED_ENGINE_VERSION` (chdb-core, compile time),
`engine_version()` (chdb-core, from the library), `clickhouse_version()`
(ClickHouse, from a query). The constant is `None` rather than the pin whenever
the build linked a library it did not fetch; `ENGINE_SOURCE` says where it came
from.

**`CHDB_LIB_DIR` / `CHDB_INCLUDE_DIR`** build against an engine you built
yourself. Separate variables because a chdb-core build tree leaves `libchdb.a` at
the repository root and the header in `programs/local`.

**The engine is fetched once.** It was unpacked into `OUT_DIR`, which Cargo hands
out per profile and per feature combination: 4.9 GB under `target/` here, seven
copies of two engines. Now a shared cache keyed by tag and asset, movable with
`CHDB_ENGINE_CACHE_DIR`.

**Docs**: what each linkage costs, that a dynamically linked binary does not run
outside Cargo without an rpath or `LD_LIBRARY_PATH`/`DYLD_LIBRARY_PATH` (all
three remedies checked), and `[profile.release] strip = "symbols"` — 490 MB to
361 MB, and only the user can set it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `static` feature and strict engine resolution to `build.rs`
> - Adds a `static` cargo feature; `isolate_archive` symlinks `libchdb.a` into a dedicated directory so the linker cannot pick up a dynamic `libchdb`.
> - Refactors engine resolution to honor `CHDB_LIB_DIR`/`CHDB_INCLUDE_DIR` strictly (errors if invalid), prefer existing local/system installations, and otherwise download to a shared cache outside `target/` keyed by `CHDB_ENGINE_CACHE_DIR`.
> - Publishes `CHDB_EXPECTED_ENGINE_VERSION` and `CHDB_ENGINE_SOURCE` at build time; new `version` module exposes `engine_version()`, `clickhouse_version()`, and compile-time provenance constants.
> - Adds a `runtime_faces` custom test harness (harness = false) that spawns per-case subprocesses to catch C++ runtime duplication and static-linking issues (locale, exceptions, `std::filesystem`, MergeTree, concurrency, Arrow callbacks).
> - CI gains a `static` job (Linux + macOS) that builds with `--features static`, verifies each test binary statically links the engine via [check-static-link.sh](https://github.com/chdb-io/chdb-rust/pull/41/files#diff-01570e20ad1534dbce41d4f52bb31ccc5835fa9be613a8f2ba3ac65842089ef4), then runs the binaries directly.
> - Risk: `find_existing_libchdb` now requires both a linkage-matching library file and `chdb.h` in `./` or `/usr/local/{lib,include}`; builds that previously fell back silently to a download will now use the local copy or fail. `Error::EngineVersionUnavailable` is a new variant returned by `engine_version()` when the linked library predates chdb-core v26.7.0.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 378a7f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->