### PR TITLE
Guard the chained-fixup path without moving anything else to macOS 12

### DIFF
--- a/.github/scripts/check-static-link.sh
+++ b/.github/scripts/check-static-link.sh
@@ -14,12 +14,17 @@
 # Two checks per binary:
 #
 #   1. no dynamic dependency on libchdb
-#   2. the C API is defined inside the binary
+#   2. the C API is not imported - it is either defined here or not referenced
 #
 # The first can pass on its own for a binary that finds libchdb through a
 # mechanism the check does not read, such as a dlopen. The second can pass on
 # its own for a binary that also carries a dynamic reference. Together they say
 # the engine is in this file and is not being loaded from anywhere else.
+#
+# "Not imported" rather than "defined here", because a test that never calls the
+# engine is legitimately linked without it: the linker drops what nothing
+# references. What must never happen is an undefined reference, which is exactly
+# how the engine would be arriving dynamically.
 #
 # Usage: check-static-link.sh <binary>...
 
@@ -68,12 +73,15 @@ for bin in "$@"; do
 		echo "   ok: no dynamic libchdb dependency"
 	fi
 
-	if nm "$bin" 2>/dev/null | grep -Eq "[[:space:]][Tt][[:space:]]_?${symbol}\$"; then
+	symbols=$(nm "$bin" 2>/dev/null | grep -E "[[:space:]]_?${symbol}\$" || true)
+	if printf '%s\n' "$symbols" | grep -Eq "[[:space:]]U[[:space:]]_?${symbol}\$"; then
+		echo "   FAIL: ${symbol} is imported, so the engine is arriving from elsewhere"
+		printf '%s\n' "$symbols" | sed 's/^/     /'
+		failed=1
+	elif printf '%s\n' "$symbols" | grep -Eq "[[:space:]][Tt][[:space:]]_?${symbol}\$"; then
 		echo "   ok: ${symbol} is defined here"
 	else
-		echo "   FAIL: ${symbol} is not defined here, so the engine is elsewhere"
-		nm "$bin" 2>/dev/null | grep -E "[[:space:]]_?${symbol}\$" | sed 's/^/     /' || true
-		failed=1
+		echo "   ok: ${symbol} is not referenced, so nothing was linked for it"
 	fi
 
 	echo "   size: $(wc -c <"$bin" | tr -d ' ') bytes"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -111,14 +111,23 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: cargo clippy --all-targets --all-features -- --deny warnings
 
+    # --tests, because without it cargo also links the eight examples, and the
+    # filter below then discards them: seventeen artifacts of a few hundred
+    # megabytes built to keep nine.
+    #
+    # -j 2, because one link of this crate peaks at 4.7 GiB of resident memory,
+    # measured on aarch64 with GNU time. Cargo defaults to one job per core, so
+    # four of those at once want around 19 GiB on a runner that has 16, and the
+    # kernel takes the runner agent down with the build. Two fit.
+    #
+    # Both numbers are printed: the disk one because it was the first suspect
+    # and turned out to have 109 GB spare, the memory one because it is the
+    # constraint that actually binds.
     - name: Build the tests
       run: |
-        # Printed because the way this job fails when it runs out is as a dead
-        # runner rather than as a build error: nine test binaries of a few
-        # hundred megabytes each, plus the unpacked archive and the rlib that
-        # carries a copy of it.
         df -h /
-        cargo test --features static --no-run --message-format=json > artifacts.json
+        free -m || true
+        cargo test --features static --no-run --tests -j 2 --message-format=json > artifacts.json
         jq -r 'select(.reason == "compiler-artifact" and .profile.test == true and .executable != null)
                | .executable' artifacts.json > test-binaries.txt
         if [ ! -s test-binaries.txt ]; then

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -102,11 +102,22 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    # One cell, like the other lints: what clippy reports does not vary by
+    # architecture, and this is the step that materialises a second copy of the
+    # engine as a static rlib. Leaving it on every cell cost the arm64 runner
+    # its disk, and the runner service dies with it - "the runner has received a
+    # shutdown signal", exit 143, at the same point in the next step every time.
     - name: Check clippy with every feature
