### PR TITLE
Give sessions a shared engine record, and stop them deleting each other's data

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,60 @@ engine's own debug information is already gone before it reaches you — chdb-co
 strips the archive when it builds it — so what is left is the symbol table of
 the final link, which is why only the final link can drop it.
 
+## Sessions
+
+chDB embeds one engine per process, serving one data path. Any number of
+sessions may be open on that path at once and they query concurrently, sharing
+one database. A session on a *different* path is refused until every existing
+session and connection is closed.
+
+An in-memory connection is a data path of its own, since the engine binds
+`:memory:` when none is given. So `execute`, which opens one, fails while a
+session is open, and the reverse also holds. Both report `Error::PathConflict`,
+naming the path the engine is on and the one that was asked for.
+`active_engine_path()` and `active_engine_refs()` report the same two facts.
+
+### Concurrency
+
+Give each thread its own session. A connection is `Send`, so a session can be
+moved to the thread that will use it:
+
+```rust
+let readers: Vec<_> = (0..4)
+    .map(|_| {
+        let path = path.clone();
+        std::thread::spawn(move || {
+            let session = SessionBuilder::new().with_data_path(&path).build()?;
+            session.execute("SELECT count() FROM t", None)
+        })
+    })
+    .collect();
+```
+
+A single session is not shared between threads: a connection is `Send` but not
+`Sync`. `chdb_query` is thread-safe, but the Arrow registration calls a session
+also makes say nothing about concurrent use.
+
+### Cleaning Up
+
+`SessionBuilder::with_auto_cleanup(true)` removes the data directory when the
+session is dropped, but only when it is the last handle on that path: a session
+with a sibling still open removes nothing.
+
+So one rule: **if you use `with_auto_cleanup`, set it on every session you open
+on that path.** A mixture leaves the outcome to drop order, since the session
+holding the flag may not be the one that closes last:
+
+```rust
+let a = SessionBuilder::new().with_data_path(&dir).with_auto_cleanup(true).build()?;
+let b = SessionBuilder::new().with_data_path(&dir).build()?;  // no flag
+drop(a);  // not the last handle, so nothing is removed
+drop(b);  // the last handle, but no flag, so nothing is removed
+```
+
+`Session::cleanup()` is the deterministic form: it removes the directory
+whether or not the flag was set, and still only as the last handle.
+
 ## Which Engine Is Linked
 
 Three accessors, each reporting exactly one versioning scheme. A chdb-core

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -11,7 +11,7 @@ use crate::arrow_stream::{ArrowArray, ArrowSchema, ArrowStream};
 use crate::error::{Error, Result};
 use crate::format::OutputFormat;
 use crate::query_result::QueryResult;
-use crate::{bindings, CHDB_PROGRAM_NAME};
+use crate::{bindings, registry, CHDB_PROGRAM_NAME};
 
 /// A connection to a chDB database.
 ///
@@ -43,6 +43,9 @@ use crate::{bindings, CHDB_PROGRAM_NAME};
 pub struct Connection {
     // Pointer to chdb_connection (which is *mut chdb_connection_)
     inner: *mut bindings::chdb_connection,
+    /// Holds this connection's claim on the process-wide engine. Dropping it
+    /// is what lets a later connection bind a different data path.
+    _slot: registry::Slot,
 }
 
 // Safety: Connection is safe to send between threads
@@ -79,6 +82,11 @@ impl Connection {
             .map(CString::new)
             .collect::<std::result::Result<_, _>>()?;
 
+        // Claimed before connecting, so that a second data path is refused with
+        // the reason rather than by the engine, which reports a refusal as a
+        // null connection and nothing else.
+        let slot = registry::acquire(registry::key_from_args(args))?;
+
         let argv: Vec<*const c_char> = c_args.iter().map(|s| s.as_ptr()).collect();
         let conn_ptr =
             unsafe { bindings::chdb_connect(argv.len() as i32, argv.as_ptr() as *mut *mut c_char) };
@@ -93,7 +101,10 @@ impl Connection {
             return Err(Error::ConnectionFailed);
         }
 
-        Ok(Self { inner: conn_ptr })
+        Ok(Self {
+            inner: conn_ptr,
+            _slot: slot,
+        })
     }
 
     /// Connect to an in-memory database.

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -44,8 +44,8 @@ pub struct Connection {
     // Pointer to chdb_connection (which is *mut chdb_connection_)
     inner: *mut bindings::chdb_connection,
     /// Holds this connection's claim on the process-wide engine. Dropping it
-    /// is what lets a later connection bind a different data path.
-    _slot: registry::Slot,
+    /// lets a later connection bind a different data path.
+    slot: registry::Slot,
 }
 
 // Safety: Connection is safe to send between threads
@@ -103,7 +103,7 @@ impl Connection {
 
         Ok(Self {
             inner: conn_ptr,
-            _slot: slot,
+            slot,
         })
     }
 
@@ -468,6 +468,16 @@ fn check_insert_result(result_ptr: *mut bindings::chdb_result) -> Result<()> {
 
     let result = QueryResult::new(result_ptr);
     result.check_error().map(|_| ())
+}
+
+impl Connection {
+    /// Removes `dir` once this is the last connection on its data path.
+    ///
+    /// The removal happens while the engine record is locked, so a connection
+    /// cannot attach to the path in between and lose its data.
+    pub(crate) fn remove_dir_on_last(&mut self, dir: std::path::PathBuf) {
+        self.slot.remove_on_last(dir);
+    }
 }
 
 impl Drop for Connection {

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,22 @@ pub enum Error {
     /// Failed to establish a connection to chDB.
     #[error("Connection failed")]
     ConnectionFailed,
+    /// The engine is already bound to a different data path.
+    ///
+    /// One engine per process serves one storage path. An in-memory connection
+    /// counts as a path of its own, since the engine binds `:memory:` when none
+    /// is given.
+    #[error(
+        "the engine is already open on {active}; chDB serves one data path per \
+         process, so {requested} cannot be opened until every connection to \
+         {active} is closed"
+    )]
+    PathConflict {
+        /// The path the engine is bound to.
+        active: String,
+        /// The path that was asked for.
+        requested: String,
+    },
     /// Invalid data was encountered.
     #[error("Invalid data: {0}")]
     InvalidData(String),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@ pub mod error;
 pub mod format;
 pub mod log_level;
 pub mod query_result;
+pub(crate) mod registry;
 pub mod session;
 pub mod version;
 
@@ -126,8 +127,23 @@ pub(crate) const CHDB_PROGRAM_NAME: &str = "clickhouse";
 /// - The query syntax is invalid
 /// - The connection cannot be established
 /// - The query execution fails