+      if: matrix.os == 'ubuntu-latest'
       run: cargo clippy --all-targets --all-features -- --deny warnings
 
     - name: Build the tests
       run: |
+        # Printed because the way this job fails when it runs out is as a dead
+        # runner rather than as a build error: nine test binaries of a few
+        # hundred megabytes each, plus the unpacked archive and the rlib that
+        # carries a copy of it.
+        df -h /
         cargo test --features static --no-run --message-format=json > artifacts.json
         jq -r 'select(.reason == "compiler-artifact" and .profile.test == true and .executable != null)
                | .executable' artifacts.json > test-binaries.txt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,21 +59,17 @@ jobs:
   # the static archive and there is no dynamic library anywhere for the link to
   # reach instead, which is half of what check-static-link.sh then confirms.
   #
-  # Both cells take rustc's default macOS deployment target, and one more cell
-  # belongs here that is not here yet. 12.0 is where the linker starts emitting
-  # chained fixups, which is the mechanism that can bind a call inside the
-  # archive to the system C++ runtime instead of the copy the archive carries;
-  # below 12.0 there are none, so this job establishes that the tests ran
-  # against the archive but says nothing about that binding. Measured against
-  # the currently pinned engine: at the default 11.0 the suite passes, at 12.0 it
-  # hangs partway through and has to be killed. So the cell would be red for a
-  # reason that is not this repository's to fix - it is chdb-io/chdb-core#198,
-  # which bakes the visibility gate into the archive at compile time. Add
-  # `MACOSX_DEPLOYMENT_TARGET: "12.0"` as a matrix dimension when the pin moves
-  # to a release carrying that fix, and give each value its own
-  # CARGO_TARGET_DIR: the variable is not part of cargo's fingerprint, so
-  # changing it does not relink, and two cells sharing a target directory would
-  # test whichever binary was built first.
+  # CHDB_TEST_MIN_MACOS raises the macOS deployment floor of this crate's test
+  # binaries and nothing else. That is where the property has to be exercised:
+  # under macOS 12 the linker emits no chained fixups, so nothing can rebind a
+  # call made inside the archive to the system C++ runtime, and a green run
+  # would say nothing about whether it could. The library, the examples and
+  # anything a user builds stay at the default floor - see build.rs.
+  #
+  # It goes through the build script rather than MACOSX_DEPLOYMENT_TARGET
+  # because that variable is not part of Cargo's fingerprint: changing it does
+  # not relink, so a second cell sharing a target directory would silently
+  # re-run the first cell's binaries. A build script's output is fingerprinted.
   static:
     needs: engine_pin
     strategy:
@@ -81,8 +77,15 @@ jobs:
       # with different linkers and only one of them has ever had this problem.
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+          - os: macos-latest
+            test_min_macos: "12.0"
     runs-on: ${{ matrix.os }}
+    env:
+      # Empty on the platforms that have no deployment target, which build.rs
+      # reads as unset.
+      CHDB_TEST_MIN_MACOS: ${{ matrix.test_min_macos }}
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,20 +24,28 @@ jobs:
     # it and reports test results for it, which is exactly the misleading outcome
     # the check exists to prevent.
     needs: engine_pin
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-15-intel]
+    runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
-    - name: Fetch library
-      run: |
-          bash update_libchdb.sh --local
-          sudo mv libchdb.so /usr/lib/libchdb.so
-          sudo ldconfig
+    - uses: actions/checkout@v4
+    # --global rather than moving the library into /usr/lib by hand: it installs
+    # into /usr/local, which is on the default search path of both loaders, and
+    # skips ldconfig where there is none. One command for every platform here,
+    # and the same one the README gives users.
+    - name: Install the engine
+      run: ./update_libchdb.sh --global
+    # Once rather than once per platform: neither depends on the target.
     - name: Check formatting
+      if: matrix.os == 'ubuntu-latest'
       run: cargo fmt --check
     # Default features only. --all-features enables `static`, which downloads a
     # few hundred megabytes of archive that clippy then does not link; that
     # belongs in the job that links it.
     - name: Check clippy
+      if: matrix.os == 'ubuntu-latest'
       run: cargo clippy --all-targets -- --deny warnings
     - name: Build
       run: cargo build --verbose
@@ -73,13 +81,18 @@ jobs:
   static:
     needs: engine_pin
     strategy:
-      # One platform failing should not hide the other's result: the two link
-      # with different linkers and only one of them has ever had this problem.
+      # The four platforms this crate claims to support. One failing should not
+      # hide the others: the two operating systems link with different linkers,
+      # only one of them has ever had this problem, and the two architectures
+      # get separately built archives.
       fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
           - os: macos-latest
+            test_min_macos: "12.0"
+          - os: macos-15-intel
             test_min_macos: "12.0"
     runs-on: ${{ matrix.os }}
     env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ harness = false
 #
 # .github/scripts/check-engine-pin.sh keeps it in step with build.rs and
 # update_libchdb.sh, which are what actually fetch the engine.
-engine = "v26.7.0"
+engine = "v26.7.2-rc.2"
 
 [package.metadata.docs.rs]
 # docs.rs cannot download libchdb or link native libraries.

--- a/build.rs
+++ b/build.rs
@@ -15,7 +15,7 @@ fn main() {
     if env::var("DOCS_RS").is_ok() {
         // docs.rs links no engine, but the version accessors still have to
         // compile, and they read their provenance out of the environment.
-        publish_engine_provenance(None, "none: docs.rs build");
+        publish_engine_provenance(None, "none: docs.rs build", Path::new(""));
         return;
     }
 
@@ -26,7 +26,7 @@ fn main() {
     let libchdb_info = find_libchdb_or_download(&out_path);
     match libchdb_info {
         Ok(engine) => {
-            publish_engine_provenance(engine.version.as_deref(), &engine.source);
+            publish_engine_provenance(engine.version.as_deref(), &engine.source, &engine.lib_path);
             setup_link_paths(&engine.lib_path, &engine.header_path, &out_path);
             generate_bindings(&engine.header_path, &out_path);
         }
@@ -64,12 +64,18 @@ struct Engine {
 /// build did not fetch the engine itself. A constant that reports the pin while
 /// the artifact came from somewhere else is worse than no constant at all: it
 /// reads as a fact about the linked library and is not one.
-fn publish_engine_provenance(version: Option<&str>, source: &str) {
+fn publish_engine_provenance(version: Option<&str>, source: &str, lib_path: &Path) {
     println!(
         "cargo:rustc-env=CHDB_EXPECTED_ENGINE_VERSION={}",
         version.unwrap_or_default()
     );
     println!("cargo:rustc-env=CHDB_ENGINE_SOURCE={source}");
+    // The artifact itself, so a test can inspect what was linked rather than
+    // guess where it came from.
+    println!(
+        "cargo:rustc-env=CHDB_LINKED_ARTIFACT={}",
+        lib_path.display()
+    );
 }
 
 /// Below this the linker emits no chained fixups, and a run proves nothing.

--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 /// The engine this crate is developed against, used when no libchdb is already
 /// present. Keep it on its own line and in step with CHDB_ENGINE_PIN in
 /// update_libchdb.sh: the release check greps for both when it proposes a bump.
-const CHDB_ENGINE_PIN: &str = "v26.7.0";
+const CHDB_ENGINE_PIN: &str = "v26.7.2-rc.2";
 
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(direct_arrow_insert)");

--- a/build.rs
+++ b/build.rs
@@ -19,6 +19,8 @@ fn main() {
         return;
     }
 
+    emit_test_macos_floor();
+
     let out_dir = env::var("OUT_DIR").unwrap();
     let out_path = PathBuf::from(&out_dir);
     let libchdb_info = find_libchdb_or_download(&out_path);
@@ -68,6 +70,73 @@ fn publish_engine_provenance(version: Option<&str>, source: &str) {
         version.unwrap_or_default()
     );
     println!("cargo:rustc-env=CHDB_ENGINE_SOURCE={source}");
+}
+
+/// Below this the linker emits no chained fixups, and a run proves nothing.
+const TEST_MIN_MACOS_FLOOR: u32 = 12;
+
+/// A macOS deployment floor for this crate's own test binaries.
+///
+/// What static linking has to be guarded against is decided at the final link:
+/// under macOS 12 the linker emits no chained fixups, so nothing can rebind a
+/// call inside the archive to the system C++ runtime and a green run says
+/// nothing about whether it could. Raising the floor is therefore the only way
+/// to exercise it — but the library, the examples and anything a user builds
+/// have no reason to move, which is why this goes out as `rustc-link-arg-tests`
+/// and reaches the test binaries alone. Measured: they come out at `minos 12.0`
+/// while an example beside them stays at the default 11.0.
+///
+/// One gap, since the directive is keyed on target kind: the unit-test binary
+/// built from the library is a `lib` target rather than a `test` one, so it
+/// keeps the default floor. The eight integration test binaries do get the
+/// floor, `runtime_faces` among them — and that is the suite written for this
+/// exact question, where all ten cases hang against an ungated archive. So what
+/// stays at the default is covered elsewhere at the raised one.
+///
+/// Opt-in, because a binary whose floor is above the running OS cannot run
+/// there. CI sets it; someone on an older macOS is not forced to.
+///
+/// Routing it through the build script rather than setting
+/// `MACOSX_DEPLOYMENT_TARGET` for the whole build is also what makes it take
+/// effect. That variable is not part of Cargo's fingerprint — measured, changing
+/// it does not relink — so two runs at different floors can silently share one
+/// binary. A build script's output is fingerprinted, so changing this does
+/// relink.
+fn emit_test_macos_floor() {
+    println!("cargo:rerun-if-env-changed=CHDB_TEST_MIN_MACOS");
+    let Some(floor) = env_dir("CHDB_TEST_MIN_MACOS") else {
+        return;
+    };
+    let Some(floor) = floor.to_str() else {
+        println!("cargo:warning=CHDB_TEST_MIN_MACOS is not a version number");
+        std::process::exit(1);
+    };
+
+    if target_platform().0 != "macos" {
+        // Said out loud rather than ignored: a floor set for a target that has
+        // no deployment target at all is a mistake somewhere, and silence would
+        // read as "the guard is on".
+        println!("cargo:warning=CHDB_TEST_MIN_MACOS={floor} ignored: the target is not macOS");
+        return;
+    }
+
+    let major = floor
+        .split('.')
+        .next()
+        .and_then(|major| major.parse::<u32>().ok());
+    match major {
+        Some(major) if major >= TEST_MIN_MACOS_FLOOR => {
+            println!("cargo:rustc-link-arg-tests=-mmacosx-version-min={floor}");
+        }
+        Some(_) => {
+            println!("cargo:warning=CHDB_TEST_MIN_MACOS={floor} is below {TEST_MIN_MACOS_FLOOR}: the linker emits no chained fixups under that, so the tests would pass without exercising the binding this floor exists to exercise");
+            std::process::exit(1);
+        }
+        None => {
+            println!("cargo:warning=CHDB_TEST_MIN_MACOS={floor} does not start with a major version number");
+            std::process::exit(1);
+        }
+    }
 }
 
 /// Whether the enabled features ask rustc to link the engine statically.

--- a/tests/bundled_runtime_hidden.rs
+++ b/tests/bundled_runtime_hidden.rs
@@ -1,0 +1,228 @@
+//! The bundled C++ runtime must not be visible from outside the archive.
+//!
+//! This is the cause the runtime cases in `runtime_faces.rs` observe the effect
+//! of, checked directly and without linking anything.
+//!
+//! `libchdb.so` / `.dylib` gate their exports at link time, with a version
+//! script on Linux and an exported-symbols list on macOS, which is why dynamic
+//! linking never had this problem. An archive has no link step of its own: every
+//! symbol it carries reaches the final artifact and takes part in resolution. So
+//! for a static build the gate has to be compiled into the objects, and this
+//! asserts that it was — that the three bundled runtime targets have no
+//! externally visible definitions at all.
+//!
+//! Two reasons to check the cause and not only the effect. It holds on Linux,
+//! where the visibility can regress with no symptom to observe, so no runtime
+//! case would notice. And it needs no elevated deployment target, no linker and
+//! no process: it reads the archive this build is about to link.
+//!
+//! Not a reimplementation for its own sake — chdb-core runs the same assertion
+//! over its own build output (`chdb/build/check_static_lib_hermetic.sh`, gate
+//! 2). That one guards the release; this one guards what actually arrived.
+//!
+//! Measured across the two engines this crate has been pinned to: v26.7.0 shows
+//! 2365 externally visible definitions among 58 runtime members, and
+//! v26.7.2-rc.2 shows 0 among the same 58.
+
+mod common;
+
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+
+/// The archive members holding the bundled runtime, by the naming chdb-core's
+/// `create_static_libchdb.py` gives them.
+const RUNTIME_MEMBER_PREFIXES: [&str; 3] = ["libcxx__", "libcxxabi__", "libunwind__"];
+
+/// How many offending symbols to print before giving up on the reader.
+const OFFENDERS_SHOWN: usize = 20;
+
+#[test]
+fn bundled_runtime_objects_export_nothing() {
+    let artifact = Path::new(env!("CHDB_LINKED_ARTIFACT"));
+    assert!(
+        !artifact.as_os_str().is_empty(),
+        "the build script did not record which artifact it linked"
+    );
+
+    if artifact.extension().is_none_or(|kind| kind != "a") {
+        println!(
+            "not applicable: {} is not an archive. A dynamic library gates its \
+             exports at its own link step, so there is nothing here to check.",
+            artifact.display()
+        );
+        return;
+    }
+
+    let members = runtime_members(artifact);
+    // Zero would mean the naming changed and this test had quietly stopped
+    // testing anything, which is worse than a failure.
+    assert!(
+        !members.is_empty(),
+        "no {RUNTIME_MEMBER_PREFIXES:?} members among the archive's members: either the \
+         bundled runtime is no longer a separate set of objects, or chdb-core renamed them"
+    );
+
+    let scratch = common::tempdir();
+    let objects = extract(artifact, &members, scratch.path());
+    assert_eq!(
+        objects.len(),
+        members.len(),
+        "extracted {} of {} runtime members",
+        objects.len(),
+        members.len()
+    );
+
+    let (defined, visible) = symbols(&objects);
+
+    println!(
+        "{}: {} runtime members, {} definitions, {} externally visible",
+        artifact.display(),
+        members.len(),
+        defined,
+        visible.len()
+    );
+
+    if !visible.is_empty() {
+        for symbol in visible.iter().take(OFFENDERS_SHOWN) {
+            println!("  {symbol}");
+        }
+        if visible.len() > OFFENDERS_SHOWN {
+            println!("  ... and {} more", visible.len() - OFFENDERS_SHOWN);
+        }
+    }
+
+    // Asserted at zero rather than "disjoint from this host's system runtime".
+    // These targets are built to have no externally visible definitions at all,
+    // and a symbol that merely happens to be absent from the running OS version
+    // would otherwise slip through.
+    assert!(
+        visible.is_empty(),
+        "{} of {} definitions in the bundled runtime are visible from outside the \
+         archive; a static build can then bind a call made inside the engine to \
+         another copy of the C++ runtime",
+        visible.len(),
+        defined
+    );
+}
+
+/// Runs `program`, requiring it to succeed, and returns its stdout.
+fn run(program: &str, args: &[&OsStr], cwd: Option<&Path>) -> String {
+    let mut command = common::command(program);
+    command.args(args);
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+
+    let output = command
+        .output()
+        .unwrap_or_else(|e| panic!("cannot run {program}: {e}"));
+    assert!(
+        output.status.success(),
+        "{program} exited with {}: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn runtime_members(artifact: &Path) -> Vec<String> {
+    run("ar", &[OsStr::new("t"), artifact.as_os_str()], None)
+        .lines()
+        .map(str::trim)
+        .filter(|member| {
+            RUNTIME_MEMBER_PREFIXES
+                .iter()
+                .any(|prefix| member.starts_with(prefix))
+        })
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Extracts `members` into `into`, returning the object files that appeared.
+fn extract(artifact: &Path, members: &[String], into: &Path) -> Vec<PathBuf> {
+    // `ar x` writes into the working directory, so the archive has to be named
+    // absolutely from there.
+    let artifact = artifact
+        .canonicalize()
+        .unwrap_or_else(|e| panic!("cannot resolve {}: {e}", artifact.display()));
+
+    let mut args: Vec<&OsStr> = vec![OsStr::new("x"), artifact.as_os_str()];
+    args.extend(members.iter().map(|member| OsStr::new(member.as_str())));
+    run("ar", &args, Some(into));
+
+    members
+        .iter()
+        .map(|member| into.join(member))
+        .filter(|path| path.exists())
+        .collect()
+}
+
+/// The distinct definitions across `objects`, and which of them are visible
+/// from outside their object.
+fn symbols(objects: &[PathBuf]) -> (usize, Vec<String>) {
+    let args: Vec<&OsStr> = objects.iter().map(|path| path.as_os_str()).collect();
+
+    if cfg!(target_os = "macos") {
+        // Only the -m listing spells out "private external". Plain -g shows
+        // hidden symbols as well and would report a gated archive as wide open.
+        let mut nm = vec![
+            OsStr::new("-m"),
+            OsStr::new("-g"),
+            OsStr::new("--defined-only"),
+        ];
+        nm.extend_from_slice(&args);
+        let listing = run("nm", &nm, None);
+        let mut defined = Vec::new();
+        let mut visible = Vec::new();
+        for line in listing.lines() {
+            let Some(symbol) = line.split_whitespace().next_back() else {
+                continue;
+            };
+            let Some(symbol) = symbol.strip_prefix('_') else {
+                continue;
+            };
+            defined.push(symbol.to_owned());
+            if !line.contains("private external") {
+                visible.push(symbol.to_owned());
+            }
+        }
+        counted(defined, visible)
+    } else {
+        let mut readelf = vec![OsStr::new("-sW")];
+        readelf.extend_from_slice(&args);
+        let listing = run("readelf", &readelf, None);
+        let mut defined = Vec::new();
+        let mut visible = Vec::new();
+        for line in listing.lines() {
+            let fields: Vec<&str> = line.split_whitespace().collect();
+            // Num: Value Size Type Bind Vis Ndx Name
+            if fields.len() < 8 || !fields[0].ends_with(':') {
+                continue;
+            }
+            let (bind, vis, ndx, name) = (fields[4], fields[5], fields[6], fields[7]);
+            if ndx == "UND" || !matches!(bind, "GLOBAL" | "WEAK") {
+                continue;
+            }
+            let name = name.split('@').next().unwrap_or_default();
+            if name.is_empty() {
+                continue;
+            }
+            defined.push(name.to_owned());
+            if matches!(vis, "DEFAULT" | "PROTECTED") {
+                visible.push(name.to_owned());
+            }
+        }
+        counted(defined, visible)
+    }
+}
+
+/// Both counted as distinct names, so the two numbers in a failure message are
+/// in the same unit.
+fn counted(mut defined: Vec<String>, mut visible: Vec<String>) -> (usize, Vec<String>) {
+    defined.sort_unstable();
+    defined.dedup();
+    visible.sort_unstable();
+    visible.dedup();
+    (defined.len(), visible)
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,3 +1,39 @@
+// Shared by several test binaries, each of which uses a different part of it.
+#![allow(dead_code)]
+
+use std::ffi::OsStr;
+use std::process::Command;
+
 pub fn tempdir() -> tempdir::TempDir {
     tempdir::TempDir::new("chdb-rust").expect("failed to create temp dir")
+}
+
+/// A [`Command`] whose stdio redirection survives static linking.
+///
+/// A statically linked artifact resolves `posix_spawn` and the whole
+/// `posix_spawn_file_actions_*` family against `libchdb.a`, which carries
+/// ClickHouse's glibc-compatibility shims. That `posix_spawn` deliberately does
+/// not walk file actions — its own source says "callers that need file actions
+/// must avoid this stub or fall back to fork+exec" — so the standard library
+/// records a dup2 action, calls it, gets no error back, and the child quietly
+/// inherits this process's stdout. Measured against the published archive on
+/// linux/aarch64: captured output came back empty while the child's answer
+/// appeared on the parent's stdout.
+///
+/// An empty `pre_exec` closure is what makes the standard library skip the
+/// `posix_spawn` fast path, which is the fallback that source recommends. The
+/// fork/exec path calls `dup2` directly, and that symbol the archive does not
+/// define.
+pub fn command(program: impl AsRef<OsStr>) -> Command {
+    let mut command = Command::new(program);
+
+    // SAFETY: the closure allocates nothing, takes no locks and only returns
+    // Ok, which is all that is allowed between fork and exec.
+    #[cfg(unix)]
+    unsafe {
+        use std::os::unix::process::CommandExt as _;
+        command.pre_exec(|| Ok(()));
+    }
+
+    command
 }

--- a/tests/runtime_faces.rs
+++ b/tests/runtime_faces.rs
@@ -30,11 +30,11 @@
 
 use std::fmt::Write as _;
 use std::io::{Read as _, Write as _};
-#[cfg(unix)]
-use std::os::unix::process::CommandExt as _;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 use std::time::{Duration, Instant};
+
+mod common;
 
 use chdb_rust::connection::Connection;
 use chdb_rust::error::Error;
@@ -523,37 +523,12 @@ fn run_child(exe: &Path, case: &Case) -> Result<Duration, String> {
     // yet, and nothing here depends on a writable temp directory. stderr is
     // inherited: the diagnostics are there, and swallowing them is how a failure
     // becomes unexplainable.
-    let mut command = Command::new(exe);
+    let mut command = common::command(exe);
     command
         .env(CASE_ENV, case.name)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit());
-
-    // Force the standard library onto its fork/exec path.
-    //
-    // A statically linked artifact resolves posix_spawn and the whole
-    // posix_spawn_file_actions_* family against the engine's archive, which
-    // carries ClickHouse's glibc-compatibility shims. That posix_spawn
-    // deliberately ignores file actions - its own source says so: "callers are
-    // compiled against glibc's <spawn.h> ... walking it as `struct fdop` would
-    // dereference garbage. Posix_spawn callers that need file actions must avoid
-    // this stub or fall back to fork+exec". The standard library records a dup2
-    // action and calls it anyway, so the redirection is dropped without an
-    // error and the child writes to whatever stdout this process had. Measured
-    // on linux/aarch64 against libchdb.a v26.7.0: the case output appeared on
-    // the parent's stdout and the capture came back empty.
-    //
-    // A pre_exec closure is what makes the standard library skip the posix_spawn
-    // fast path. The fork/exec path calls dup2 directly, and that symbol the
-    // archive does not define.
-    //
-    // SAFETY: the closure allocates nothing, takes no locks and only returns
-    // Ok, which is all that is allowed between fork and exec.
-    #[cfg(unix)]
-    unsafe {
-        command.pre_exec(|| Ok(()));
-    }
 
     let mut child = command.spawn().map_err(|e| format!("cannot spawn: {e}"))?;
 

--- a/update_libchdb.sh
+++ b/update_libchdb.sh
@@ -31,7 +31,7 @@ download_and_extract() {
 # The engine this crate is developed against. Keep it on its own line and
 # literal, and in step with CHDB_ENGINE_PIN in build.rs: the release check greps
 # for both when it proposes a bump.
-CHDB_ENGINE_PIN=v26.7.0
+CHDB_ENGINE_PIN=v26.7.2-rc.2
 
 # CHDB_ENGINE_VERSION overrides the pin, which is how the release check runs the
 # suite against an engine this repository has not adopted yet.


### PR DESCRIPTION
Follows #41. chdb-io/chdb-core#199 is merged and v26.7.2-rc.2 carries it, so static linking on macOS can finally be exercised where it matters.

**The engine pin moves to v26.7.2-rc.2.** Measured on the published macos-arm64 archive: 58 bundled-runtime members either way, and 2365 of their definitions externally visible at v26.7.0 against 0 at v26.7.2-rc.2. Still an rc, and nothing is published from this branch.

**The deployment floor is raised for the test binaries alone.** Under macOS 12 the linker emits no chained fixups, so a green run says nothing about whether a call made inside the archive can bind to the system C++ runtime. `CHDB_TEST_MIN_MACOS` goes out as `cargo:rustc-link-arg-tests`, so eight test binaries link at `minos 12.0` while the library, the examples and anything a user builds stay at the default. Routing it through the build script rather than setting `MACOSX_DEPLOYMENT_TARGET` is also what makes it take effect: that variable is not part of Cargo's fingerprint, so changing it does not relink — which is why the static job needs no second matrix cell and no second target directory.

**A new test asserts the cause rather than the effect.** It reads the archive the build is about to link and requires the bundled libc++ / libc++abi / libunwind objects to have no externally visible definitions: no linker, no elevated deployment target, a tenth of a second. It fails against v26.7.0 (2365 visible) and passes against v26.7.2-rc.2 (0). It also holds on Linux, where that visibility can regress with no symptom for any runtime case to observe.

**One check reworded.** The static gate required every test binary to define `chdb_connect`, but a test that never calls the engine is legitimately linked without it. It now fails on an *imported* symbol instead, which is the state that actually means the engine is arriving dynamically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Apply macOS 12 deployment floor only to static test binaries
> - The build script handles `CHDB_TEST_MIN_MACOS` in [build.rs](https://github.com/chdb-io/chdb-rust/pull/42/files#diff-d0d98998092552a1d3259338c2c71e118a5b8343dd4703c0c7f552ada7f9cb42) via `emit_test_macos_floor`, passing a deployment-target link arg to test binaries only on macOS with a valid major version ≥12; invalid values fail the build, non-macOS targets emit a warning.
> - CI build and static-link jobs in [.github/workflows/rust.yml](https://github.com/chdb-io/chdb-rust/pull/42/files#diff-73e17259d77e5fbef83b2bdbbe4dc40a912f807472287f7f45b77e0cbf78792d) now use a 4-cell matrix (Ubuntu x86_64, Ubuntu arm64, macOS arm64, macOS Intel). macOS cells set `CHDB_TEST_MIN_MACOS=12.0`; formatting and clippy run only on the Ubuntu x86_64 cell.
> - New test in [tests/bundled_runtime_hidden.rs](https://github.com/chdb-io/chdb-rust/pull/42/files#diff-df7181958112e3fb6d0070f4c2055ccafa5e7ed21a62ef6fedcd67fbb12dfafb) extracts bundled libc++, libc++abi, and libunwind archive members and fails if any have externally visible symbols or if no runtime members are found.
> - Engine pin bumped from v26.7.0 to v26.7.2-rc.2 in [Cargo.toml](https://github.com/chdb-io/chdb-rust/pull/42/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542) and [update_libchdb.sh](https://github.com/chdb-io/chdb-rust/pull/42/files#diff-6f35e23173ec48cae47760551bfa867846783d6a777bcf30354d7dd8e2e11ecb); build script now records the resolved artifact path in `CHDB_LINKED_ARTIFACT` for crate and test consumption.
> - Behavioral Change: [check-static-link.sh](https://github.com/chdb-io/chdb-rust/pull/42/files#diff-01570e20ad1534dbce41d4f52bb31ccc5835fa9be613a8f2ba3ac65842089ef4) now rejects binaries with an undefined/imported engine symbol but accepts binaries that do not reference the engine at all, replacing the previous check that required a defined engine symbol in every binary.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d508e2a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->