+/// - A connection is already open on a data path, since the in-memory
+///   connection this opens would be a second one. See
+///   [`Error::PathConflict`](error::Error::PathConflict).
 pub fn execute(query: &str, query_args: Option<&[Arg]>) -> Result<QueryResult> {
     let conn = Connection::open_in_memory()?;
     let fmt = extract_output_format(query_args, OutputFormat::TabSeparated);
     conn.query(query, fmt)
+}
+
+/// The data path the embedded engine is bound to, or `None` when no connection
+/// is open. `:memory:` for an in-memory engine, a directory otherwise.
+pub fn active_engine_path() -> Option<String> {
+    registry::active_path()
+}
+
+/// How many open connections are holding the embedded engine. Zero means the
+/// next connection may bind any path.
+pub fn active_engine_refs() -> usize {
+    registry::refs()
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,0 +1,149 @@
+//! Which data path the engine is bound to, and how many handles hold it.
+//!
+//! chDB embeds one engine per process, serving one storage path. Any number of
+//! connections to that path may be open at once; a different path is refused
+//! until they are all closed. The engine reports a refusal as a null connection
+//! and nothing more, so the reason is kept here instead.
+//!
+//! Connections opened against libchdb by another crate in the same process are
+//! not visible here, and the engine would refuse those the same way.
+
+use std::sync::{Mutex, OnceLock};
+
+use crate::error::{Error, Result};
+
+/// What the engine binds when no path is given, which is why an in-memory
+/// connection and an on-disk one cannot be open together.
+pub(crate) const IN_MEMORY: &str = ":memory:";
+
+#[derive(Default)]
+struct Registry {
+    /// Resolved identity of the live engine, or `None` when nothing is open.
+    active: Option<String>,
+    /// How many handles are holding `active`.
+    refs: usize,
+}
+
+fn registry() -> &'static Mutex<Registry> {
+    static REGISTRY: OnceLock<Mutex<Registry>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(Registry::default()))
+}
+
+/// A held reference to the live engine. Releasing it lets a later connection
+/// bind a different path.
+#[derive(Debug)]
+pub(crate) struct Slot {
+    key: String,
+}
+
+impl Drop for Slot {
+    fn drop(&mut self) {
+        let mut registry = match registry().lock() {
+            Ok(registry) => registry,
+            // Refusing to decrement on a poisoned lock would strand the
+            // engine for the rest of the process.
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        registry.refs = registry.refs.saturating_sub(1);
+        if registry.refs == 0 {
+            registry.active = None;
+        }
+        debug_assert!(
+            registry.refs == 0 || registry.active.as_deref() == Some(self.key.as_str()),
+            "the registry holds {:?} while a slot for {:?} was released",
+            registry.active,
+            self.key
+        );
+    }
+}
+
+/// Claims a reference to the engine on `key`, or explains why it cannot.
+pub(crate) fn acquire(key: String) -> Result<Slot> {
+    let mut registry = match registry().lock() {
+        Ok(registry) => registry,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+
+    match registry.active.as_deref() {
+        Some(active) if active != key => {
+            return Err(Error::PathConflict {
+                active: active.to_string(),
+                requested: key,
+            })
+        }
+        Some(_) => {}
+        None => registry.active = Some(key.clone()),
+    }
+
+    registry.refs += 1;
+    Ok(Slot { key })
+}
+
+/// The path the engine is currently bound to, or `None` when it is not running.
+pub(crate) fn active_path() -> Option<String> {
+    match registry().lock() {
+        Ok(registry) => registry.active.clone(),
+        Err(poisoned) => poisoned.into_inner().active.clone(),
+    }
+}
+
+/// How many handles are holding the live engine.
+pub(crate) fn refs() -> usize {
+    match registry().lock() {
+        Ok(registry) => registry.refs,
+        Err(poisoned) => poisoned.into_inner().refs,
+    }
+}
+
+/// The engine path named by a connection's arguments.
+pub(crate) fn key_from_args(args: &[&str]) -> String {
+    args.iter()
+        .find_map(|arg| arg.strip_prefix("--path="))
+        .map_or_else(|| IN_MEMORY.to_string(), resolve_key)
+}
+
+/// The identity two handles are compared by: the `--path=` value itself.
+///
+/// Not normalized, because the engine compares these strings as given: an
+/// identical string attaches, the same directory with a trailing slash is
+/// refused. Treating more as equivalent than the engine does would wave a
+/// handle through for it to reject. Spellings converge earlier, in
+/// [`SessionBuilder`].
+///
+/// [`SessionBuilder`]: crate::session::SessionBuilder
+pub(crate) fn resolve_key(path: &str) -> String {
+    if path.is_empty() {
+        return IN_MEMORY.to_string();
+    }
+    path.to_string()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn no_path_argument_means_in_memory() {
+        assert_eq!(key_from_args(&[]), IN_MEMORY);
+        assert_eq!(key_from_args(&["--log-level=debug"]), IN_MEMORY);
+        assert_eq!(key_from_args(&["--path=:memory:"]), IN_MEMORY);
+    }
+
+    #[test]
+    fn the_path_argument_is_found_among_others() {
+        let key = key_from_args(&["--log-level=debug", "--path=/tmp", "--max_threads=2"]);
+        assert_eq!(key, resolve_key("/tmp"));
+    }
+
+    #[test]
+    fn two_spellings_of_one_directory_are_two_keys() {
+        assert_ne!(resolve_key("/tmp"), resolve_key("/tmp/"));
+        assert_ne!(resolve_key("db"), resolve_key("./db"));
+        assert_ne!(resolve_key("file:/tmp"), resolve_key("/tmp"));
+    }
+
+    #[test]
+    fn an_identical_spelling_is_one_key() {
+        assert_eq!(resolve_key("/tmp/db"), resolve_key("/tmp/db"));
+    }
+}

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -8,6 +8,8 @@
 //! Connections opened against libchdb by another crate in the same process are
 //! not visible here, and the engine would refuse those the same way.
 
+use std::fs;
+use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 
 use crate::error::{Error, Result};
@@ -34,6 +36,15 @@ fn registry() -> &'static Mutex<Registry> {
 #[derive(Debug)]
 pub(crate) struct Slot {
     key: String,
+    /// Removed when this slot is the last one released.
+    remove_on_last: Option<PathBuf>,
+}
+
+impl Slot {
+    /// Removes `dir` if this slot turns out to be the last on its path.
+    pub(crate) fn remove_on_last(&mut self, dir: PathBuf) {
+        self.remove_on_last = Some(dir);
+    }
 }
 
 impl Drop for Slot {
@@ -47,6 +58,11 @@ impl Drop for Slot {
         registry.refs = registry.refs.saturating_sub(1);
         if registry.refs == 0 {
             registry.active = None;
+            // Under the lock, so no connection can acquire the path between
+            // this becoming the last handle and the directory going.
+            if let Some(dir) = self.remove_on_last.take() {
+                let _ = fs::remove_dir_all(dir);
+            }
         }
         debug_assert!(
             registry.refs == 0 || registry.active.as_deref() == Some(self.key.as_str()),
@@ -76,7 +92,10 @@ pub(crate) fn acquire(key: String) -> Result<Slot> {
     }
 
     registry.refs += 1;
-    Ok(Slot { key })
+    Ok(Slot {
+        key,
+        remove_on_last: None,
+    })
 }
 
 /// The path the engine is currently bound to, or `None` when it is not running.

--- a/src/session.rs
+++ b/src/session.rs
@@ -23,7 +23,6 @@ use crate::connection::Connection;
 use crate::error::{Error, Result};
 use crate::format::OutputFormat;
 use crate::query_result::QueryResult;
-use crate::registry;
 
 /// Builder for creating [`Session`] instances.
 ///
@@ -98,7 +97,6 @@ pub struct Session {
     conn: Option<Connection>,
     data_path: PathBuf,
     default_format: OutputFormat,
-    auto_cleanup: bool,
 }
 
 impl<'a> SessionBuilder<'a> {
@@ -269,23 +267,27 @@ impl<'a> SessionBuilder<'a> {
         fs::remove_file(&probe_path).ok(); // best-effort cleanup of write probe
 
         // The engine compares path strings verbatim, so spellings converge
-        // here: "db", "./db" and "db/" reach it as one string and share an
-        // engine. The directory exists by now.
-        self.data_path = self.data_path.canonicalize()?;
-        let data_path = self.data_path.to_str().ok_or(Error::PathError)?;
-        let path_arg = format!("--path={data_path}");
+        // before it sees them: "db", "./db" and "db/" reach it as one string
+        // and share an engine. Only the argument is canonical; data_path stays
+        // as given, so cleanup removes what the caller named rather than what a
+        // symlink pointed at.
+        let canonical = self.data_path.canonicalize()?;
+        let canonical = canonical.to_str().ok_or(Error::PathError)?;
+        let path_arg = format!("--path={canonical}");
         let owned: Vec<String> = self.arguments.iter().map(|a| a.to_string()).collect();
         let mut args: Vec<&str> = Vec::with_capacity(1 + owned.len());
         args.push(&path_arg);
         args.extend(owned.iter().map(String::as_str));
 
-        let conn = Connection::open(&args)?;
+        let mut conn = Connection::open(&args)?;
+        if self.auto_cleanup {
+            conn.remove_dir_on_last(self.data_path.clone());
+        }
 
         Ok(Session {
             conn: Some(conn),
             data_path: self.data_path,
             default_format: self.default_format,
-            auto_cleanup: self.auto_cleanup,
         })
     }
 }
@@ -359,26 +361,23 @@ impl Session {
             .expect("a session holds its connection until it is dropped")
     }
 
-    /// The canonical data path this session is on.
+    /// The data path this session is on, as it was given.
     pub fn path(&self) -> &Path {
         &self.data_path
     }
 
     /// Closes this session and removes its data directory, whether or not
-    /// [`SessionBuilder::with_auto_cleanup`] was set, and only when this is the
+    /// [`SessionBuilder::with_auto_cleanup`] was set, and only once this is the
     /// last handle on the path.
     ///
-    /// # Errors
-    ///
-    /// Returns the I/O error if the directory could not be removed. A session
-    /// that is not the last handle removes nothing and returns `Ok`.
-    pub fn cleanup(mut self) -> Result<()> {
-        let last = registry::refs() == 1;
-        drop(self.conn.take());
-        if last {
-            fs::remove_dir_all(&self.data_path)?;
+    /// Removal is best effort, as it is on drop: it happens while the engine
+    /// record is locked, so there is no error to hand back.
+    pub fn cleanup(mut self) {
+        let dir = self.data_path.clone();
+        if let Some(conn) = self.conn.as_mut() {
+            conn.remove_dir_on_last(dir);
         }
-        Ok(())
+        drop(self.conn.take());
     }
 
     /// See [`insert_record_batch`](crate::arrow_insert::insert_record_batch).
@@ -439,18 +438,12 @@ impl Session {
 
 impl Drop for Session {
     fn drop(&mut self) {
-        // Asked while this session still counts.
-        let last = registry::refs() == 1;
-
-        // Released before the directory goes, not while the engine is still
-        // writing to it.
+        // Releasing the connection is the whole teardown. Whether this was the
+        // last handle, and so whether the directory goes, is decided while the
+        // engine record is locked; deciding it here would race both a fresh
+        // connection on the same path and another session releasing at the same
+        // moment.
         drop(self.conn.take());
-
-        // A session that is not the last one leaves the directory alone, rather
-        // than taking the data out from under its siblings.
-        if self.auto_cleanup && last {
-            fs::remove_dir_all(&self.data_path).ok();
-        }
     }
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -3,7 +3,7 @@
 //! This module provides the [`Session`] and [`SessionBuilder`] types for managing
 //! persistent database connections with automatic cleanup.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::{fs, io};
 
 #[cfg(feature = "arrow")]
@@ -23,6 +23,7 @@ use crate::connection::Connection;
 use crate::error::{Error, Result};
 use crate::format::OutputFormat;
 use crate::query_result::QueryResult;
+use crate::registry;
 
 /// Builder for creating [`Session`] instances.
 ///
@@ -92,7 +93,9 @@ pub struct SessionBuilder<'a> {
 /// ```
 #[derive(Debug)]
 pub struct Session {
-    conn: Connection,
+    /// An `Option` so that [`Drop`] can release the connection before removing
+    /// the directory it was using.
+    conn: Option<Connection>,
     data_path: PathBuf,
     default_format: OutputFormat,
     auto_cleanup: bool,
@@ -265,6 +268,10 @@ impl<'a> SessionBuilder<'a> {
         }
         fs::remove_file(&probe_path).ok(); // best-effort cleanup of write probe
 
+        // The engine compares path strings verbatim, so spellings converge
+        // here: "db", "./db" and "db/" reach it as one string and share an
+        // engine. The directory exists by now.
+        self.data_path = self.data_path.canonicalize()?;
         let data_path = self.data_path.to_str().ok_or(Error::PathError)?;
         let path_arg = format!("--path={data_path}");
         let owned: Vec<String> = self.arguments.iter().map(|a| a.to_string()).collect();
@@ -275,7 +282,7 @@ impl<'a> SessionBuilder<'a> {
         let conn = Connection::open(&args)?;
 
         Ok(Session {
-            conn,
+            conn: Some(conn),
             data_path: self.data_path,
             default_format: self.default_format,
             auto_cleanup: self.auto_cleanup,
@@ -342,12 +349,36 @@ impl Session {
     /// - The query execution fails for any other reason
     pub fn execute(&self, query: &str, query_args: Option<&[Arg]>) -> Result<QueryResult> {
         let fmt = extract_output_format(query_args, self.default_format);
-        self.conn.query(query, fmt)
+        self.connection().query(query, fmt)
     }
 
     /// Access the session's [`Connection`] for Arrow registration and low-level queries.
     pub fn connection(&self) -> &Connection {
-        &self.conn
+        self.conn
+            .as_ref()
+            .expect("a session holds its connection until it is dropped")
+    }
+
+    /// The canonical data path this session is on.
+    pub fn path(&self) -> &Path {
+        &self.data_path
+    }
+
+    /// Closes this session and removes its data directory, whether or not
+    /// [`SessionBuilder::with_auto_cleanup`] was set, and only when this is the
+    /// last handle on the path.
+    ///
+    /// # Errors
+    ///
+    /// Returns the I/O error if the directory could not be removed. A session
+    /// that is not the last handle removes nothing and returns `Ok`.
+    pub fn cleanup(mut self) -> Result<()> {
+        let last = registry::refs() == 1;
+        drop(self.conn.take());
+        if last {
+            fs::remove_dir_all(&self.data_path)?;
+        }
+        Ok(())
     }
 
     /// See [`insert_record_batch`](crate::arrow_insert::insert_record_batch).
@@ -408,7 +439,16 @@ impl Session {
 
 impl Drop for Session {
     fn drop(&mut self) {
-        if self.auto_cleanup {
+        // Asked while this session still counts.
+        let last = registry::refs() == 1;
+
+        // Released before the directory goes, not while the engine is still
+        // writing to it.
+        drop(self.conn.take());
+
+        // A session that is not the last one leaves the directory alone, rather
+        // than taking the data out from under its siblings.
+        if self.auto_cleanup && last {
             fs::remove_dir_all(&self.data_path).ok();
         }
     }

--- a/tests/engine_registry.rs
+++ b/tests/engine_registry.rs
@@ -1,7 +1,7 @@
 //! What the process-wide engine record says, and when it refuses.
 //!
-//! These tests need the engine to themselves, so each leaves it idle and the
-//! harness runs them one at a time.
+//! These tests need the engine to themselves, so each takes [`engine`] first
+//! and leaves the engine idle afterwards.
 
 use chdb_rust::connection::Connection;
 use chdb_rust::error::Error;
@@ -10,8 +10,22 @@ use chdb_rust::{active_engine_path, active_engine_refs};
 
 mod common;
 
+/// Takes the engine for one test.
+///
+/// The engine is process-wide, so these tests cannot overlap: each asserts it
+/// starts from an idle engine. Serializing here rather than relying on
+/// `--test-threads=1` means a plain `cargo test` reports real failures instead
+/// of collisions.
+fn engine() -> std::sync::MutexGuard<'static, ()> {
+    static ENGINE: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    ENGINE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 #[test]
 fn the_record_counts_every_open_handle() {
+    let _engine = engine();
     assert_eq!(
         active_engine_refs(),
         0,
@@ -53,6 +67,7 @@ fn the_record_counts_every_open_handle() {
 
 #[test]
 fn a_second_data_path_is_refused_by_name() {
+    let _engine = engine();
     assert_eq!(active_engine_refs(), 0);
     let held = common::tempdir();
     let other = common::tempdir();
@@ -97,6 +112,7 @@ fn a_second_data_path_is_refused_by_name() {
 /// session on disk. That is what makes `execute` refuse while one is open.
 #[test]
 fn an_in_memory_connection_is_a_data_path() {
+    let _engine = engine();
     assert_eq!(active_engine_refs(), 0);
     let dir = common::tempdir();
     let session = SessionBuilder::new()
@@ -130,6 +146,7 @@ fn an_in_memory_connection_is_a_data_path() {
 
 #[test]
 fn the_next_path_is_free_once_the_last_handle_goes() {
+    let _engine = engine();
     assert_eq!(active_engine_refs(), 0);
     let first = common::tempdir();
     let second = common::tempdir();
@@ -160,6 +177,7 @@ fn the_next_path_is_free_once_the_last_handle_goes() {
 /// second session attaches instead of being refused.
 #[test]
 fn one_directory_named_two_ways_shares_the_engine() {
+    let _engine = engine();
     assert_eq!(active_engine_refs(), 0);
     let dir = common::tempdir();
     let plain = dir.path().to_path_buf();
@@ -203,6 +221,7 @@ fn one_directory_named_two_ways_shares_the_engine() {
 /// so a sibling's data survives.
 #[test]
 fn auto_cleanup_leaves_a_shared_path_alone() {
+    let _engine = engine();
     assert_eq!(active_engine_refs(), 0);
     let dir = common::tempdir();
     let path = dir.path().to_path_buf();
@@ -275,6 +294,7 @@ fn auto_cleanup_leaves_a_shared_path_alone() {
 /// `cleanup` ignores the flag but still yields to siblings.
 #[test]
 fn cleanup_is_explicit_and_still_yields_to_siblings() {
+    let _engine = engine();
     assert_eq!(active_engine_refs(), 0);
     let dir = common::tempdir();
     let path = dir.path().to_path_buf();
@@ -288,14 +308,14 @@ fn cleanup_is_explicit_and_still_yields_to_siblings() {
         .build()
         .expect("other");
 
-    other.cleanup().expect("cleanup with a sibling open");
+    other.cleanup();
     assert!(
         path.exists(),
         "cleanup must not delete from under a sibling"
     );
     assert_eq!(active_engine_refs(), 1);
 
-    keeper.cleanup().expect("cleanup as the last handle");
+    keeper.cleanup();
     assert!(
         !path.exists(),
         "the last handle's cleanup removes the directory"
@@ -307,6 +327,7 @@ fn cleanup_is_explicit_and_still_yields_to_siblings() {
 /// thread using it.
 #[test]
 fn sessions_on_one_path_query_from_several_threads() {
+    let _engine = engine();
     assert_eq!(active_engine_refs(), 0);
     let dir = common::tempdir();
     let path = dir.path().to_path_buf();
@@ -358,5 +379,99 @@ fn sessions_on_one_path_query_from_several_threads() {
         "every reader should have released its handle"
     );
     drop(writer);
+    assert_eq!(active_engine_refs(), 0);
+}
+
+/// A symlinked data path is not followed when the directory is removed: the
+/// link goes, the directory it pointed at stays.
+#[test]
+fn auto_cleanup_does_not_follow_a_symlink() {
+    let _engine = engine();
+    assert_eq!(active_engine_refs(), 0);
+    let real = common::tempdir();
+    let target = real.path().join("target");
+    std::fs::create_dir(&target).expect("target");
+    std::fs::write(target.join("keep-me"), b"x").expect("marker");
+
+    let link = real.path().join("link");
+    std::os::unix::fs::symlink(&target, &link).expect("symlink");
+
+    let session = SessionBuilder::new()
+        .with_data_path(&link)
+        .with_auto_cleanup(true)
+        .build()
+        .expect("session on a symlink");
+    drop(session);
+
+    assert!(
+        target.join("keep-me").exists(),
+        "the directory the link pointed at must survive"
+    );
+}
+
+/// Two sessions releasing at the same time: exactly one of them is last, and
+/// the directory goes with it.
+#[test]
+fn concurrent_drops_still_remove_the_directory() {
+    let _engine = engine();
+    assert_eq!(active_engine_refs(), 0);
+    let dir = common::tempdir();
+    let path = dir.path().to_path_buf();
+
+    let mut threads = Vec::new();
+    for _ in 0..2 {
+        let path = path.clone();
+        threads.push(std::thread::spawn(move || {
+            let session = SessionBuilder::new()
+                .with_data_path(&path)
+                .with_auto_cleanup(true)
+                .build()
+                .expect("session");
+            session.execute("SELECT 1", None).expect("query");
+            // Both release at roughly the same moment, which is the point.
+            drop(session);
+        }));
+    }
+    for thread in threads {
+        thread.join().expect("thread");
+    }
+
+    assert_eq!(active_engine_refs(), 0);
+    assert!(
+        !path.exists(),
+        "the last handle to go should have removed the directory"
+    );
+}
+
+/// Cleanup cannot delete the directory out from under a connection that
+/// attaches while it is releasing.
+#[test]
+fn cleanup_does_not_race_a_new_connection() {
+    let _engine = engine();
+    assert_eq!(active_engine_refs(), 0);
+    let dir = common::tempdir();
+    let path = dir.path().to_path_buf();
+
+    let holder = SessionBuilder::new()
+        .with_data_path(&path)
+        .build()
+        .expect("holder");
+    let leaving = SessionBuilder::new()
+        .with_data_path(&path)
+        .build()
+        .expect("leaving");
+
+    leaving.cleanup();
+
+    assert!(path.exists(), "a sibling was still holding the path");
+    assert_eq!(
+        holder
+            .execute("SELECT 1", None)
+            .expect("still usable")
+            .data_utf8_lossy()
+            .trim(),
+        "1"
+    );
+    drop(holder);
     assert_eq!(active_engine_refs(), 0);
 }

--- a/tests/engine_registry.rs
+++ b/tests/engine_registry.rs
@@ -1,0 +1,362 @@
+//! What the process-wide engine record says, and when it refuses.
+//!
+//! These tests need the engine to themselves, so each leaves it idle and the
+//! harness runs them one at a time.
+
+use chdb_rust::connection::Connection;
+use chdb_rust::error::Error;
+use chdb_rust::session::SessionBuilder;
+use chdb_rust::{active_engine_path, active_engine_refs};
+
+mod common;
+
+#[test]
+fn the_record_counts_every_open_handle() {
+    assert_eq!(
+        active_engine_refs(),
+        0,
+        "a previous test left a handle open"
+    );
+    assert_eq!(active_engine_path(), None);
+
+    let dir = common::tempdir();
+    let first = SessionBuilder::new()
+        .with_data_path(dir.path())
+        .build()
+        .expect("first session");
+    assert_eq!(active_engine_refs(), 1);
+    let bound = active_engine_path().expect("a path once something is open");
+
+    let second = SessionBuilder::new()
+        .with_data_path(dir.path())
+        .build()
+        .expect("a second session on the same path");
+    assert_eq!(active_engine_refs(), 2);
+    assert_eq!(active_engine_path().as_deref(), Some(bound.as_str()));
+
+    drop(second);
+    assert_eq!(active_engine_refs(), 1);
+    assert_eq!(
+        active_engine_path().as_deref(),
+        Some(bound.as_str()),
+        "the engine stays bound while a handle remains"
+    );
+
+    drop(first);
+    assert_eq!(active_engine_refs(), 0);
+    assert_eq!(
+        active_engine_path(),
+        None,
+        "the last handle releases the path"
+    );
+}
+
+#[test]
+fn a_second_data_path_is_refused_by_name() {
+    assert_eq!(active_engine_refs(), 0);
+    let held = common::tempdir();
+    let other = common::tempdir();
+
+    let session = SessionBuilder::new()
+        .with_data_path(held.path())
+        .build()
+        .expect("session");
+    let bound = active_engine_path().expect("bound");
+
+    let refused = SessionBuilder::new()
+        .with_data_path(other.path())
+        .build()
+        .expect_err("a second data path cannot be opened");
+
+    match &refused {
+        Error::PathConflict { active, requested } => {
+            assert_eq!(active, &bound);
+            assert!(
+                requested.ends_with(
+                    other
+                        .path()
+                        .file_name()
+                        .and_then(|name| name.to_str())
+                        .expect("temp dir name")
+                ),
+                "the refusal should name what was asked for, got {requested}"
+            );
+        }
+        other => panic!("expected PathConflict, got {other}"),
+    }
+
+    // The reason has to survive being turned into a message.
+    let message = refused.to_string();
+    assert!(message.contains(&bound), "{message}");
+
+    drop(session);
+    assert_eq!(active_engine_refs(), 0);
+}
+
+/// An in-memory connection is a data path of its own, so it cannot join a
+/// session on disk. That is what makes `execute` refuse while one is open.
+#[test]
+fn an_in_memory_connection_is_a_data_path() {
+    assert_eq!(active_engine_refs(), 0);
+    let dir = common::tempdir();
+    let session = SessionBuilder::new()
+        .with_data_path(dir.path())
+        .build()
+        .expect("session");
+
+    for refused in [
+        Connection::open_in_memory().expect_err("connection refused"),
+        chdb_rust::execute("SELECT 1", None).expect_err("execute refused"),
+    ] {
+        match refused {
+            Error::PathConflict { requested, .. } => assert_eq!(requested, ":memory:"),
+            other => panic!("expected PathConflict, got {other}"),
+        }
+    }
+
+    drop(session);
+
+    // And the other way round, once the engine is idle.
+    let memory = Connection::open_in_memory().expect("in-memory once idle");
+    assert_eq!(active_engine_path().as_deref(), Some(":memory:"));
+    let refused = SessionBuilder::new()
+        .with_data_path(dir.path())
+        .build()
+        .expect_err("on-disk cannot join an in-memory engine");
+    assert!(matches!(refused, Error::PathConflict { .. }));
+    drop(memory);
+    assert_eq!(active_engine_refs(), 0);
+}
+
+#[test]
+fn the_next_path_is_free_once_the_last_handle_goes() {
+    assert_eq!(active_engine_refs(), 0);
+    let first = common::tempdir();
+    let second = common::tempdir();
+
+    let session = SessionBuilder::new()
+        .with_data_path(first.path())
+        .build()
+        .expect("first path");
+    drop(session);
+
+    let session = SessionBuilder::new()
+        .with_data_path(second.path())
+        .build()
+        .expect("a different path once the engine is idle");
+    assert_eq!(
+        session
+            .execute("SELECT 1", None)
+            .expect("query")
+            .data_utf8_lossy()
+            .trim(),
+        "1"
+    );
+    drop(session);
+    assert_eq!(active_engine_refs(), 0);
+}
+
+/// Two spellings of one directory converge before the engine sees them, so the
+/// second session attaches instead of being refused.
+#[test]
+fn one_directory_named_two_ways_shares_the_engine() {
+    assert_eq!(active_engine_refs(), 0);
+    let dir = common::tempdir();
+    let plain = dir.path().to_path_buf();
+    let trailing_slash = format!("{}/", plain.display());
+
+    let first = SessionBuilder::new()
+        .with_data_path(&plain)
+        .build()
+        .expect("first spelling");
+    let second = SessionBuilder::new()
+        .with_data_path(&trailing_slash)
+        .build()
+        .expect("a trailing slash names the same directory");
+    assert_eq!(active_engine_refs(), 2);
+
+    // One database, not two that coexist.
+    first
+        .execute(
+            "CREATE TABLE shared (x UInt32) ENGINE = MergeTree ORDER BY x",
+            None,
+        )
+        .expect("create");
+    first
+        .execute("INSERT INTO shared VALUES (1)", None)
+        .expect("insert");
+    assert_eq!(
+        second
+            .execute("SELECT count() FROM shared", None)
+            .expect("read back")
+            .data_utf8_lossy()
+            .trim(),
+        "1"
+    );
+
+    drop(second);
+    drop(first);
+    assert_eq!(active_engine_refs(), 0);
+}
+
+/// A session with auto-cleanup removes its directory only as the last handle,
+/// so a sibling's data survives.
+#[test]
+fn auto_cleanup_leaves_a_shared_path_alone() {
+    assert_eq!(active_engine_refs(), 0);
+    let dir = common::tempdir();
+    let path = dir.path().to_path_buf();
+
+    let keeper = SessionBuilder::new()
+        .with_data_path(&path)
+        .build()
+        .expect("keeper");
+    keeper
+        .execute(
+            "CREATE TABLE kept (x UInt32) ENGINE = MergeTree ORDER BY x",
+            None,
+        )
+        .expect("create");
+    keeper
+        .execute("INSERT INTO kept VALUES (1)", None)
+        .expect("insert");
+
+    {
+        let transient = SessionBuilder::new()
+            .with_data_path(&path)
+            .with_auto_cleanup(true)
+            .build()
+            .expect("transient");
+        assert_eq!(active_engine_refs(), 2);
+        assert_eq!(
+            transient
+                .execute("SELECT count() FROM kept", None)
+                .expect("shared read")
+                .data_utf8_lossy()
+                .trim(),
+            "1"
+        );
+    }
+
+    assert!(
+        keeper.path().exists(),
+        "a session that is not the last handle must not remove the directory"
+    );
+    assert_eq!(
+        keeper
+            .execute("SELECT count() FROM kept", None)
+            .expect("still readable")
+            .data_utf8_lossy()
+            .trim(),
+        "1"
+    );
+
+    // And the last handle, which does carry the flag, does remove it.
+    let path_again = keeper.path().to_path_buf();
+    drop(keeper);
+    assert_eq!(active_engine_refs(), 0);
+    assert!(
+        path_again.exists(),
+        "the last handle here had no flag, so nothing should have been removed"
+    );
+
+    let solo = SessionBuilder::new()
+        .with_data_path(&path_again)
+        .with_auto_cleanup(true)
+        .build()
+        .expect("solo");
+    drop(solo);
+    assert!(
+        !path_again.exists(),
+        "the only handle carried the flag, so the directory should be gone"
+    );
+}
+
+/// `cleanup` ignores the flag but still yields to siblings.
+#[test]
+fn cleanup_is_explicit_and_still_yields_to_siblings() {
+    assert_eq!(active_engine_refs(), 0);
+    let dir = common::tempdir();
+    let path = dir.path().to_path_buf();
+
+    let keeper = SessionBuilder::new()
+        .with_data_path(&path)
+        .build()
+        .expect("keeper");
+    let other = SessionBuilder::new()
+        .with_data_path(&path)
+        .build()
+        .expect("other");
+
+    other.cleanup().expect("cleanup with a sibling open");
+    assert!(
+        path.exists(),
+        "cleanup must not delete from under a sibling"
+    );
+    assert_eq!(active_engine_refs(), 1);
+
+    keeper.cleanup().expect("cleanup as the last handle");
+    assert!(
+        !path.exists(),
+        "the last handle's cleanup removes the directory"
+    );
+    assert_eq!(active_engine_refs(), 0);
+}
+
+/// Several sessions on one path, querying at the same time, each owned by the
+/// thread using it.
+#[test]
+fn sessions_on_one_path_query_from_several_threads() {
+    assert_eq!(active_engine_refs(), 0);
+    let dir = common::tempdir();
+    let path = dir.path().to_path_buf();
+
+    let writer = SessionBuilder::new()
+        .with_data_path(&path)
+        .build()
+        .expect("writer");
+    writer
+        .execute(
+            "CREATE TABLE t (x UInt32) ENGINE = MergeTree ORDER BY x",
+            None,
+        )
+        .expect("create");
+    writer
+        .execute("INSERT INTO t SELECT number FROM numbers(1000)", None)
+        .expect("insert");
+
+    let readers: Vec<_> = (0..4)
+        .map(|id| {
+            let path = path.clone();
+            std::thread::spawn(move || -> Result<String, String> {
+                let session = SessionBuilder::new()
+                    .with_data_path(&path)
+                    .build()
+                    .map_err(|e| format!("thread {id} could not attach: {e}"))?;
+                let mut last = String::new();
+                for _ in 0..5 {
+                    last = session
+                        .execute("SELECT count(), sum(x) FROM t", None)
+                        .map_err(|e| format!("thread {id} query: {e}"))?
+                        .data_utf8_lossy()
+                        .trim()
+                        .to_string();
+                }
+                Ok(last)
+            })
+        })
+        .collect();
+
+    for reader in readers {
+        let answer = reader.join().expect("thread").expect("query");
+        assert_eq!(answer, "1000\t499500");
+    }
+
+    assert_eq!(
+        active_engine_refs(),
+        1,
+        "every reader should have released its handle"
+    );
+    drop(writer);
+    assert_eq!(active_engine_refs(), 0);
+}


### PR DESCRIPTION
chDB embeds one engine per process, serving one data path. Several sessions may be open on that path at once and query concurrently; a different path is refused until they all close, and the engine signals that refusal with a null connection and nothing else.

**A registry** keeps the bound path and a count of the handles holding it, and refuses a second path itself, naming both. `active_engine_path()` and `active_engine_refs()` report it. An in-memory connection is a path of its own, which is why `execute` fails while a session is open — that now says so instead of returning `Connection failed`.

**Auto-cleanup no longer deletes a shared path.** A session built with the flag used to remove its data directory on drop regardless of what else was on that path, leaving its siblings querying files that no longer existed and losing everything at exit. It now removes the directory only as the last handle, and releases the connection first.

**New:** `Session::path()` and `Session::cleanup()`. Nothing is removed from the API, and the one behaviour change is the cleanup gating above.

The README documents the model, how to spread work across threads, and the one rule the per-session flag implies: set it on every session on that path, or drop order decides whether the directory goes.

Tests cover the record under contention, both refusals, two spellings of one directory sharing an engine, and four threads querying one path at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add shared engine registry to `Session` to prevent cross-session data deletion
> - Introduces a process-wide registry in [registry.rs](https://github.com/chdb-io/chdb-rust/pull/43/files#diff-d5b93d4a7caa06c359c97e5e8528a0b6c636621edba60a960f3f5afeed0c97a8) that tracks one active engine path and a reference count across all connections, using a mutex-guarded `OnceLock` for synchronized access
> - `Connection::open` claims a registry slot before connecting and returns `Error::PathConflict` when the requested path differs from the active engine path; multiple connections to the same path increment the reference count
> - `SessionBuilder` canonicalizes data paths so equivalent spellings share one engine; auto-cleanup and the new consuming `Session::cleanup` method remove the data directory only when the connection is the last handle on that path
> - Adds `active_engine_path` and `active_engine_refs` public accessors for inspecting registry state
> - Behavioral Change: dropping a `Session` with auto-cleanup no longer unconditionally deletes its directory — removal happens only when its connection is the final reference. Opening a connection to a different path while another is active now fails with `Error::PathConflict` instead of silently proceeding
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 169aa6f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->