### PR TITLE
Durable V1: a database whose authoritative state lives in storage you own

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,6 +64,16 @@ jobs:
       run: cargo test --features durable -- --test-threads=1
       env:
         RUST_BACKTRACE: full
+    # The S3 backend has no credentials here, and its own tests skip themselves
+    # without a bucket. What this still catches is the half that does not need
+    # one: that the feature compiles, and that the signer, the URL forms and the
+    # status mapping still agree with their unit tests. The real bucket runs
+    # locally, against `cargo test --features durable-s3 --test durable_s3`.
+    - name: Check the S3 backend
+      if: matrix.os == 'ubuntu-latest'
+      run: cargo test --features durable-s3 --lib -- --test-threads=1 durable::backends
+      env:
+        RUST_BACKTRACE: full
 
   # Static linking, built and run rather than merely compiled. Until this job
   # existed the only step that enabled the feature was a `clippy --all-features`

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,6 +55,15 @@ jobs:
       run: cargo test -- --test-threads=1
       env:
         RUST_BACKTRACE: full
+    # A second cell of the same matrix rather than a job of its own: the durable
+    # protocol is only as good as the engine underneath it, so it has to be
+    # exercised on every platform the crate claims, against the engine installed
+    # above. The feature is off by default, so nothing else here would compile
+    # it, let alone run it.
+    - name: Run the durable tests
+      run: cargo test --features durable -- --test-threads=1
+      env:
+        RUST_BACKTRACE: full
 
   # Static linking, built and run rather than merely compiled. Until this job
   # existed the only step that enabled the feature was a `clippy --all-features`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,12 @@ required-features = ["durable"]
 #
 # .github/scripts/check-engine-pin.sh keeps it in step with build.rs and
 # update_libchdb.sh, which are what actually fetch the engine.
+#
+# Release gate: this crate does not publish against a release candidate. The pin
+# moves to v26.7.3 — the first stable release carrying the Durable V1 ABI — and
+# the test matrix runs again before anything goes to crates.io. Until then rc.2
+# is what local builds and CI test against, since it is where backup, restore
+# and statement analysis first appeared.
 engine = "v26.7.2-rc.2"
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,10 @@ keywords = ["clickhouse", "chdb", "database", "embedded", "analytics"]
 
 [dependencies]
 arrow = { version = "59", optional = true, features = ["ffi"] }
+serde_json = { version = "1", optional = true }
+sha2 = { version = "0.10", optional = true }
 thiserror = "1"
+uuid = { version = "1", optional = true, features = ["v4"] }
 
 [features]
 default = ["arrow"]
@@ -21,6 +24,10 @@ arrow = ["dep:arrow"]
 # By default, we link dynamically.
 # Users can opt-in to static linking with --features static
 static = []
+# chDB Durable V1: a database whose authoritative state lives in object
+# storage, as a full checkpoint plus a statement WAL under a leased head.json.
+# Needs an engine with the Durable V1 ABI (chdb-core v26.7.2-rc.2 or newer).
+durable = ["dep:serde_json", "dep:sha2", "dep:uuid"]
 
 [build-dependencies]
 bindgen = "0.70.1"
@@ -59,6 +66,18 @@ required-features = ["arrow"]
 [[test]]
 name = "runtime_faces"
 harness = false
+
+[[test]]
+name = "durable_conformance"
+required-features = ["durable"]
+
+[[test]]
+name = "durable_engine"
+required-features = ["durable"]
+
+[[example]]
+name = "09_durable_object"
+required-features = ["durable"]
 
 [package.metadata.chdb]
 # The chdb-core release this crate builds against. This is a chdb-core release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,13 @@ arrow = { version = "59", optional = true, features = ["ffi"] }
 serde_json = { version = "1", optional = true }
 sha2 = { version = "0.10", optional = true }
 thiserror = "1"
+# The S3 backend signs its own requests: two operations do not justify an async
+# runtime and several dozen crates in the graph of every caller. Default
+# features are off to leave out gzip, which would decode a checkpoint nobody
+# asked it to decode.
+ureq = { version = "3", optional = true, default-features = false, features = ["rustls"] }
 uuid = { version = "1", optional = true, features = ["v4"] }
+hmac = { version = "0.12", optional = true }
 
 [features]
 default = ["arrow"]
@@ -28,6 +34,8 @@ static = []
 # storage, as a full checkpoint plus a statement WAL under a leased head.json.
 # Needs an engine with the Durable V1 ABI (chdb-core v26.7.2-rc.2 or newer).
 durable = ["dep:serde_json", "dep:sha2", "dep:uuid"]
+# An S3-compatible backend for `durable` — AWS S3, Cloudflare R2, MinIO.
+durable-s3 = ["durable", "dep:ureq", "dep:hmac"]
 
 [build-dependencies]
 bindgen = "0.70.1"
@@ -74,6 +82,10 @@ required-features = ["durable"]
 [[test]]
 name = "durable_engine"
 required-features = ["durable"]
+
+[[test]]
+name = "durable_s3"
+required-features = ["durable-s3"]
 
 [[example]]
 name = "09_durable_object"

--- a/README.md
+++ b/README.md
@@ -300,6 +300,71 @@ See [docs/examples.md](docs/examples.md#fast-bulk-inserts-arrow) for usage, or r
 cargo run --example 08_arrow_insert
 ```
 
+## Durable Objects
+
+`--features durable` turns a database into an object in storage you own: a full
+checkpoint plus a statement write-ahead log under one compare-and-set
+`head.json`, in the layout the Python, Node and Go bindings share. A different
+process — or a different machine, given a shared backend — restores it from
+those files alone.
+
+```rust
+use chdb_rust::durable::{Namespace, OpenOptions};
+use chdb_rust::format::OutputFormat;
+
+let namespace = Namespace::new("file:///var/lib/chdb-durable")?.with_owner("worker-1");
+let (object, existed) = namespace.open("tenant-123", OpenOptions {
+    database: Some("mem".to_string()),
+    ..OpenOptions::default()
+})?;
+
+if !existed {
+    object.execute("CREATE TABLE events (id UInt64) ENGINE = MergeTree ORDER BY id")?;
+}
+let ticket = object.execute("INSERT INTO events VALUES (1)")?;
+object.flush_through(ticket)?;   // now it survives losing this machine
+let rows = object.query("SELECT count() FROM events", OutputFormat::CSV)?;
+object.checkpoint()?;            // fold base + WAL into a fresh base
+object.close()?;                 // flush, release the lease, reclaim the scratch
+```
+
+Four things to know before using it:
+
+- **`execute` is not a durability barrier.** It runs the statement locally and
+  buffers it; `flush` (or `flush_through` for one statement) is what publishes
+  it. A service that answers a client before flushing is choosing to lose that
+  write on a crash.
+- **Replay re-executes your SQL.** Log literals — compute a timestamp or an id
+  in the caller — not `now()`, `rand()`, `generateUUIDv4()` or an
+  `INSERT ... SELECT` from a volatile source.
+- **One object per process.** chdb-core binds one data path per process, so
+  opening a second object returns an error naming both paths. Fan out across
+  worker processes.
+- **The lease is coordination, not security.** Anyone who can write the object's
+  prefix can read, modify or take it; access control is your storage's.
+
+Every `query` and `execute` is put to ClickHouse's own parser first — statement
+count, class, write targets, embedded credentials — and the answer is the gate.
+The same three engine entry points are available directly, without the feature,
+on any engine that exports them: see
+[`Connection::backup_database`, `restore_database` and `classify_query`](src/admin.rs).
+
+A local directory is the only backend that ships; a cloud provider is plugged in
+by implementing `durable::Backend` and passing it to `Namespace::with_backend`.
+The protocol is specified in [CHDB_DURABLE_V1_CONTRACT.md][contract] in the chdb
+repository, which is the source of truth rather than this implementation.
+
+```bash
+cargo run --features durable --example 09_durable_object
+cargo test --features durable
+```
+
+Needs chdb-core v26.7.2-rc.2 or newer, which is where backup, restore and
+statement analysis were added; an older engine fails the build with a message
+saying so.
+
+[contract]: https://github.com/chdb-io/chdb/blob/main/dev-docs/CHDB_DURABLE_V1_CONTRACT.md
+
 ## Contributing
 
 We welcome contributions! Here's how you can help:

--- a/README.md
+++ b/README.md
@@ -349,14 +349,57 @@ The same three engine entry points are available directly, without the feature,
 on any engine that exports them: see
 [`Connection::backup_database`, `restore_database` and `classify_query`](src/admin.rs).
 
-A local directory is the only backend that ships; a cloud provider is plugged in
-by implementing `durable::Backend` and passing it to `Namespace::with_backend`.
+### Backends
+
+`--features durable` ships a local directory: `file:///path`, `local:/path`, or
+a bare absolute path. It is for development, tests and single-host use — a
+directory on one machine cannot be the authority another machine recovers from.
+
+`--features durable-s3` adds S3-compatible storage, which is what makes an
+object recoverable somewhere else:
+
+```rust
+// AWS
+let namespace = Namespace::new("s3://my-bucket/durable?region=eu-central-1")?;
+// Cloudflare R2
+let namespace = Namespace::new(
+    "s3://my-bucket/durable?region=auto&endpoint=https://<id>.r2.cloudflarestorage.com",
+)?;
+// MinIO
+let namespace = Namespace::new("s3://my-bucket/durable?endpoint=http://127.0.0.1:9000")?;
+```
+
+The two conditional writes the protocol rests on are the provider's own:
+`If-None-Match: *` for a create nobody can both win, `If-Match: <etag>` for the
+compare-and-swap that fences a superseded writer. Requests are signed in-crate
+rather than through `aws-sdk-s3`, so enabling this costs an HTTP and TLS stack
+rather than an async runtime and several dozen crates.
+
+Credentials are never part of the URL — a namespace URL gets logged, committed
+and pasted into issues. They come from `AWS_ACCESS_KEY_ID` /
+`AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN`, or from `~/.aws/credentials`
+honouring `AWS_PROFILE`. SSO and instance roles are not resolved in-crate;
+export them first, the way the CLI does:
+
+```bash
+eval "$(aws configure export-credentials --profile my-profile --format env)"
+```
+
+`AWS_CA_BUNDLE` is honoured, so a host behind a TLS-inspecting proxy works the
+same way `aws s3` does beside it. Any other provider is plugged in by
+implementing `durable::Backend` — six methods — and passing it to
+`Namespace::with_backend`.
+
 The protocol is specified in [CHDB_DURABLE_V1_CONTRACT.md][contract] in the chdb
 repository, which is the source of truth rather than this implementation.
 
 ```bash
 cargo run --features durable --example 09_durable_object
 cargo test --features durable
+
+# Against a bucket you own. Skipped, loudly, when the variable is unset.
+export CHDB_DURABLE_S3_BUCKET=my-bucket CHDB_DURABLE_S3_REGION=eu-central-1
+cargo test --features durable-s3 --test durable_s3 -- --test-threads=1
 ```
 
 Needs chdb-core v26.7.2-rc.2 or newer, which is where backup, restore and

--- a/build.rs
+++ b/build.rs
@@ -11,6 +11,7 @@ const CHDB_ENGINE_PIN: &str = "v26.7.2-rc.2";
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(direct_arrow_insert)");
     println!("cargo::rustc-check-cfg=cfg(has_chdb_version)");
+    println!("cargo::rustc-check-cfg=cfg(has_durable_abi)");
 
     if env::var("DOCS_RS").is_ok() {
         // docs.rs links no engine, but the version accessors still have to
@@ -614,6 +615,16 @@ fn isolate_archive(lib_path: &Path, out_dir: &Path) -> Option<PathBuf> {
     Some(dir)
 }
 
+/// The three entry points the Durable V1 contract requires of chdb-core: a
+/// database backup, a database restore, and a statement analysis a caller can
+/// gate writes on. They arrived together in v26.7.2-rc.2, and `src/admin.rs`
+/// binds them.
+const DURABLE_ABI: [&str; 3] = [
+    "chdb_backup_database_n",
+    "chdb_restore_database_n",
+    "chdb_classify_query_n",
+];
+
 fn setup_link_paths(lib_path: &Path, header_path: &Path, out_dir: &Path) {
     let lib_dir = lib_path.parent().unwrap_or(Path::new("."));
 
@@ -656,6 +667,17 @@ fn setup_link_paths(lib_path: &Path, header_path: &Path, out_dir: &Path) {
     // not link, so the accessor is compiled out instead.
     if header_declares(header_path, "chdb_version") {
         println!("cargo:rustc-cfg=has_chdb_version");
+    }
+
+    // Backup, restore and query analysis arrived together in chdb-core
+    // v26.7.2-rc.2, as the Durable V1 ABI. All three are gated on one cfg
+    // because the durable protocol needs all three: an engine carrying only
+    // some of them cannot serve an object either way.
+    if DURABLE_ABI
+        .iter()
+        .all(|symbol| header_declares(header_path, symbol))
+    {
+        println!("cargo:rustc-cfg=has_durable_abi");
     }
 
     println!("cargo:rerun-if-changed=wrapper.h");

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -482,9 +482,27 @@ match object.flush() {
 
 ### Backends
 
-A local directory (`file:///path`, `local:/path`, or a bare absolute path) is
-the only backend that ships, and it is for development, tests and single-host
-use. A cloud provider is plugged in by implementing `durable::Backend` — six
+A local directory (`file:///path`, `local:/path`, or a bare absolute path) comes
+with `--features durable`, and is for development, tests and single-host use.
+
+`--features durable-s3` adds S3-compatible storage — AWS, R2, MinIO — which is
+what lets a different machine recover the object:
+
+```rust
+use chdb_rust::durable::Namespace;
+
+let namespace = Namespace::new("s3://my-bucket/durable?region=eu-central-1")?;
+# Ok::<(), chdb_rust::durable::Error>(())
+```
+
+Credentials come from the environment or `~/.aws/credentials`, never from the
+URL. For an SSO profile, export them first:
+
+```bash
+eval "$(aws configure export-credentials --profile my-profile --format env)"
+```
+
+Any other provider is plugged in by implementing `durable::Backend` — six
 methods, of which the two conditional writes carry the whole protocol — and
 handing it to `Namespace::with_backend`.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -12,6 +12,7 @@ This document provides simple and easy-to-follow examples for using chdb-rust, a
 6. [Reading from Files](#reading-from-files)
 7. [Error Handling](#error-handling)
 8. [Fast Bulk Inserts (Arrow)](#fast-bulk-inserts-arrow)
+9. [Durable Objects](#durable-objects)
 
 ## Basic Setup
 
@@ -393,6 +394,103 @@ session.insert_record_batch("metrics", "flush_1", &batch)?;
 `dest_table` must be a bare ClickHouse table identifier (e.g. `metrics`); dotted names (`db.table`) and reserved words are not quoted automatically.
 
 See `examples/08_arrow_insert.rs` for a runnable program.
+
+## Durable Objects
+
+Enabled by `--features durable`. A durable object is a chDB database whose
+authoritative state lives in storage you own — a full checkpoint plus a
+statement write-ahead log under one compare-and-set `head.json` — in the layout
+the Python, Node and Go bindings share, so any of them can recover an object the
+others wrote.
+
+```rust
+use chdb_rust::durable::{Namespace, OpenOptions};
+use chdb_rust::format::OutputFormat;
+
+let namespace = Namespace::new("file:///var/lib/chdb-durable")?
+    .with_owner("worker-1");
+
+// `existed` tells "restored" from "created" without a second round-trip.
+let (object, existed) = namespace.open("tenant-123", OpenOptions {
+    database: Some("mem".to_string()),
+    ..OpenOptions::default()
+})?;
+
+if !existed {
+    object.execute(
+        "CREATE TABLE events (id UInt64, tag String) ENGINE = MergeTree ORDER BY id",
+    )?;
+}
+
+// execute() runs the statement here and buffers it for the WAL. It is not a
+// durability barrier; flush_through() is.
+let ticket = object.execute("INSERT INTO events VALUES (1, 'first')")?;
+object.flush_through(ticket)?;
+
+let rows = object.query("SELECT count() FROM events", OutputFormat::CSV)?;
+println!("{}", String::from_utf8_lossy(&rows));
+
+// Fold the WAL into a fresh full checkpoint, so recovery reads one archive
+// rather than replaying a long chain.
+object.checkpoint()?;
+
+// close() drains, flushes and releases the lease. Dropping the handle instead
+// reclaims local resources but leaves the lease to expire on its own.
+object.close()?;
+# Ok::<(), chdb_rust::durable::Error>(())
+```
+
+### What can be logged
+
+Recovery re-executes the logged SQL, so a statement has to mean the same thing
+twice:
+
+```rust
+// DO: compute the value in the caller and log the literal.
+let now = "2026-09-07 12:00:00";
+object.execute(&format!("INSERT INTO events VALUES (1, '{now}')"))?;
+
+// DON'T: now(), rand(), generateUUIDv4(), or INSERT ... SELECT from anything
+// that can change underneath you. Replay would produce different rows.
+# Ok::<(), chdb_rust::durable::Error>(())
+```
+
+Every statement goes to ClickHouse's own parser before it runs, and the answer
+is the gate: exactly one statement, the right class, every persistent write
+inside this object's database, no embedded credential. Refusals come back as
+`Category::ClassificationRefused` or `Category::SecretRefused`, and the message
+never quotes the statement.
+
+### Handling failure
+
+```rust
+use chdb_rust::durable::Category;
+
+match object.flush() {
+    Ok(published) => { /* committed, and another process can recover it */ }
+    Err(e) if e.category() == Category::CommitAmbiguous => {
+        // The remote may or may not have committed. Never retried blindly:
+        // reopen the object and look at the manifest.
+    }
+    Err(e) if e.category() == Category::LeaseFenced => {
+        // Another writer took the object. This handle is done.
+    }
+    Err(e) => return Err(e),
+}
+# Ok::<(), chdb_rust::durable::Error>(())
+```
+
+### Backends
+
+A local directory (`file:///path`, `local:/path`, or a bare absolute path) is
+the only backend that ships, and it is for development, tests and single-host
+use. A cloud provider is plugged in by implementing `durable::Backend` — six
+methods, of which the two conditional writes carry the whole protocol — and
+handing it to `Namespace::with_backend`.
+
+See `examples/09_durable_object.rs` for a runnable program, and
+[CHDB_DURABLE_V1_CONTRACT.md](https://github.com/chdb-io/chdb/blob/main/dev-docs/CHDB_DURABLE_V1_CONTRACT.md)
+for the protocol itself, which is the source of truth rather than this crate.
 
 ## Additional Resources
 

--- a/examples/09_durable_object.rs
+++ b/examples/09_durable_object.rs
@@ -1,0 +1,76 @@
+/// Example: Durable Objects
+///
+/// A durable object is a chDB database whose authoritative state lives in
+/// storage you own — a full checkpoint plus a statement WAL under a leased
+/// `head.json`, in the layout every chDB binding shares. This example writes
+/// one, loses the handle, and recovers the database from storage alone.
+///
+/// Run it with the feature on:
+///
+///     cargo run --features durable --example 09_durable_object
+use chdb_rust::durable::{Namespace, OpenOptions};
+use chdb_rust::format::OutputFormat;
+
+fn main() -> Result<(), chdb_rust::durable::Error> {
+    println!("=== Durable Object Examples ===\n");
+
+    // One directory per namespace, one subdirectory per object. A cloud backend
+    // is what makes an object recoverable on *another* machine; a directory is
+    // for development and for seeing the layout.
+    let root = std::env::temp_dir().join("chdb-durable-example");
+    let namespace =
+        Namespace::new(root.to_str().expect("a UTF-8 temp dir"))?.with_owner("example-writer");
+
+    println!("1. Opening the object (creating it if this is the first run)...");
+    let (object, existed) = namespace.open(
+        "tenant-123",
+        OpenOptions {
+            database: Some("mem".to_string()),
+            ..OpenOptions::default()
+        },
+    )?;
+    println!(
+        "   {} at {}",
+        if existed { "restored" } else { "created" },
+        root.display()
+    );
+
+    if !existed {
+        object.execute(
+            "CREATE TABLE events (id UInt64, tag String) ENGINE = MergeTree ORDER BY id",
+        )?;
+    }
+
+    println!("2. Writing...");
+    // Log literals, never now() or rand(): recovery re-executes the statement,
+    // and V1 promises ordered replay, not the same answer twice.
+    let ticket = object.execute("INSERT INTO events VALUES (1, 'first')")?;
+
+    // execute() ran the statement here. flush_through() is what makes it
+    // survive losing this machine — wait for it before answering anyone.
+    println!("3. Flushing, which is the durability barrier...");
+    object.flush_through(ticket)?;
+
+    println!("4. Folding the WAL into a fresh checkpoint...");
+    let base = object.checkpoint()?;
+    println!("   base is now {}", base.key);
+
+    let stats = object.stats();
+    println!(
+        "   generation {}, seq {}, {} statement(s) committed",
+        stats.generation, stats.committed_seq, stats.committed_statements
+    );
+
+    // close() drains, flushes and releases the lease. Dropping the handle
+    // instead reclaims local resources but leaves the lease to expire.
+    object.close()?;
+
+    println!("\n5. Reopening from storage alone...");
+    let (object, _) = namespace.open("tenant-123", OpenOptions::default())?;
+    let rows = object.query("SELECT id, tag FROM events ORDER BY id", OutputFormat::CSV)?;
+    println!("{}", String::from_utf8_lossy(&rows));
+    object.close()?;
+
+    println!("Run it again: the row count grows, and each run recovers the last.");
+    Ok(())
+}

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1,0 +1,388 @@
+//! Backup, restore and statement analysis: chdb-core's management ABI.
+//!
+//! These are the three entry points the [chDB Durable V1 contract][contract]
+//! requires of an engine, and they exist for one reason: some questions can
+//! only be answered by the ClickHouse parser, and some statements can only be
+//! built safely by the engine that will run them.
+//!
+//! * [`Connection::backup_database`] and [`Connection::restore_database`] take
+//!   a database name and a path as *arguments*. The engine builds the AST and
+//!   quotes both, so a database called `` my`db `` or a path holding an
+//!   apostrophe cannot change what runs. Nothing in this crate assembles
+//!   `BACKUP` or `RESTORE` text.
+//! * [`Connection::classify_query`] reports what a statement would do without
+//!   running it: how many executable statements the text holds, what class
+//!   they are, whether every persistent write lands in one named database, and
+//!   whether the text embeds a credential. A prefix list cannot answer any of
+//!   those — it cannot see through `INSERT ... FORMAT` inline data, and it
+//!   cannot resolve an unqualified table name against the current database.
+//!
+//! The whole module is compiled only when the linked library declares all
+//! three, which is chdb-core v26.7.2-rc.2 or newer. See [`crate::durable`] for
+//! the protocol built on top of them.
+//!
+//! [contract]: https://github.com/chdb-io/chdb/blob/main/dev-docs/CHDB_DURABLE_V1_CONTRACT.md
+
+use std::path::Path;
+
+use crate::bindings;
+use crate::connection::Connection;
+use crate::error::{Error, Result};
+use crate::query_result::QueryResult;
+
+/// What a statement does to state that outlives it.
+///
+/// The classes answer two questions at once: does this change anything after
+/// the statement returns, and would `BACKUP DATABASE` carry the change?
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum QueryClass {
+    /// `SELECT`, `SHOW`, `DESCRIBE`, `EXPLAIN`, `EXISTS`, `CHECK`: leaves no trace.
+    ReadOnly,
+    /// `INSERT`, `CREATE`, `ALTER`, `DROP`, `TRUNCATE`, `RENAME`, `UPDATE`,
+    /// `DELETE`, `OPTIMIZE`: changes a database, and `BACKUP DATABASE` captures
+    /// the change.
+    Mutating,
+    /// Global UDFs, named collections, workloads, resources, access management
+    /// and writes into `system`: persistent, replayable, and outside every
+    /// database a checkpoint could capture.
+    MutatingGlobal,
+    /// `USE`, `SET`, `ATTACH`, `DETACH`, `SYSTEM`, `BACKUP`, `RESTORE`, `KILL`,
+    /// transaction control, and statements writing outside the engine
+    /// (`INTO OUTFILE`, `INSERT INTO FUNCTION`).
+    Control,
+    /// Did not parse, or parsed into a statement this engine does not classify.
+    /// A caller gating writes on the class has to treat it as a refusal.
+    Unknown,
+}
+
+impl QueryClass {
+    fn from_abi(value: u32) -> Self {
+        match value {
+            bindings::chdb_query_class_CHDB_QUERY_READ_ONLY => Self::ReadOnly,
+            bindings::chdb_query_class_CHDB_QUERY_MUTATING => Self::Mutating,
+            bindings::chdb_query_class_CHDB_QUERY_MUTATING_GLOBAL => Self::MutatingGlobal,
+            bindings::chdb_query_class_CHDB_QUERY_CONTROL => Self::Control,
+            // Including any class a later engine adds: an unrecognised answer
+            // is exactly as unproven as text that did not parse.
+            _ => Self::Unknown,
+        }
+    }
+
+    /// The contract's wire name for this class, which every binding reports
+    /// identically so a cross-binding conformance run can compare them.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ReadOnly => "READ_ONLY",
+            Self::Mutating => "MUTATING",
+            Self::MutatingGlobal => "MUTATING_GLOBAL",
+            Self::Control => "CONTROL",
+            Self::Unknown => "UNKNOWN",
+        }
+    }
+}
+
+impl std::fmt::Display for QueryClass {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// What [`Connection::classify_query`] reports about a statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryAnalysis {
+    /// What the statement does to state that outlives it.
+    pub class: QueryClass,
+    /// How many executable statements the text holds. Zero for empty input or
+    /// text that did not parse; a `PARALLEL WITH` arm counts as one, because
+    /// both arms execute.
+    pub statement_count: u32,
+    /// The text carries a credential: a named collection's key, a password, an
+    /// access key handed to a table function. Never set for [`QueryClass::Unknown`],
+    /// since nothing was proven about text that did not parse.
+    pub has_secrets: bool,
+    /// Every persistent write lands in the database named in the call. Set only
+    /// when the engine can prove it, and never set when no target database was
+    /// named. A statement that writes nothing sets it vacuously.
+    pub writes_only_target_database: bool,
+    /// The statement creates, drops or renames a database rather than acting
+    /// inside one — a change to the container rather than its contents.
+    pub changes_database_lifecycle: bool,
+}
+
+impl Connection {
+    /// Write a full backup of `database` into `file_path`.
+    ///
+    /// The archive is a single file, named by its extension: `.tar.gz` is a
+    /// gzipped tar, and a path without a recognised archive extension is
+    /// treated as a directory backup instead.
+    ///
+    /// `file_path` must be absolute, its parent directory must exist, and it
+    /// must be inside the connection's `backups.allowed_path` — which is a
+    /// connection argument, so a connection that never set it cannot back
+    /// anything up:
+    ///
+    /// ```no_run
+    /// use std::path::Path;
+    /// use chdb_rust::connection::Connection;
+    ///
+    /// let conn = Connection::open(&["--path=/tmp/db", "--backups.allowed_path=/tmp/archives"])?;
+    /// conn.query("CREATE DATABASE IF NOT EXISTS mem", chdb_rust::format::OutputFormat::CSV)?;
+    /// conn.backup_database("mem", Path::new("/tmp/archives/mem-1.tar.gz"))?;
+    /// # Ok::<(), chdb_rust::error::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// An existing destination is never overwritten — the call fails instead,
+    /// so give every backup its own name. Also returns an error if the path is
+    /// relative, outside the allowed path, or if the backup itself fails.
+    pub fn backup_database(&self, database: &str, file_path: &Path) -> Result<()> {
+        let path = absolute_str(file_path, "backup")?;
+        let result_ptr = unsafe {
+            bindings::chdb_backup_database_n(
+                self.raw(),
+                database.as_ptr().cast(),
+                database.len(),
+                path.as_ptr().cast(),
+                path.len(),
+                // V1 checkpoints are always full. An incremental archive
+                // records the *local path* of its base, which does not survive
+                // the trip through object storage.
+                std::ptr::null(),
+                0,
+            )
+        };
+        check(result_ptr)
+    }
+
+    /// Restore `database` from an archive written by [`Self::backup_database`].
+    ///
+    /// The path rules match `backup_database`, and the archive has to exist.
+    /// The connection's current database is left alone: restoring into `mem`
+    /// does not make `mem` current.
+    ///
+    /// # Errors
+    ///
+    /// `RESTORE` appends to an existing table rather than replacing it, so
+    /// restoring into a database that already holds the archive's tables
+    /// duplicates rows rather than failing. Restore into an empty database.
+    pub fn restore_database(&self, database: &str, file_path: &Path) -> Result<()> {
+        let path = absolute_str(file_path, "restore")?;
+        let result_ptr = unsafe {
+            bindings::chdb_restore_database_n(
+                self.raw(),
+                database.as_ptr().cast(),
+                database.len(),
+                path.as_ptr().cast(),
+                path.len(),
+            )
+        };
+        check(result_ptr)
+    }
+
+    /// Say what a statement would do, without running it.
+    ///
+    /// The connection's own parser, dialect and current database are used, so
+    /// an unqualified name resolves the way it would if the statement ran.
+    /// Nothing is executed: no current database change, no settings change, no
+    /// query log entry.
+    ///
+    /// `target_database` is the database the caller considers its own, and is
+    /// what [`QueryAnalysis::writes_only_target_database`] is judged against.
+    /// `None` skips that judgement, and the flag is then never set.
+    ///
+    /// ```no_run
+    /// use chdb_rust::admin::QueryClass;
+    /// use chdb_rust::connection::Connection;
+    ///
+    /// let conn = Connection::open_in_memory()?;
+    /// let analysis = conn.classify_query("INSERT INTO t VALUES (1)", Some("mem"))?;
+    /// assert_eq!(analysis.class, QueryClass::Mutating);
+    /// assert_eq!(analysis.statement_count, 1);
+    /// # Ok::<(), chdb_rust::error::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// SQL that does not parse is not an error: it reports
+    /// [`QueryClass::Unknown`] with a statement count of zero, because what it
+    /// is, is the answer. An error means the engine could not be asked at all.
+    pub fn classify_query(
+        &self,
+        sql: &str,
+        target_database: Option<&str>,
+    ) -> Result<QueryAnalysis> {
+        let mut analysis = bindings::chdb_query_analysis_v1 {
+            struct_size: std::mem::size_of::<bindings::chdb_query_analysis_v1>() as u32,
+            statement_count: 0,
+            flags: 0,
+            query_class: bindings::chdb_query_class_CHDB_QUERY_UNKNOWN,
+        };
+        let (target_ptr, target_len) = match target_database {
+            Some(database) => (database.as_ptr().cast(), database.len()),
+            None => (std::ptr::null(), 0),
+        };
+
+        let state = unsafe {
+            bindings::chdb_classify_query_n(
+                self.raw(),
+                sql.as_ptr().cast(),
+                sql.len(),
+                target_ptr,
+                target_len,
+                &mut analysis,
+            )
+        };
+        if state != bindings::chdb_state_CHDBSuccess {
+            return Err(Error::QueryError(
+                // Deliberately without the statement: analysis is run on text
+                // that may embed a credential, and this path cannot yet know
+                // whether it does.
+                "the engine could not analyse the statement".to_string(),
+            ));
+        }
+
+        let class = QueryClass::from_abi(analysis.query_class);
+        Ok(QueryAnalysis {
+            class,
+            statement_count: analysis.statement_count,
+            has_secrets: has_flag(
+                analysis.flags,
+                bindings::chdb_query_analysis_flag_CHDB_QUERY_HAS_SECRETS,
+            ),
+            writes_only_target_database: has_flag(
+                analysis.flags,
+                bindings::chdb_query_analysis_flag_CHDB_QUERY_WRITES_ONLY_TARGET_DATABASE,
+            ),
+            changes_database_lifecycle: has_flag(
+                analysis.flags,
+                bindings::chdb_query_analysis_flag_CHDB_QUERY_CHANGES_DATABASE_LIFECYCLE,
+            ),
+        })
+    }
+}
+
+fn has_flag(flags: u32, flag: bindings::chdb_query_analysis_flag) -> bool {
+    flags & flag != 0
+}
+
+/// The path as UTF-8, refused unless it is absolute.
+///
+/// The engine checks this too, but its refusal names `backups.allowed_path`
+/// rather than the path, because a relative destination is resolved against the
+/// data directory before it gets there. Saying it here keeps the message about
+/// the argument the caller passed.
+fn absolute_str<'a>(path: &'a Path, what: &str) -> Result<&'a str> {
+    if !path.is_absolute() {
+        return Err(Error::InvalidData(format!(
+            "{what} path must be absolute, got {}",
+            path.display()
+        )));
+    }
+    path.to_str().ok_or(Error::PathError)
+}
+
+/// Turn a management result into `Ok(())` or the engine's own error.
+fn check(result_ptr: *mut bindings::chdb_result) -> Result<()> {
+    if result_ptr.is_null() {
+        return Err(Error::NoResult);
+    }
+    QueryResult::new(result_ptr).check_error().map(|_| ())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test_utils::tempdir;
+
+    /// A connection on its own data directory, with `tmp/archives` as the one
+    /// place it may read or write an archive.
+    fn connection(tmp: &std::path::Path, data: &str) -> Result<Connection> {
+        let data_dir = tmp.join(data);
+        let archives = tmp.join("archives");
+        std::fs::create_dir_all(&data_dir)?;
+        std::fs::create_dir_all(&archives)?;
+        let data = format!("--path={}", data_dir.to_str().expect("a UTF-8 path"));
+        let allowed = format!(
+            "--backups.allowed_path={}",
+            archives.to_str().expect("a UTF-8 path")
+        );
+        Connection::open(&[&data, &allowed])
+    }
+
+    #[test]
+    fn classification_sees_through_inline_data_and_unqualified_names() -> Result<()> {
+        let tmp = tempdir();
+        let conn = connection(tmp.path(), "data")?;
+        conn.query("CREATE DATABASE mem", crate::format::OutputFormat::CSV)?;
+        conn.query("USE mem", crate::format::OutputFormat::CSV)?;
+
+        // A semicolon inside VALUES is data, not a statement boundary.
+        let inline = conn.classify_query("INSERT INTO t VALUES ('a;b')", Some("mem"))?;
+        assert_eq!(inline.statement_count, 1);
+        assert_eq!(inline.class, QueryClass::Mutating);
+        assert!(inline.writes_only_target_database);
+
+        // `t` is unqualified, so it resolves through the current database —
+        // which is `mem`, not the target named here.
+        let elsewhere = conn.classify_query("INSERT INTO t VALUES (1)", Some("other"))?;
+        assert!(!elsewhere.writes_only_target_database);
+
+        let two = conn.classify_query("SELECT 1; SELECT 2", Some("mem"))?;
+        assert_eq!(two.statement_count, 2);
+
+        let nonsense = conn.classify_query("this is not sql", Some("mem"))?;
+        assert_eq!(nonsense.class, QueryClass::Unknown);
+        assert_eq!(nonsense.statement_count, 0);
+        assert!(!nonsense.has_secrets);
+
+        Ok(())
+    }
+
+    #[test]
+    fn a_backup_round_trips_through_an_archive() -> Result<()> {
+        let tmp = tempdir();
+        let archive = tmp.path().join("archives").join("mem.tar.gz");
+
+        {
+            let conn = connection(tmp.path(), "origin")?;
+            conn.query("CREATE DATABASE mem", crate::format::OutputFormat::CSV)?;
+            conn.query(
+                "CREATE TABLE mem.t (n UInt64) ENGINE = MergeTree ORDER BY n",
+                crate::format::OutputFormat::CSV,
+            )?;
+            conn.query(
+                "INSERT INTO mem.t VALUES (7)",
+                crate::format::OutputFormat::CSV,
+            )?;
+
+            conn.backup_database("mem", &archive)?;
+            assert!(archive.exists());
+
+            // The same name a second time is refused rather than overwritten.
+            assert!(conn.backup_database("mem", &archive).is_err());
+        }
+
+        // A different data directory, which is what a restore is for. The
+        // archive names the database it holds, so it comes back as `mem`, and
+        // RESTORE appends rather than replaces — hence a directory with no `mem`
+        // in it.
+        let conn = connection(tmp.path(), "recovered")?;
+        conn.restore_database("mem", &archive)?;
+        let rows = conn.query("SELECT n FROM mem.t", crate::format::OutputFormat::CSV)?;
+        assert_eq!(rows.data_utf8_lossy().trim(), "7");
+
+        Ok(())
+    }
+
+    #[test]
+    fn a_relative_archive_path_is_refused_before_the_engine_sees_it() -> Result<()> {
+        let tmp = tempdir();
+        let conn = connection(tmp.path(), "data")?;
+        let err = conn
+            .backup_database("mem", Path::new("relative.tar.gz"))
+            .expect_err("a relative backup path is refused");
+        assert!(err.to_string().contains("must be absolute"), "{err}");
+        Ok(())
+    }
+}

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -471,6 +471,16 @@ fn check_insert_result(result_ptr: *mut bindings::chdb_result) -> Result<()> {
 }
 
 impl Connection {
+    /// The engine handle behind this connection, for the FFI calls in sibling
+    /// modules. `chdb_connect` hands back a pointer to the handle, and every
+    /// entry point takes the handle itself.
+    pub(crate) fn raw(&self) -> bindings::chdb_connection {
+        // SAFETY: `inner` is non-null for the lifetime of a Connection —
+        // `open` returns an error rather than a handle when either the outer
+        // or the inner pointer is null.
+        unsafe { *self.inner }
+    }
+
     /// Removes `dir` once this is the last connection on its data path.
     ///
     /// The removal happens while the engine record is locked, so a connection

--- a/src/durable/backend.rs
+++ b/src/durable/backend.rs
@@ -1,0 +1,120 @@
+//! The object-storage contract every durable backend must satisfy (§5.1).
+//!
+//! The trait is small on purpose. Only two properties are load-bearing, and
+//! both are properties a provider either has or does not:
+//!
+//! 1. **Real conditional operations.** [`Backend::put_bytes_if_absent`] must be
+//!    an atomic create and [`Backend::replace_if_match`] an atomic
+//!    compare-and-swap. Simulating either with a read followed by a write is
+//!    not a weaker implementation, it is a broken one: the window between the
+//!    two is exactly where two writers both conclude they are the only writer.
+//! 2. **Streaming.** A checkpoint is a full database archive. Requiring it to
+//!    pass through a `Vec<u8>` puts a ceiling on database size that has nothing
+//!    to do with the database. So checkpoints move as files and readers; only
+//!    the head and WAL segments — both bounded by the protocol — move as bytes.
+//!
+//! A third property is expressed in the return values rather than the methods:
+//! every mutating call can answer "ambiguous". A request whose response was lost
+//! is not a failure, and reporting it as one would make a caller retry a commit
+//! that already happened. The state machine resolves ambiguity by re-reading
+//! (§5.8), which is only possible if the backend admits it.
+//!
+//! Deleting is absent by design: V1 has no destroy and no garbage collection, so
+//! nothing in the protocol has the authority to remove an object.
+
+use std::io::Read;
+use std::path::Path;
+
+use super::digest::Digest;
+use super::errors::Result;
+
+/// The result of a conditional create.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PutOutcome {
+    /// The object was created by this call.
+    Created,
+    /// The key was already there. For a key minted per attempt this means *we*
+    /// created it earlier, on a try whose response never arrived.
+    AlreadyExists,
+    /// The request may or may not have landed, and the caller has to re-read to
+    /// find out.
+    Ambiguous,
+}
+
+/// The result of a conditional replace.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReplaceOutcome {
+    /// The compare-and-swap succeeded; the new CAS token is attached.
+    Done {
+        /// The token the next replace has to present.
+        etag: String,
+    },
+    /// The stored token no longer matched: someone else wrote first.
+    NotMatched,
+    /// The outcome is unknown.
+    Ambiguous,
+}
+
+/// One object read whole, with the CAS token describing that same version.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Tagged {
+    /// The object's bytes.
+    pub data: Vec<u8>,
+    /// An opaque compare-and-swap token. Never assumed to be a content MD5.
+    pub etag: String,
+}
+
+/// A key/value store scoped to one object's prefix.
+///
+/// Keys are relative, `/`-separated and validated by
+/// [`is_valid_object_key`](super::is_valid_object_key): they arrive from a
+/// `head.json` that came out of object storage, so they are untrusted input,
+/// and an implementation that resolves them against a directory must refuse a
+/// traversal rather than trust the caller.
+///
+/// `Option` distinguishes an absent key from a failure. Absence is a normal,
+/// expected answer at nearly every call site — a cold object, a probe for a
+/// head — and a caller that has to unwrap an error to learn something ordinary
+/// eventually forgets to.
+///
+/// An implementation is shared across the heartbeat thread and the caller's, so
+/// it has to be `Send + Sync`.
+pub trait Backend: Send + Sync {
+    /// A human-readable location of the object prefix, for logs and errors. It
+    /// must never contain credentials.
+    fn describe(&self) -> String;
+
+    /// Reads a whole object.
+    fn get_bytes(&self, key: &str) -> Result<Option<Vec<u8>>>;
+
+    /// Reads a whole object together with its CAS token.
+    ///
+    /// The two must describe the same version: pairing an old body with a new
+    /// token would let a compare-and-swap succeed against state nobody read.
+    fn get_bytes_with_etag(&self, key: &str) -> Result<Option<Tagged>>;
+
+    /// Opens a byte stream for a potentially large object, so a checkpoint
+    /// download never has to be resident.
+    fn open_reader(&self, key: &str) -> Result<Option<Box<dyn Read + Send>>>;
+
+    /// Atomically creates an object from bytes. It never overwrites.
+    fn put_bytes_if_absent(&self, key: &str, data: &[u8]) -> Result<PutOutcome>;
+
+    /// Atomically creates an object by uploading a local file. It never
+    /// overwrites.
+    ///
+    /// `digest` is the file's already-computed length and SHA-256 — the
+    /// protocol requires both to be known before publishing, so they are passed
+    /// rather than recomputed. A backend may use them to sign or verify the
+    /// upload without a second pass over the file.
+    fn put_file_if_absent(
+        &self,
+        key: &str,
+        local_path: &Path,
+        digest: &Digest,
+    ) -> Result<PutOutcome>;
+
+    /// Atomically replaces an object only if its stored token still equals
+    /// `etag`.
+    fn replace_if_match(&self, key: &str, data: &[u8], etag: &str) -> Result<ReplaceOutcome>;
+}

--- a/src/durable/backends/local.rs
+++ b/src/durable/backends/local.rs
@@ -1,0 +1,481 @@
+//! Local-filesystem backend.
+//!
+//! This is the backend every test uses, and the one a developer gets from a
+//! `file://` namespace URL. That makes its conditional operations load-bearing
+//! rather than a convenience: if they were approximations, every scenario that
+//! passes here would prove nothing about the ones that run against a real object
+//! store.
+//!
+//! # Conditional create
+//!
+//! `link(2)` is the primitive. It fails with `EEXIST` atomically, so writing to
+//! a unique scratch file and then linking it into place is a true
+//! create-if-absent — with the full contents already in the file at the moment
+//! the name appears. Rename would have been simpler and wrong: it clobbers.
+//!
+//! # Conditional replace
+//!
+//! POSIX has no compare-and-swap on file contents, and the usual workarounds are
+//! worse than the problem. A lock file turns a crash into a stuck object that
+//! needs a staleness heuristic to recover; read-compare-rename has the race it
+//! is meant to prevent.
+//!
+//! So the one mutable key is stored as a chain of immutable versions with a
+//! symlink naming the current one:
+//!
+//! ```text
+//! head.json                -> symlink to .head-versions/7.json
+//! .head-versions/7.json    immutable
+//! .head-versions/6.json    immutable
+//! ```
+//!
+//! The ETag is the version number. Replacing against ETag `v7` means creating
+//! `.head-versions/8.json`, and `link(2)` lets exactly one racer do that — so
+//! the `EEXIST` *is* the compare-and-swap failure. The symlink is then swapped
+//! in with an atomic rename. A writer that wins the create and dies before the
+//! rename has still legitimately won: a racer reading version 7 will fail to
+//! create 8 and correctly report not-replaced.
+//!
+//! Version numbers only ever move forward, because creating version N+1 requires
+//! having read version N, which requires the symlink to already point at it.
+//!
+//! # Reading what another binding wrote
+//!
+//! An object produced elsewhere has a plain `head.json` file and no version
+//! chain. That reads fine — the ETag is then a content digest — and the first
+//! `replace_if_match` adopts it into the chain: verify the plain file still
+//! hashes to the ETag, create `.head-versions/1.json` exclusively, swap the
+//! symlink. Adoption is atomic against other adopters, since only one can win
+//! the create.
+//!
+//! # What this backend is for, and what that rules out
+//!
+//! Development and conformance. Recovery on another machine needs storage
+//! neither machine owns, which is an object-store backend; a directory on one
+//! host cannot be a remote authority. That scope decides which hardening belongs
+//! here and which is noise. What it still defends, because both are real
+//! regardless of scope, is keys arriving out of an untrusted `head.json`, and
+//! losing data it has already reported as written.
+
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use crate::durable::backend::{Backend, PutOutcome, ReplaceOutcome, Tagged};
+use crate::durable::digest::{digest_of, Digest};
+use crate::durable::errors::{backend_err, err, Category, Error, Result};
+use crate::durable::keys::{is_valid_object_key, uuid8, HEAD_KEY};
+
+/// Where the mutable key's version chain lives, relative to the object prefix.
+///
+/// One directory, because V1 has exactly one mutable key. It is dot-prefixed so
+/// it cannot collide with a protocol key, and a reader that only understands
+/// plain files still sees a correct `head.json` through the symlink.
+const VERSIONS_DIR: &str = ".head-versions";
+
+/// Scratch for partially written files.
+const TMP_DIR: &str = ".tmp";
+
+/// One durable object stored as a directory.
+#[derive(Debug)]
+pub struct LocalBackend {
+    root: PathBuf,
+}
+
+impl LocalBackend {
+    /// Binds a backend to one object's directory, creating it if needed.
+    pub fn new(root: impl AsRef<Path>) -> Result<Self> {
+        let root = root.as_ref();
+        let root = if root.is_absolute() {
+            root.to_path_buf()
+        } else {
+            std::env::current_dir()
+                .map_err(|e| backend_err(e, format!("durable: cannot resolve {}", root.display())))?
+                .join(root)
+        };
+        fs::create_dir_all(&root)
+            .map_err(|e| backend_err(e, format!("durable: cannot create {}", root.display())))?;
+        Ok(Self { root })
+    }
+
+    /// Resolves a protocol key under the object root, refusing anything that is
+    /// not a plain relative key.
+    fn path_for(&self, key: &str) -> Result<PathBuf> {
+        if !is_valid_object_key(key) {
+            return Err(err(
+                Category::Backend,
+                format!("durable: refusing to resolve invalid key {key:?}"),
+            ));
+        }
+        Ok(self.root.join(key))
+    }
+
+    fn versions_dir(&self) -> PathBuf {
+        self.root.join(VERSIONS_DIR)
+    }
+
+    fn version_path(&self, version: u64) -> PathBuf {
+        self.versions_dir().join(format!("{version}.json"))
+    }
+
+    /// Which version the head symlink names, if it is a chain at all.
+    fn current_version(&self) -> Option<u64> {
+        let target = fs::read_link(self.root.join(HEAD_KEY)).ok()?;
+        let target = target.to_str()?;
+        let number = target
+            .strip_prefix(VERSIONS_DIR)?
+            .strip_prefix('/')?
+            .strip_suffix(".json")?;
+        number.parse().ok()
+    }
+
+    /// Which version a replace against `etag` would create, or `None` when the
+    /// token no longer describes the stored head.
+    fn next_version_for(&self, etag: &str) -> Result<Option<u64>> {
+        if let Some(current) = self.current_version() {
+            if etag != version_etag(current) {
+                return Ok(None);
+            }
+            return Ok(Some(current + 1));
+        }
+
+        // No chain yet: this is either a cold object created through
+        // put_bytes_if_absent or one another binding wrote. Adopting it into
+        // the chain is only sound if the plain file is still exactly what the
+        // caller read.
+        match fs::read(self.root.join(HEAD_KEY)) {
+            Ok(data) if etag == digest_etag(&digest_of(&data)) => Ok(Some(1)),
+            Ok(_) => Ok(None),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(backend_err(e, format!("durable: cannot read {HEAD_KEY}"))),
+        }
+    }
+
+    /// Swaps the head symlink to name one version, atomically.
+    fn point_head_at(&self, version: u64) -> std::io::Result<()> {
+        let tmp = self.root.join(TMP_DIR);
+        fs::create_dir_all(&tmp)?;
+        let link = tmp.join(format!("head-{}.link", uuid8()));
+        let relative = format!("{VERSIONS_DIR}/{version}.json");
+        std::os::unix::fs::symlink(relative, &link)?;
+        if let Err(e) = fs::rename(&link, self.root.join(HEAD_KEY)) {
+            let _ = fs::remove_file(&link);
+            return Err(e);
+        }
+        sync_dir(&self.root);
+        Ok(())
+    }
+
+    /// Writes content to a unique scratch file, flushed, and returns its path.
+    /// The caller publishes or removes it.
+    fn stage(&self, write: impl FnOnce(&mut File) -> std::io::Result<()>) -> Result<PathBuf> {
+        let dir = self.root.join(TMP_DIR);
+        fs::create_dir_all(&dir).map_err(|e| {
+            backend_err(e, "durable: cannot create a staging directory".to_string())
+        })?;
+        let path = dir.join(format!("{}.part", uuid8()));
+        let staged = (|| -> std::io::Result<()> {
+            let mut file = File::options().create_new(true).write(true).open(&path)?;
+            write(&mut file)?;
+            // Flush before the name appears. Publishing bytes that are only in
+            // the page cache would let a crash roll back a write this backend
+            // has already reported as done.
+            file.sync_all()
+        })();
+        if let Err(e) = staged {
+            let _ = fs::remove_file(&path);
+            return Err(backend_err(e, "durable: cannot stage a write".to_string()));
+        }
+        Ok(path)
+    }
+
+    /// Links a staged file into place, reporting whether the name was free.
+    fn publish(&self, staged: &Path, target: &Path, key: &str) -> Result<PutOutcome> {
+        let parent = target.parent().unwrap_or(&self.root);
+        fs::create_dir_all(parent)
+            .map_err(|e| backend_err(e, format!("durable: cannot create a directory for {key}")))?;
+        match fs::hard_link(staged, target) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                return Ok(PutOutcome::AlreadyExists)
+            }
+            Err(e) => return Err(backend_err(e, format!("durable: cannot publish {key}"))),
+        }
+        // Flush the directory that gained the name, and the root above it: a
+        // name in a directory that is itself a fresh, unflushed entry is no
+        // more durable than the entry above it.
+        sync_dir(parent);
+        sync_dir(&self.root);
+        Ok(PutOutcome::Created)
+    }
+}
+
+fn version_etag(version: u64) -> String {
+    format!("v{version}")
+}
+
+fn digest_etag(digest: &Digest) -> String {
+    format!("sha256:{}", digest.sha256)
+}
+
+/// Flushes a directory entry, so a name this backend created survives power
+/// loss.
+///
+/// Best effort by design: some filesystems refuse `fsync` on a directory, and
+/// that is not a reason to fail a publish whose data is already flushed. The
+/// name may just be less durable than the bytes.
+fn sync_dir(dir: &Path) {
+    let _ = File::open(dir).and_then(|handle| handle.sync_all());
+}
+
+impl Backend for LocalBackend {
+    fn describe(&self) -> String {
+        format!("file://{}", self.root.display())
+    }
+
+    fn get_bytes(&self, key: &str) -> Result<Option<Vec<u8>>> {
+        let path = self.path_for(key)?;
+        match fs::read(&path) {
+            Ok(data) => Ok(Some(data)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(backend_err(e, format!("durable: cannot read {key}"))),
+        }
+    }
+
+    fn get_bytes_with_etag(&self, key: &str) -> Result<Option<Tagged>> {
+        let path = self.path_for(key)?;
+        if key == HEAD_KEY {
+            if let Some(version) = self.current_version() {
+                // The symlink names a version that is not there. Reading that
+                // as absent would hand a fresh writer a cold object on top of a
+                // live one, so it is a failure instead.
+                let data = fs::read(self.version_path(version)).map_err(|e| {
+                    Error::wrap(
+                        Category::Corrupt,
+                        e,
+                        format!("durable: {key} points at version {version}, which cannot be read"),
+                    )
+                })?;
+                return Ok(Some(Tagged {
+                    data,
+                    etag: version_etag(version),
+                }));
+            }
+        }
+        match fs::read(&path) {
+            Ok(data) => {
+                let etag = digest_etag(&digest_of(&data));
+                Ok(Some(Tagged { data, etag }))
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(backend_err(e, format!("durable: cannot read {key}"))),
+        }
+    }
+
+    fn open_reader(&self, key: &str) -> Result<Option<Box<dyn Read + Send>>> {
+        let path = self.path_for(key)?;
+        match File::open(&path) {
+            Ok(file) => Ok(Some(Box::new(file))),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(backend_err(e, format!("durable: cannot open {key}"))),
+        }
+    }
+
+    fn put_bytes_if_absent(&self, key: &str, data: &[u8]) -> Result<PutOutcome> {
+        let path = self.path_for(key)?;
+        let staged = self.stage(|file| file.write_all(data))?;
+        let outcome = self.publish(&staged, &path, key);
+        let _ = fs::remove_file(&staged);
+        outcome
+    }
+
+    fn put_file_if_absent(
+        &self,
+        key: &str,
+        local_path: &Path,
+        _digest: &Digest,
+    ) -> Result<PutOutcome> {
+        // The digest is not used here: a local publish is a copy inside one
+        // filesystem, so there is nothing to sign and nothing a second read of
+        // the same bytes would establish. It is part of the trait because a
+        // remote backend does need it.
+        let path = self.path_for(key)?;
+        let mut source = File::open(local_path).map_err(|e| {
+            backend_err(e, format!("durable: cannot read {}", local_path.display()))
+        })?;
+        let staged = self.stage(|file| std::io::copy(&mut source, file).map(|_| ()))?;
+        let outcome = self.publish(&staged, &path, key);
+        let _ = fs::remove_file(&staged);
+        outcome
+    }
+
+    fn replace_if_match(&self, key: &str, data: &[u8], etag: &str) -> Result<ReplaceOutcome> {
+        if key != HEAD_KEY {
+            // Every other key in the protocol is immutable, so a conditional
+            // replace against one is a bug rather than a race. Reporting it as
+            // a failed compare-and-swap would send the caller into a reconcile
+            // that can never settle.
+            return Err(err(
+                Category::Backend,
+                format!("durable: {key} is immutable; only {HEAD_KEY} can be replaced"),
+            ));
+        }
+        self.path_for(key)?;
+        fs::create_dir_all(self.versions_dir())
+            .map_err(|e| backend_err(e, "durable: cannot create the version chain".to_string()))?;
+
+        let Some(next) = self.next_version_for(etag)? else {
+            return Ok(ReplaceOutcome::NotMatched);
+        };
+
+        let staged = self.stage(|file| file.write_all(data))?;
+        let target = self.version_path(next);
+        let outcome = self.publish(&staged, &target, key);
+        let _ = fs::remove_file(&staged);
+
+        if outcome? != PutOutcome::Created {
+            // Somebody else created this version. That is the compare-and-swap
+            // losing, told by the filesystem rather than guessed at.
+            return Ok(ReplaceOutcome::NotMatched);
+        }
+
+        if self.point_head_at(next).is_err() {
+            // The version exists and is durable; only the pointer is behind. A
+            // reader still sees the previous head, and another writer holding
+            // the previous ETag will fail to create this same version — so the
+            // compare-and-swap has been won but not published, which is exactly
+            // what ambiguous means.
+            return Ok(ReplaceOutcome::Ambiguous);
+        }
+        Ok(ReplaceOutcome::Done {
+            etag: version_etag(next),
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test_utils::tempdir;
+
+    fn backend(root: &Path) -> LocalBackend {
+        LocalBackend::new(root.join("object")).expect("a backend on a fresh directory")
+    }
+
+    #[test]
+    fn a_conditional_create_lets_exactly_one_writer_win() -> Result<()> {
+        let tmp = tempdir();
+        let backend = backend(tmp.path());
+        assert_eq!(
+            backend.put_bytes_if_absent("wal/1-1-aaaaaaaa.jsonl", b"first")?,
+            PutOutcome::Created
+        );
+        assert_eq!(
+            backend.put_bytes_if_absent("wal/1-1-aaaaaaaa.jsonl", b"second")?,
+            PutOutcome::AlreadyExists
+        );
+        assert_eq!(
+            backend.get_bytes("wal/1-1-aaaaaaaa.jsonl")?.as_deref(),
+            Some(&b"first"[..]),
+            "an immutable object is never overwritten"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn a_replace_against_a_stale_token_does_not_apply() -> Result<()> {
+        let tmp = tempdir();
+        let backend = backend(tmp.path());
+        backend.put_bytes_if_absent(HEAD_KEY, b"cold")?;
+
+        let first = backend.get_bytes_with_etag(HEAD_KEY)?.expect("a head");
+        let second = match backend.replace_if_match(HEAD_KEY, b"one", &first.etag)? {
+            ReplaceOutcome::Done { etag } => etag,
+            other => panic!("expected the first replace to apply, got {other:?}"),
+        };
+
+        // The token the first reader held is now stale.
+        assert_eq!(
+            backend.replace_if_match(HEAD_KEY, b"two", &first.etag)?,
+            ReplaceOutcome::NotMatched
+        );
+        assert_eq!(
+            backend.replace_if_match(HEAD_KEY, b"two", &second)?,
+            ReplaceOutcome::Done {
+                etag: "v2".to_string()
+            }
+        );
+        assert_eq!(backend.get_bytes(HEAD_KEY)?.as_deref(), Some(&b"two"[..]));
+        Ok(())
+    }
+
+    #[test]
+    fn a_head_another_binding_wrote_is_adopted_into_the_chain() -> Result<()> {
+        let tmp = tempdir();
+        let backend = backend(tmp.path());
+        // A plain file, as a binding without the version chain would leave it.
+        fs::write(tmp.path().join("object").join(HEAD_KEY), b"foreign").unwrap();
+
+        let tagged = backend.get_bytes_with_etag(HEAD_KEY)?.expect("a head");
+        assert!(tagged.etag.starts_with("sha256:"), "{}", tagged.etag);
+        assert_eq!(
+            backend.replace_if_match(HEAD_KEY, b"ours", &tagged.etag)?,
+            ReplaceOutcome::Done {
+                etag: "v1".to_string()
+            }
+        );
+        assert_eq!(backend.get_bytes(HEAD_KEY)?.as_deref(), Some(&b"ours"[..]));
+        Ok(())
+    }
+
+    #[test]
+    fn a_key_out_of_an_untrusted_head_cannot_leave_the_object() {
+        let tmp = tempdir();
+        let backend = backend(tmp.path());
+        for key in ["../escape", "/etc/passwd", "wal/../../escape"] {
+            let error = backend.get_bytes(key).expect_err("a traversal is refused");
+            assert_eq!(error.category(), Category::Backend, "{key}");
+        }
+    }
+
+    #[test]
+    fn only_the_head_may_be_replaced() {
+        let tmp = tempdir();
+        let backend = backend(tmp.path());
+        let error = backend
+            .replace_if_match("wal/1-1-aaaaaaaa.jsonl", b"x", "v1")
+            .expect_err("an immutable key has no compare-and-swap");
+        assert_eq!(error.category(), Category::Backend);
+    }
+
+    #[test]
+    fn a_file_is_published_whole_and_streams_back() -> Result<()> {
+        let tmp = tempdir();
+        let backend = backend(tmp.path());
+        let archive = tmp.path().join("checkpoint.tar.gz");
+        fs::write(&archive, b"archive bytes").unwrap();
+        let digest = digest_of(b"archive bytes");
+
+        assert_eq!(
+            backend.put_file_if_absent("checkpoints/1-1-aaaaaaaa.tar.gz", &archive, &digest)?,
+            PutOutcome::Created
+        );
+        let mut reader = backend
+            .open_reader("checkpoints/1-1-aaaaaaaa.tar.gz")?
+            .expect("the archive is there");
+        let mut back = Vec::new();
+        reader.read_to_end(&mut back).unwrap();
+        assert_eq!(back, b"archive bytes");
+        Ok(())
+    }
+
+    #[test]
+    fn an_absent_key_is_an_answer_rather_than_a_failure() -> Result<()> {
+        let tmp = tempdir();
+        let backend = backend(tmp.path());
+        assert!(backend.get_bytes(HEAD_KEY)?.is_none());
+        assert!(backend.get_bytes_with_etag(HEAD_KEY)?.is_none());
+        assert!(backend.open_reader(HEAD_KEY)?.is_none());
+        Ok(())
+    }
+}

--- a/src/durable/backends/mod.rs
+++ b/src/durable/backends/mod.rs
@@ -6,12 +6,20 @@
 //! approximating it — see [`local`] for why that matters even for a backend
 //! whose scope is development and conformance.
 //!
-//! An S3-compatible backend is a separate piece of work, and deliberately not
-//! in this crate's dependency graph until it exists: a caller that only ever
-//! uses a directory should not carry a cloud SDK. Until then, a provider is
-//! plugged in by implementing [`Backend`](super::Backend) and handing it to
+//! The S3-compatible backend is behind its own feature, `durable-s3`, so a
+//! caller that only ever uses a directory does not carry an HTTP stack and a
+//! TLS implementation. Any other provider is plugged in by implementing
+//! [`Backend`](super::Backend) and handing it to
 //! [`Namespace::with_backend`](super::Namespace::with_backend).
 
 pub mod local;
+#[cfg(feature = "durable-s3")]
+pub mod s3;
+#[cfg(feature = "durable-s3")]
+mod sigv4;
 
 pub use local::LocalBackend;
+#[cfg(feature = "durable-s3")]
+pub use s3::{S3Backend, S3Options, MAX_SINGLE_PUT_BYTES};
+#[cfg(feature = "durable-s3")]
+pub use sigv4::Credentials;

--- a/src/durable/backends/mod.rs
+++ b/src/durable/backends/mod.rs
@@ -1,0 +1,17 @@
+//! Backends this crate ships.
+//!
+//! One, for now: a directory. The conditional-write contract in
+//! [`Backend`](super::Backend) is what a provider has to satisfy, and the local
+//! backend satisfies it with `link(2)` and a version chain rather than
+//! approximating it — see [`local`] for why that matters even for a backend
+//! whose scope is development and conformance.
+//!
+//! An S3-compatible backend is a separate piece of work, and deliberately not
+//! in this crate's dependency graph until it exists: a caller that only ever
+//! uses a directory should not carry a cloud SDK. Until then, a provider is
+//! plugged in by implementing [`Backend`](super::Backend) and handing it to
+//! [`Namespace::with_backend`](super::Namespace::with_backend).
+
+pub mod local;
+
+pub use local::LocalBackend;

--- a/src/durable/backends/s3.rs
+++ b/src/durable/backends/s3.rs
@@ -1,0 +1,737 @@
+//! S3-compatible backend — AWS S3, Cloudflare R2, MinIO, and anything else that
+//! speaks the same two operations.
+//!
+//! This is the backend that makes the whole thing mean something. A local
+//! directory cannot be a remote authority: when the machine holding it is gone,
+//! so is the object. Recovering a database on a *different* machine needs the
+//! head, the checkpoints and the WAL to live somewhere neither machine owns.
+//!
+//! # Conditional writes are the whole contract
+//!
+//! The protocol needs a real atomic create and a real atomic compare-and-swap;
+//! simulating either with a HEAD followed by a PUT is not a weaker version, it
+//! is the bug the protocol exists to prevent. S3 provides both as preconditions
+//! on `PutObject`:
+//!
+//! ```text
+//! put_bytes_if_absent  ->  PUT with If-None-Match: *
+//! replace_if_match     ->  PUT with If-Match: <etag>
+//! ```
+//!
+//! A precondition failure is a compare-and-swap outcome, not a transport error,
+//! and it is reported as one. Everything the state machine does with
+//! [`PutOutcome::AlreadyExists`] and [`ReplaceOutcome::NotMatched`] depends on
+//! that distinction being made here rather than upstream.
+//!
+//! # No retries here, on purpose
+//!
+//! The object layer already knows how to settle an uncertain write: the keys it
+//! publishes are unique per attempt, so it re-reads and compares a digest, and
+//! its head commits re-read and look for their own intent. A retry loop in the
+//! backend would sit underneath all of that and turn a request that landed into
+//! a precondition failure — recoverable, but only because the layer above never
+//! trusts a status code on its own. Leaving the retry to the layer that can
+//! prove what happened keeps one deadline and one attempt count for the whole
+//! commit, which is what §5.8 asks for.
+//!
+//! # ETags stay opaque, and carry one assumption worth naming
+//!
+//! An S3 ETag is quoted, and it is only an MD5 for single-part uploads — not on
+//! R2, not for multipart, not necessarily forever. It is stored and handed back
+//! exactly as received and never parsed, which is what the contract requires.
+//!
+//! Being a content hash has a consequence a version counter would not have:
+//! writing *byte-identical* content does not advance the ETag, so the token used
+//! for that write stays valid afterwards and a second racer holding it could
+//! also win. Durable is safe from this because every head write changes the
+//! bytes — a lease acquisition moves the generation, a heartbeat moves
+//! `expires_at`, and a flush or checkpoint moves `manifest.seq`. That is a real
+//! dependency rather than a coincidence, so it is written down here: anything
+//! that made a head write idempotent at the byte level would break
+//! compare-and-swap on any content-hash-ETag provider.
+//!
+//! # V1 limits
+//!
+//! Single `PutObject` only, so an object caps at 5 GiB and a larger checkpoint
+//! fails with [`Category::LimitExceeded`] rather than silently truncating.
+//! Multipart upload is the fix and is not here yet.
+
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+use std::time::Duration;
+
+use ureq::Agent;
+
+use crate::durable::backend::{Backend, PutOutcome, ReplaceOutcome, Tagged};
+use crate::durable::digest::Digest;
+use crate::durable::errors::{err, Category, Error, Result};
+use crate::durable::keys::is_valid_object_key;
+
+use super::sigv4::{sha256_hex, sign, Credentials, Signable};
+
+/// The ceiling for one `PutObject`. Beyond it a checkpoint needs multipart
+/// upload.
+pub const MAX_SINGLE_PUT_BYTES: u64 = 5 * 1024 * 1024 * 1024;
+
+/// How an [`S3Backend`] reaches its bucket.
+#[derive(Debug, Clone, Default)]
+pub struct S3Options {
+    /// The bucket. Required.
+    pub bucket: String,
+    /// The key prefix for this object, without a leading slash. May be empty.
+    pub prefix: String,
+    /// The region the signature is scoped to. Falls back to `AWS_REGION`, then
+    /// `AWS_DEFAULT_REGION`, then `us-east-1` — which is what an S3-compatible
+    /// store that ignores regions expects to be told.
+    pub region: Option<String>,
+    /// Overrides the AWS endpoint, for MinIO, R2, or an S3-compatible gateway.
+    /// Must include a scheme.
+    pub endpoint: Option<String>,
+    /// Puts the bucket in the path rather than the hostname. Defaults to true
+    /// when `endpoint` is set, because that is what a local MinIO wants, and
+    /// false against AWS.
+    pub path_style: Option<bool>,
+    /// Credentials, when the environment and the shared credentials file are
+    /// not where they live. See [`Credentials::resolve`].
+    pub credentials: Option<Credentials>,
+    /// How long one request may take. Defaults to five minutes, which a
+    /// checkpoint of a large database may need raised.
+    pub timeout: Option<Duration>,
+}
+
+/// One durable object stored under a bucket prefix.
+pub struct S3Backend {
+    bucket: String,
+    prefix: String,
+    region: String,
+    endpoint: Option<(String, String, String)>,
+    path_style: bool,
+    credentials: Credentials,
+    agent: Agent,
+    describe: String,
+}
+
+impl std::fmt::Debug for S3Backend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("S3Backend")
+            .field("location", &self.describe)
+            .field("region", &self.region)
+            .finish_non_exhaustive()
+    }
+}
+
+fn backend_error(message: impl Into<String>) -> Error {
+    err(Category::Backend, message)
+}
+
+/// Splits an endpoint URL into scheme, host and base path.
+fn split_endpoint(endpoint: &str) -> Result<(String, String, String)> {
+    let (scheme, rest) = endpoint.split_once("://").ok_or_else(|| {
+        backend_error(format!(
+            "durable: an S3 endpoint needs a scheme, got {endpoint:?}"
+        ))
+    })?;
+    let (host, path) = match rest.split_once('/') {
+        Some((host, path)) => (host, format!("/{}", path.trim_end_matches('/'))),
+        None => (rest, String::new()),
+    };
+    if scheme.is_empty() || host.is_empty() {
+        return Err(backend_error(format!(
+            "durable: an S3 endpoint needs a scheme and a host, got {endpoint:?}"
+        )));
+    }
+    Ok((
+        scheme.to_string(),
+        host.to_string(),
+        path.trim_end_matches('/').to_string(),
+    ))
+}
+
+/// The HTTP agent, honouring `AWS_CA_BUNDLE` the way the AWS tools do.
+///
+/// Reading it matters more than it looks: on a host behind a TLS-inspecting
+/// proxy, that variable is the only place the extra root lives, and a client
+/// that ignores it fails every request with a certificate error while `aws s3`
+/// beside it works.
+fn build_agent(timeout: Duration) -> Result<Agent> {
+    let config = Agent::config_builder()
+        .timeout_global(Some(timeout))
+        // 4xx and 5xx are answers here, not errors: a 412 is the
+        // compare-and-swap losing, and a 404 is an absent object.
+        .http_status_as_error(false);
+
+    let Ok(bundle) = std::env::var("AWS_CA_BUNDLE") else {
+        return Ok(config.build().into());
+    };
+    if bundle.is_empty() {
+        return Ok(config.build().into());
+    }
+
+    let pem = std::fs::read(&bundle).map_err(|e| {
+        Error::wrap(
+            Category::Backend,
+            e,
+            format!("durable: cannot read the AWS_CA_BUNDLE at {bundle}"),
+        )
+    })?;
+    let mut roots = Vec::new();
+    for item in ureq::tls::parse_pem(&pem) {
+        if let Ok(ureq::tls::PemItem::Certificate(certificate)) = item {
+            roots.push(certificate);
+        }
+    }
+    if roots.is_empty() {
+        return Err(backend_error(format!(
+            "durable: the AWS_CA_BUNDLE at {bundle} holds no certificates"
+        )));
+    }
+    let tls = ureq::tls::TlsConfig::builder()
+        .root_certs(ureq::tls::RootCerts::Specific(std::sync::Arc::new(roots)))
+        .build();
+    Ok(config.tls_config(tls).build().into())
+}
+
+impl S3Backend {
+    /// Binds a backend to one object's key prefix.
+    ///
+    /// # Errors
+    ///
+    /// [`Category::Backend`] when there is no bucket, no resolvable
+    /// credentials, or an endpoint that is not a URL.
+    pub fn new(options: S3Options) -> Result<Self> {
+        if options.bucket.is_empty() {
+            return Err(backend_error("durable: the S3 backend needs a bucket"));
+        }
+        let credentials = Credentials::resolve(options.credentials)?;
+        let region = options
+            .region
+            .filter(|region| !region.is_empty())
+            .or_else(|| std::env::var("AWS_REGION").ok().filter(|r| !r.is_empty()))
+            .or_else(|| {
+                std::env::var("AWS_DEFAULT_REGION")
+                    .ok()
+                    .filter(|r| !r.is_empty())
+            })
+            // The signature needs a region whether or not the provider cares
+            // which one.
+            .unwrap_or_else(|| "us-east-1".to_string());
+
+        let endpoint = match &options.endpoint {
+            Some(endpoint) if !endpoint.is_empty() => Some(split_endpoint(endpoint)?),
+            _ => None,
+        };
+        let path_style = options.path_style.unwrap_or(endpoint.is_some());
+        let prefix = options.prefix.trim_matches('/').to_string();
+
+        Ok(Self {
+            // Never the credentials, and never a presigned anything: this
+            // string ends up in error messages and logs.
+            describe: format!("s3://{}/{}", options.bucket, prefix),
+            bucket: options.bucket,
+            prefix,
+            region,
+            endpoint,
+            path_style,
+            credentials,
+            agent: build_agent(options.timeout.unwrap_or(Duration::from_secs(300)))?,
+        })
+    }
+
+    /// Prefixes a protocol key, refusing one that is not a plain relative key.
+    fn key_for(&self, key: &str) -> Result<String> {
+        if !is_valid_object_key(key) {
+            return Err(backend_error(format!(
+                "durable: refusing to resolve invalid key {key:?}"
+            )));
+        }
+        if self.prefix.is_empty() {
+            Ok(key.to_string())
+        } else {
+            Ok(format!("{}/{key}", self.prefix))
+        }
+    }
+
+    /// The request URL and the host the signature covers.
+    fn url_for(&self, key: &str) -> Result<(String, String, String)> {
+        let full = self.key_for(key)?;
+        let (scheme, host, path) = match (&self.endpoint, self.path_style) {
+            (Some((scheme, host, base)), true) => (
+                scheme.clone(),
+                host.clone(),
+                format!("{base}/{}/{full}", self.bucket),
+            ),
+            (Some((scheme, host, base)), false) => (
+                scheme.clone(),
+                format!("{}.{host}", self.bucket),
+                format!("{base}/{full}"),
+            ),
+            (None, true) => (
+                "https".to_string(),
+                format!("s3.{}.amazonaws.com", self.region),
+                format!("/{}/{full}", self.bucket),
+            ),
+            (None, false) => (
+                "https".to_string(),
+                format!("{}.s3.{}.amazonaws.com", self.bucket, self.region),
+                format!("/{full}"),
+            ),
+        };
+        let encoded = super::sigv4::uri_encode_path(&path);
+        Ok((format!("{scheme}://{host}{encoded}"), host, path))
+    }
+
+    /// Signs and sends one request whose body is already known.
+    ///
+    /// The method follows from the body rather than being passed alongside it:
+    /// ureq types a builder by whether it carries one, and the two cannot be
+    /// mixed up if only one of them can be built.
+    fn send(
+        &self,
+        key: &str,
+        headers: &[(String, String)],
+        payload_hash: &str,
+        body: Body<'_>,
+    ) -> Result<Outcome> {
+        let method = body.method();
+        let (url, host, path) = self.url_for(key)?;
+        let signed = sign(
+            Signable {
+                method,
+                host: &host,
+                path: &path,
+                query: "",
+                headers,
+                payload_hash,
+            },
+            &self.credentials,
+            &self.region,
+            std::time::SystemTime::now(),
+        );
+        let all = || headers.iter().chain(signed.iter());
+
+        let sent = match body {
+            Body::None => {
+                let mut request = self.agent.get(&url);
+                for (name, value) in all() {
+                    request = request.header(name.as_str(), value.as_str());
+                }
+                request.call()
+            }
+            Body::Bytes(bytes) => {
+                let mut request = self.agent.put(&url);
+                for (name, value) in all() {
+                    request = request.header(name.as_str(), value.as_str());
+                }
+                request.send(bytes)
+            }
+            Body::File(file) => {
+                let mut request = self.agent.put(&url);
+                for (name, value) in all() {
+                    request = request.header(name.as_str(), value.as_str());
+                }
+                // A File body carries its own length, so the request goes out
+                // length-delimited rather than chunked. That is not a nicety:
+                // SigV4 header signing of a chunked body is a different signing
+                // scheme, and the request would be rejected.
+                request.send(file)
+            }
+        };
+
+        match sent {
+            Ok(response) => Ok(Outcome::Responded(response)),
+            Err(e) if reached_the_service(&e) => Ok(Outcome::Indeterminate),
+            Err(e) => Err(Error::wrap(
+                Category::Backend,
+                e,
+                format!("durable: {method} {key} failed against {}", self.describe),
+            )),
+        }
+    }
+
+    fn assert_within_single_put(&self, key: &str, size: u64) -> Result<()> {
+        if size > MAX_SINGLE_PUT_BYTES {
+            return Err(err(
+                Category::LimitExceeded,
+                format!(
+                    "durable: {key} is {size} bytes, over the {MAX_SINGLE_PUT_BYTES}-byte ceiling \
+                     for a single PutObject; multipart upload is not implemented, so checkpoint \
+                     more often or reduce the database"
+                ),
+            )
+            .with_limit(MAX_SINGLE_PUT_BYTES, size));
+        }
+        Ok(())
+    }
+
+    /// Turns an unexpected status into an error carrying the beginning of the
+    /// provider's own message.
+    ///
+    /// S3 answers with an XML document whose `Code` and `Message` are what an
+    /// operator needs; the cap is there because an error body is not a place to
+    /// trust a length.
+    fn status_error(&self, what: &str, mut response: Response) -> Error {
+        let status = response.status().as_u16();
+        let detail = response
+            .body_mut()
+            .with_config()
+            .limit(2048)
+            .read_to_string()
+            .unwrap_or_default();
+        let detail = detail.trim();
+        let suffix = if detail.is_empty() {
+            String::new()
+        } else {
+            format!(": {detail}")
+        };
+        backend_error(format!(
+            "durable: {what} failed against {} (HTTP {status}){suffix}",
+            self.describe
+        ))
+    }
+}
+
+type Response = ureq::http::Response<ureq::Body>;
+
+enum Outcome {
+    Responded(Response),
+    /// The request may or may not have reached the service.
+    Indeterminate,
+}
+
+enum Body<'a> {
+    None,
+    Bytes(&'a [u8]),
+    File(File),
+}
+
+impl Body<'_> {
+    fn method(&self) -> &'static str {
+        match self {
+            Self::None => "GET",
+            Self::Bytes(_) | Self::File(_) => "PUT",
+        }
+    }
+}
+
+/// Could a request that failed in transport still have been committed?
+///
+/// The distinction is the difference between a retry and a `commit_ambiguous`.
+/// A timeout or a reset connection may have reached the service; an
+/// unresolvable host or a refused connection did not. Guessing "did not" when it
+/// did is how a caller ends up publishing twice, so anything genuinely in doubt
+/// counts as in doubt — the cases below are the only ones ruled out.
+fn reached_the_service(error: &ureq::Error) -> bool {
+    match error {
+        ureq::Error::HostNotFound | ureq::Error::ConnectionFailed => false,
+        ureq::Error::Io(io) => !matches!(
+            io.kind(),
+            std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::NotFound
+        ),
+        // A bad URI, a header the http crate rejects, too many redirects: the
+        // request was never sent.
+        ureq::Error::BadUri(_)
+        | ureq::Error::Http(_)
+        | ureq::Error::InvalidProxyUrl
+        | ureq::Error::TooManyRedirects
+        | ureq::Error::BodyExceedsLimit(_) => false,
+        _ => true,
+    }
+}
+
+/// Does this status mean someone else got there first?
+///
+/// S3 answers 412 for `If-Match` and for `If-None-Match: *` against an object
+/// that already exists; a race between two conditional writes can also surface
+/// as 409 `ConditionalRequestConflict`. Both mean the same thing to the
+/// protocol.
+fn is_precondition_failure(status: u16) -> bool {
+    status == 412 || status == 409
+}
+
+fn etag_of(response: &Response) -> Option<String> {
+    response
+        .headers()
+        .get("etag")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string)
+}
+
+impl Backend for S3Backend {
+    fn describe(&self) -> String {
+        self.describe.clone()
+    }
+
+    fn get_bytes(&self, key: &str) -> Result<Option<Vec<u8>>> {
+        Ok(self.get_bytes_with_etag(key)?.map(|tagged| tagged.data))
+    }
+
+    fn get_bytes_with_etag(&self, key: &str) -> Result<Option<Tagged>> {
+        let Outcome::Responded(mut response) = self.send(key, &[], &sha256_hex(b""), Body::None)?
+        else {
+            return Err(backend_error(format!(
+                "durable: reading {key} from {} did not complete",
+                self.describe
+            )));
+        };
+        let status = response.status().as_u16();
+        if status == 404 {
+            return Ok(None);
+        }
+        if status != 200 {
+            return Err(self.status_error(&format!("reading {key}"), response));
+        }
+        // An absent ETag leaves nothing to compare-and-swap against, so it is a
+        // hard failure rather than an empty token that silently never matches.
+        let etag = etag_of(&response).ok_or_else(|| {
+            backend_error(format!(
+                "durable: {key} came back from {} without an ETag; this provider cannot support \
+                 compare-and-swap",
+                self.describe
+            ))
+        })?;
+        let data = response
+            .body_mut()
+            .with_config()
+            // A head is capped by the protocol and a WAL segment by its own
+            // limit; both are checked above this layer, and the cap here only
+            // stops a runaway response from becoming a runaway allocation.
+            .limit(crate::durable::MAX_WAL_SEGMENT_BYTES)
+            .read_to_vec()
+            .map_err(|e| {
+                Error::wrap(
+                    Category::Backend,
+                    e,
+                    format!("durable: reading the body of {key} from {}", self.describe),
+                )
+            })?;
+        Ok(Some(Tagged { data, etag }))
+    }
+
+    fn open_reader(&self, key: &str) -> Result<Option<Box<dyn Read + Send>>> {
+        let Outcome::Responded(response) = self.send(key, &[], &sha256_hex(b""), Body::None)?
+        else {
+            return Err(backend_error(format!(
+                "durable: opening {key} from {} did not complete",
+                self.describe
+            )));
+        };
+        let status = response.status().as_u16();
+        if status == 404 {
+            return Ok(None);
+        }
+        if status != 200 {
+            return Err(self.status_error(&format!("opening {key}"), response));
+        }
+        Ok(Some(Box::new(response.into_body().into_reader())))
+    }
+
+    fn put_bytes_if_absent(&self, key: &str, data: &[u8]) -> Result<PutOutcome> {
+        self.assert_within_single_put(key, data.len() as u64)?;
+        let headers = vec![("if-none-match".to_string(), "*".to_string())];
+        match self.send(key, &headers, &sha256_hex(data), Body::Bytes(data))? {
+            Outcome::Indeterminate => Ok(PutOutcome::Ambiguous),
+            Outcome::Responded(response) => Ok(self.classify_put(response)),
+        }
+    }
+
+    fn put_file_if_absent(
+        &self,
+        key: &str,
+        local_path: &Path,
+        digest: &Digest,
+    ) -> Result<PutOutcome> {
+        self.assert_within_single_put(key, digest.size)?;
+        let file = File::open(local_path).map_err(|e| {
+            Error::wrap(
+                Category::Backend,
+                e,
+                format!("durable: cannot read {}", local_path.display()),
+            )
+        })?;
+        let headers = vec![("if-none-match".to_string(), "*".to_string())];
+        // The digest the manifest records is the digest that signs the upload,
+        // so a checkpoint archive is never read twice.
+        match self.send(key, &headers, &digest.sha256, Body::File(file))? {
+            Outcome::Indeterminate => Ok(PutOutcome::Ambiguous),
+            Outcome::Responded(response) => Ok(self.classify_put(response)),
+        }
+    }
+
+    fn replace_if_match(&self, key: &str, data: &[u8], etag: &str) -> Result<ReplaceOutcome> {
+        self.assert_within_single_put(key, data.len() as u64)?;
+        let headers = vec![("if-match".to_string(), etag.to_string())];
+        let response = match self.send(key, &headers, &sha256_hex(data), Body::Bytes(data))? {
+            Outcome::Indeterminate => return Ok(ReplaceOutcome::Ambiguous),
+            Outcome::Responded(response) => response,
+        };
+
+        let status = response.status().as_u16();
+        if is_precondition_failure(status) {
+            return Ok(ReplaceOutcome::NotMatched);
+        }
+        if status == 404 {
+            // The target is gone, so the compare-and-swap did not match.
+            // Reporting it as anything else would send the caller looking for
+            // its own intent in a head that no longer exists.
+            return Ok(ReplaceOutcome::NotMatched);
+        }
+        if status >= 500 {
+            return Ok(ReplaceOutcome::Ambiguous);
+        }
+        if status != 200 {
+            return Err(self.status_error(&format!("replacing {key}"), response));
+        }
+        match etag_of(&response) {
+            Some(etag) => Ok(ReplaceOutcome::Done { etag }),
+            // The write landed but the new token is unknown, so the next
+            // compare-and-swap would have nothing to present. Re-reading is the
+            // honest way out.
+            None => Ok(ReplaceOutcome::Ambiguous),
+        }
+    }
+}
+
+impl S3Backend {
+    fn classify_put(&self, response: Response) -> PutOutcome {
+        let status = response.status().as_u16();
+        match status {
+            _ if is_precondition_failure(status) => PutOutcome::AlreadyExists,
+            200 => PutOutcome::Created,
+            // A 5xx, or anything else unexpected: the layer above settles it by
+            // re-reading the unique key it just tried to publish.
+            _ => PutOutcome::Ambiguous,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn options(bucket: &str) -> S3Options {
+        S3Options {
+            bucket: bucket.to_string(),
+            prefix: "durable/tenant-1".to_string(),
+            region: Some("eu-central-1".to_string()),
+            credentials: Some(Credentials {
+                access_key_id: "AKIDEXAMPLE".to_string(),
+                secret_access_key: "secret".to_string(),
+                session_token: None,
+            }),
+            ..S3Options::default()
+        }
+    }
+
+    #[test]
+    fn aws_gets_a_virtual_hosted_url_and_a_gateway_gets_a_path_style_one() -> Result<()> {
+        let aws = S3Backend::new(options("my-bucket"))?;
+        let (url, host, path) = aws.url_for("head.json")?;
+        assert_eq!(host, "my-bucket.s3.eu-central-1.amazonaws.com");
+        assert_eq!(path, "/durable/tenant-1/head.json");
+        assert_eq!(
+            url,
+            "https://my-bucket.s3.eu-central-1.amazonaws.com/durable/tenant-1/head.json"
+        );
+
+        let minio = S3Backend::new(S3Options {
+            endpoint: Some("http://127.0.0.1:9000".to_string()),
+            ..options("my-bucket")
+        })?;
+        let (url, host, _) = minio.url_for("wal/1-1-aa.jsonl")?;
+        assert_eq!(
+            host, "127.0.0.1:9000",
+            "a gateway keeps the bucket in the path"
+        );
+        assert_eq!(
+            url,
+            "http://127.0.0.1:9000/my-bucket/durable/tenant-1/wal/1-1-aa.jsonl"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn a_key_out_of_an_untrusted_head_cannot_leave_the_prefix() -> Result<()> {
+        let backend = S3Backend::new(options("my-bucket"))?;
+        for key in ["../elsewhere", "/absolute", "wal/../../escape", ""] {
+            assert_eq!(
+                backend.key_for(key).unwrap_err().category(),
+                Category::Backend,
+                "{key:?}"
+            );
+        }
+        assert_eq!(backend.key_for("head.json")?, "durable/tenant-1/head.json");
+        Ok(())
+    }
+
+    #[test]
+    fn the_description_carries_no_credential() -> Result<()> {
+        let backend = S3Backend::new(options("my-bucket"))?;
+        let described = format!("{} {:?}", backend.describe(), backend);
+        assert!(described.contains("s3://my-bucket/durable/tenant-1"));
+        assert!(!described.contains("secret"), "{described}");
+        assert!(!described.contains("AKIDEXAMPLE"), "{described}");
+        Ok(())
+    }
+
+    #[test]
+    fn an_object_beyond_one_put_is_a_limit_rather_than_a_truncation() -> Result<()> {
+        let backend = S3Backend::new(options("my-bucket"))?;
+        let error = backend
+            .assert_within_single_put("checkpoints/1-1-aa.tar.gz", MAX_SINGLE_PUT_BYTES + 1)
+            .expect_err("over one PutObject");
+        assert_eq!(error.category(), Category::LimitExceeded);
+        assert_eq!(
+            error.limit(),
+            Some((MAX_SINGLE_PUT_BYTES, MAX_SINGLE_PUT_BYTES + 1))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn a_precondition_failure_is_a_race_rather_than_an_error() {
+        assert!(is_precondition_failure(412), "If-Match / If-None-Match");
+        assert!(is_precondition_failure(409), "ConditionalRequestConflict");
+        assert!(!is_precondition_failure(404));
+        assert!(!is_precondition_failure(200));
+        assert!(!is_precondition_failure(500));
+    }
+
+    #[test]
+    fn only_a_request_that_provably_never_left_is_ruled_out() {
+        assert!(!reached_the_service(&ureq::Error::HostNotFound));
+        assert!(!reached_the_service(&ureq::Error::ConnectionFailed));
+        assert!(!reached_the_service(&ureq::Error::Io(
+            std::io::Error::from(std::io::ErrorKind::ConnectionRefused)
+        )));
+        // A reset or a timeout may well have been received and acted on.
+        assert!(reached_the_service(&ureq::Error::Io(std::io::Error::from(
+            std::io::ErrorKind::ConnectionReset
+        ))));
+        assert!(reached_the_service(&ureq::Error::Io(std::io::Error::from(
+            std::io::ErrorKind::BrokenPipe
+        ))));
+    }
+
+    #[test]
+    fn an_endpoint_needs_a_scheme_and_a_host() {
+        assert!(split_endpoint("127.0.0.1:9000").is_err());
+        assert!(split_endpoint("http://").is_err());
+        assert_eq!(
+            split_endpoint("https://x.r2.cloudflarestorage.com").unwrap(),
+            (
+                "https".to_string(),
+                "x.r2.cloudflarestorage.com".to_string(),
+                String::new()
+            )
+        );
+        assert_eq!(
+            split_endpoint("http://gateway.example/base/").unwrap(),
+            (
+                "http".to_string(),
+                "gateway.example".to_string(),
+                "/base".to_string()
+            )
+        );
+    }
+}

--- a/src/durable/backends/sigv4.rs
+++ b/src/durable/backends/sigv4.rs
@@ -1,0 +1,506 @@
+//! AWS Signature Version 4, for the two requests the S3 backend makes.
+//!
+//! Signing is here rather than delegated to the AWS SDK on purpose. The durable
+//! control plane needs exactly two S3 operations — `GetObject` and `PutObject`,
+//! the latter with a precondition — and `aws-sdk-s3` brings an async runtime
+//! and several dozen crates with it, for a feature most callers of this crate
+//! will never enable. The [`Backend`](crate::durable::Backend) trait is
+//! synchronous, so an SDK built on Tokio would have to be driven from a
+//! `block_on` inside every call.
+//!
+//! So the surface is small, and staying small is the point: no multipart, no
+//! listing, no chunked signing, no presigning. What is here is the SigV4
+//! header-signing form for a request whose payload hash is already known —
+//! which it always is, because the protocol computes the SHA-256 of everything
+//! it publishes before publishing it (contract §4.5). The digest a manifest
+//! records is the digest that signs the upload, so a checkpoint archive is
+//! never read twice.
+//!
+//! There is deliberately no `UNSIGNED-PAYLOAD` constant. Every request signed
+//! here knows its payload hash, and leaving the escape hatch out means a future
+//! operation cannot reach for it without first thinking about whether the
+//! provider accepts it.
+
+use std::fmt::Write as _;
+
+use hmac::{Hmac, Mac};
+use sha2::{Digest as _, Sha256};
+
+use crate::durable::errors::{err, Category, Result};
+
+const ALGORITHM: &str = "AWS4-HMAC-SHA256";
+const SERVICE: &str = "s3";
+
+/// What SigV4 needs to sign.
+///
+/// `session_token` is set only for temporary credentials, which is what SSO,
+/// an assumed role and the instance metadata service all hand out.
+#[derive(Clone)]
+pub struct Credentials {
+    /// The access key id.
+    pub access_key_id: String,
+    /// The secret access key. Never logged, and never part of `describe`.
+    pub secret_access_key: String,
+    /// The session token for temporary credentials, if there is one.
+    pub session_token: Option<String>,
+}
+
+impl std::fmt::Debug for Credentials {
+    /// Prints the key id and nothing else: this type ends up inside a backend
+    /// that a caller may well `{:?}` into a log.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Credentials")
+            .field("access_key_id", &self.access_key_id)
+            .field("secret_access_key", &"<redacted>")
+            .field(
+                "session_token",
+                &self.session_token.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
+    }
+}
+
+impl Credentials {
+    fn from_parts(
+        id: Option<String>,
+        secret: Option<String>,
+        token: Option<String>,
+    ) -> Option<Self> {
+        let (id, secret) = (id?, secret?);
+        if id.is_empty() || secret.is_empty() {
+            return None;
+        }
+        Some(Self {
+            access_key_id: id,
+            secret_access_key: secret,
+            session_token: token.filter(|token| !token.is_empty()),
+        })
+    }
+
+    /// Finds credentials the way the AWS tools do, in the order they do,
+    /// stopping at the first complete pair.
+    ///
+    /// Three sources, and the list stops where a hand-written signer stops
+    /// being the right tool:
+    ///
+    /// 1. given explicitly to the backend;
+    /// 2. the standard environment variables;
+    /// 3. the shared credentials file, honouring `AWS_PROFILE`.
+    ///
+    /// Not here: SSO, assumed roles, the EC2 and ECS metadata services, and
+    /// anything else needing a refresh loop. Those belong to the AWS SDK. For
+    /// an SSO profile, export the temporary credentials the way the CLI does:
+    ///
+    /// ```sh
+    /// eval "$(aws configure export-credentials --profile my-profile --format env)"
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// [`Category::Backend`] when nothing supplies a key pair, with a message
+    /// naming the three places that were tried.
+    pub fn resolve(explicit: Option<Credentials>) -> Result<Self> {
+        if let Some(explicit) = explicit {
+            return Ok(explicit);
+        }
+        let from_env = Self::from_parts(
+            std::env::var("AWS_ACCESS_KEY_ID").ok(),
+            std::env::var("AWS_SECRET_ACCESS_KEY").ok(),
+            std::env::var("AWS_SESSION_TOKEN").ok(),
+        );
+        if let Some(from_env) = from_env {
+            return Ok(from_env);
+        }
+        if let Some(from_file) = Self::from_shared_file() {
+            return Ok(from_file);
+        }
+        Err(err(
+            Category::Backend,
+            "durable: no S3 credentials found; set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, \
+             configure a shared credentials file, or pass credentials to the backend. SSO and \
+             instance-role credentials are not resolved here — export them first with \
+             `aws configure export-credentials --format env`",
+        ))
+    }
+
+    /// Reads the requested profile out of the shared credentials file.
+    ///
+    /// Deliberately a small parser: the INI dialect that file uses has corners
+    /// — nested properties, quoted values — that only matter for settings this
+    /// signer does not read.
+    fn from_shared_file() -> Option<Self> {
+        let path = match std::env::var("AWS_SHARED_CREDENTIALS_FILE") {
+            Ok(path) if !path.is_empty() => std::path::PathBuf::from(path),
+            _ => std::path::PathBuf::from(std::env::var("HOME").ok()?)
+                .join(".aws")
+                .join("credentials"),
+        };
+        let body = std::fs::read_to_string(path).ok()?;
+        let wanted = std::env::var("AWS_PROFILE").unwrap_or_else(|_| "default".to_string());
+
+        let (mut id, mut secret, mut token) = (None, None, None);
+        let mut in_profile = false;
+        for line in body.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
+                continue;
+            }
+            if let Some(name) = line.strip_prefix('[').and_then(|l| l.strip_suffix(']')) {
+                // A file written by the SSO tooling prefixes profile names.
+                let name = name.trim().strip_prefix("profile ").unwrap_or(name.trim());
+                in_profile = name == wanted;
+                continue;
+            }
+            if !in_profile {
+                continue;
+            }
+            let Some((key, value)) = line.split_once('=') else {
+                continue;
+            };
+            let value = value.trim().to_string();
+            match key.trim().to_ascii_lowercase().as_str() {
+                "aws_access_key_id" => id = Some(value),
+                "aws_secret_access_key" => secret = Some(value),
+                "aws_session_token" => token = Some(value),
+                _ => {}
+            }
+        }
+        Self::from_parts(id, secret, token)
+    }
+}
+
+/// The lowercase hex SHA-256 of a buffer.
+pub(crate) fn sha256_hex(data: &[u8]) -> String {
+    hex(&Sha256::digest(data))
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().fold(String::with_capacity(64), |mut out, b| {
+        let _ = write!(out, "{b:02x}");
+        out
+    })
+}
+
+fn hmac_sha256(key: &[u8], data: &[u8]) -> Vec<u8> {
+    let mut mac = <Hmac<Sha256>>::new_from_slice(key).expect("HMAC takes a key of any length");
+    mac.update(data);
+    mac.finalize().into_bytes().to_vec()
+}
+
+/// Derives the date/region/service-scoped signing key.
+///
+/// `service` is a parameter even though this module only ever signs for S3, so
+/// the derivation can be checked against AWS's own published example — which
+/// uses a different service. Getting one link of this HMAC chain wrong produces
+/// a signature that is simply rejected, with nothing to say which link it was.
+fn signing_key(secret: &str, datestamp: &str, region: &str, service: &str) -> Vec<u8> {
+    let key = hmac_sha256(format!("AWS4{secret}").as_bytes(), datestamp.as_bytes());
+    let key = hmac_sha256(&key, region.as_bytes());
+    let key = hmac_sha256(&key, service.as_bytes());
+    hmac_sha256(&key, b"aws4_request")
+}
+
+/// Percent-encodes a path the way S3 canonicalisation wants: every byte outside
+/// the unreserved set is escaped, and `/` is left alone as a separator.
+pub(crate) fn uri_encode_path(path: &str) -> String {
+    let mut out = String::with_capacity(path.len());
+    for byte in path.bytes() {
+        let unreserved =
+            byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~' | b'/');
+        if unreserved {
+            out.push(byte as char);
+        } else {
+            let _ = write!(out, "%{byte:02X}");
+        }
+    }
+    out
+}
+
+/// One header of a request being signed.
+pub(crate) type Header = (String, String);
+
+/// UTC now, as the two timestamp forms SigV4 uses.
+///
+/// Passed into [`sign`] rather than read inside it, so a test can sign at a
+/// fixed instant and compare against a known-good signature.
+pub(crate) fn timestamps(now: std::time::SystemTime) -> (String, String) {
+    let secs = now
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let (year, month, day, hour, minute, second) = civil_from_unix(secs);
+    (
+        format!("{year:04}{month:02}{day:02}T{hour:02}{minute:02}{second:02}Z"),
+        format!("{year:04}{month:02}{day:02}"),
+    )
+}
+
+/// Days-from-civil, inverted: the standard algorithm, because `std` has no
+/// calendar and a date formatter is not worth a dependency for two strings.
+fn civil_from_unix(secs: u64) -> (u64, u64, u64, u64, u64, u64) {
+    let days = secs / 86_400;
+    let rem = secs % 86_400;
+    let z = days as i64 + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097);
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (
+        y as u64,
+        m as u64,
+        d as u64,
+        rem / 3600,
+        (rem % 3600) / 60,
+        rem % 60,
+    )
+}
+
+/// One request, in the form the canonical request is built from.
+pub(crate) struct Signable<'a> {
+    /// `GET` or `PUT`.
+    pub(crate) method: &'a str,
+    /// The `Host` header the signature covers, which for a virtual-hosted
+    /// bucket is not the same as the endpoint.
+    pub(crate) host: &'a str,
+    /// The unencoded path; [`uri_encode_path`] is applied here rather than by
+    /// the caller, because the canonical form and the wire form differ.
+    pub(crate) path: &'a str,
+    /// The canonical query string, empty for every key this protocol uses.
+    pub(crate) query: &'a str,
+    /// The headers the caller has already set.
+    pub(crate) headers: &'a [Header],
+    /// The lowercase hex SHA-256 of the body.
+    pub(crate) payload_hash: &'a str,
+}
+
+/// The headers SigV4 adds to a request, ready to be set on it.
+///
+/// The ones that matter out of [`Signable::headers`] are signed, and the
+/// signature covers `host` whether or not the caller listed it. Signing the
+/// preconditions is not required by S3, but they are the headers that decide
+/// whether the request mutates anything, so leaving them out of the signature
+/// would let something between here and the bucket turn a conditional create
+/// into an overwrite.
+pub(crate) fn sign(
+    request: Signable<'_>,
+    credentials: &Credentials,
+    region: &str,
+    now: std::time::SystemTime,
+) -> Vec<Header> {
+    let Signable {
+        method,
+        host,
+        path,
+        query,
+        headers,
+        payload_hash,
+    } = request;
+    let (amz_date, datestamp) = timestamps(now);
+
+    let mut signed: Vec<Header> = vec![("host".to_string(), host.to_string())];
+    signed.push(("x-amz-date".to_string(), amz_date.clone()));
+    signed.push(("x-amz-content-sha256".to_string(), payload_hash.to_string()));
+    if let Some(token) = &credentials.session_token {
+        signed.push(("x-amz-security-token".to_string(), token.clone()));
+    }
+    for (name, value) in headers {
+        let lower = name.to_ascii_lowercase();
+        let interesting = lower.starts_with("x-amz-")
+            || lower == "if-match"
+            || lower == "if-none-match"
+            || lower == "content-type";
+        if interesting && !signed.iter().any(|(existing, _)| *existing == lower) {
+            signed.push((lower, value.trim().to_string()));
+        }
+    }
+    signed.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let canonical_headers: String = signed
+        .iter()
+        .map(|(name, value)| format!("{name}:{value}\n"))
+        .collect();
+    let signed_names: Vec<&str> = signed.iter().map(|(name, _)| name.as_str()).collect();
+    let signed_headers = signed_names.join(";");
+
+    let canonical_request = format!(
+        "{method}\n{}\n{query}\n{canonical_headers}\n{signed_headers}\n{payload_hash}",
+        uri_encode_path(path)
+    );
+    let scope = format!("{datestamp}/{region}/{SERVICE}/aws4_request");
+    let string_to_sign = format!(
+        "{ALGORITHM}\n{amz_date}\n{scope}\n{}",
+        sha256_hex(canonical_request.as_bytes())
+    );
+    let signature = hex(&hmac_sha256(
+        &signing_key(&credentials.secret_access_key, &datestamp, region, SERVICE),
+        string_to_sign.as_bytes(),
+    ));
+
+    let authorization = format!(
+        "{ALGORITHM} Credential={}/{scope}, SignedHeaders={signed_headers}, Signature={signature}",
+        credentials.access_key_id
+    );
+
+    // Everything the signature covers, plus the signature, minus `host` — which
+    // the HTTP client sets from the URL and would reject as a duplicate.
+    let mut out: Vec<Header> = signed
+        .into_iter()
+        .filter(|(name, _)| name != "host")
+        .filter(|(name, _)| {
+            !headers
+                .iter()
+                .any(|(set, _)| set.to_ascii_lowercase() == *name)
+        })
+        .collect();
+    out.push(("authorization".to_string(), authorization));
+    out
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// AWS's own published SigV4 test vector, from the "Examples of the
+    /// complete Signature Version 4 signing process" documentation.
+    ///
+    /// It signs for `iam`, not `s3`, which is exactly why `signing_key` takes
+    /// the service: a wrong link in the HMAC chain produces a signature that is
+    /// rejected with nothing to say which link it was, and this is the only
+    /// check that can tell.
+    #[test]
+    fn the_signing_key_matches_the_published_derivation() {
+        let key = signing_key(
+            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+            "20150830",
+            "us-east-1",
+            "iam",
+        );
+        assert_eq!(
+            hex(&key),
+            "c4afb1cc5771d871763a393e44b703571b55cc28424d1a5e86da6ed3c154a4b9"
+        );
+    }
+
+    #[test]
+    fn a_path_is_encoded_for_the_canonical_request_not_for_a_query_string() {
+        assert_eq!(uri_encode_path("/wal/1-1-aa.jsonl"), "/wal/1-1-aa.jsonl");
+        // A space is %20, never `+`: the `+` form produces a signature that
+        // does not match the request S3 received.
+        assert_eq!(uri_encode_path("/a b"), "/a%20b");
+        assert_eq!(uri_encode_path("/a+b"), "/a%2Bb");
+        assert_eq!(uri_encode_path("/tenant~1_2.3"), "/tenant~1_2.3");
+        assert_eq!(uri_encode_path("/é"), "/%C3%A9");
+    }
+
+    #[test]
+    fn timestamps_are_the_two_forms_sigv4_asks_for() {
+        // 2015-08-30T12:36:00Z, the instant in the AWS worked example.
+        let instant = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_440_938_160);
+        assert_eq!(
+            timestamps(instant),
+            ("20150830T123600Z".to_string(), "20150830".to_string())
+        );
+
+        // A leap day, because the civil-from-days arithmetic is the one part of
+        // this that a wrong constant would break silently for one day in four
+        // years.
+        let leap = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_709_209_800);
+        assert_eq!(
+            timestamps(leap),
+            ("20240229T123000Z".to_string(), "20240229".to_string())
+        );
+    }
+
+    #[test]
+    fn the_signature_covers_the_preconditions_that_decide_whether_a_write_mutates() {
+        let credentials = Credentials {
+            access_key_id: "AKIDEXAMPLE".to_string(),
+            secret_access_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".to_string(),
+            session_token: None,
+        };
+        let headers = vec![("If-None-Match".to_string(), "*".to_string())];
+        let signed = sign(
+            Signable {
+                method: "PUT",
+                host: "bucket.s3.eu-central-1.amazonaws.com",
+                path: "/prefix/head.json",
+                query: "",
+                headers: &headers,
+                payload_hash: &sha256_hex(b"{}"),
+            },
+            &credentials,
+            "eu-central-1",
+            std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_440_938_160),
+        );
+        let authorization = signed
+            .iter()
+            .find(|(name, _)| name == "authorization")
+            .map(|(_, value)| value.clone())
+            .expect("an Authorization header");
+
+        assert!(
+            authorization
+                .contains("SignedHeaders=host;if-none-match;x-amz-content-sha256;x-amz-date"),
+            "the precondition has to be inside the signature: {authorization}"
+        );
+        assert!(
+            !signed.iter().any(|(name, _)| name == "host"),
+            "host comes from the URL; setting it twice is a client error"
+        );
+        assert!(
+            !signed.iter().any(|(name, _)| name == "if-none-match"),
+            "a header the caller already set is not returned again"
+        );
+    }
+
+    #[test]
+    fn a_session_token_is_signed_when_there_is_one() {
+        let credentials = Credentials {
+            access_key_id: "AKIDEXAMPLE".to_string(),
+            secret_access_key: "secret".to_string(),
+            session_token: Some("token".to_string()),
+        };
+        let signed = sign(
+            Signable {
+                method: "GET",
+                host: "bucket.s3.amazonaws.com",
+                path: "/head.json",
+                query: "",
+                headers: &[],
+                payload_hash: &sha256_hex(b""),
+            },
+            &credentials,
+            "us-east-1",
+            std::time::UNIX_EPOCH,
+        );
+        assert!(signed
+            .iter()
+            .any(|(name, value)| name == "x-amz-security-token" && value == "token"));
+        let authorization = &signed.last().expect("authorization").1;
+        assert!(
+            authorization.contains("x-amz-security-token"),
+            "{authorization}"
+        );
+    }
+
+    #[test]
+    fn credentials_never_print_themselves() {
+        let credentials = Credentials {
+            access_key_id: "AKIDEXAMPLE".to_string(),
+            secret_access_key: "hunter2".to_string(),
+            session_token: Some("hunter3".to_string()),
+        };
+        let printed = format!("{credentials:?}");
+        assert!(
+            printed.contains("AKIDEXAMPLE"),
+            "the key id is not a secret"
+        );
+        assert!(!printed.contains("hunter2"), "{printed}");
+        assert!(!printed.contains("hunter3"), "{printed}");
+    }
+}

--- a/src/durable/chdb_engine.rs
+++ b/src/durable/chdb_engine.rs
@@ -1,0 +1,214 @@
+//! The real engine: a chDB connection on the object's scratch directory.
+//!
+//! Going through the crate's own [`Connection`] rather than the FFI directly is
+//! deliberate. The engine registry already models the constraint the contract
+//! states in §3.6 — chDB binds one data path per process — so a second durable
+//! object in the same process is refused by the registry with an error naming
+//! both paths, instead of failing somewhere deeper and less legibly. Nothing
+//! here maintains a second path state machine.
+
+use std::path::Path;
+
+use crate::admin::QueryAnalysis;
+use crate::connection::Connection;
+use crate::format::OutputFormat;
+
+use super::engine::{Engine, EngineStartOptions};
+use super::errors::{engine_err, err, Category, Result};
+use super::types::BACKUP_FORMAT_BASELINE;
+
+/// The settings a durable writer cannot leave to chance.
+///
+/// Asynchronous inserts and non-synchronous mutations both mean "the statement
+/// returned before its effect landed", which would put a statement in the WAL
+/// whose local effect is not yet in the database the next checkpoint archives.
+/// The public entry gate refuses statement settings that would relax these,
+/// because core classifies them as `CONTROL`.
+const SYNCHRONOUS_SETTINGS: [&str; 4] = [
+    "--async_insert=0",
+    "--wait_for_async_insert=1",
+    "--mutations_sync=2",
+    "--alter_sync=2",
+];
+
+/// Drives one durable object through a chDB connection.
+#[derive(Debug, Default)]
+pub struct ChdbEngine {
+    /// Extra connection arguments, for a caller that needs to tune the engine
+    /// for its workload. They cannot weaken the synchronous-write settings
+    /// above: those are applied after, and the public surface cannot change
+    /// them either, since `SET` classifies as `CONTROL`.
+    extra_args: Vec<String>,
+    connection: Option<Connection>,
+}
+
+impl ChdbEngine {
+    /// An engine with no extra connection arguments.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// An engine that passes `args` (in `--name=value` form) to every
+    /// connection it opens.
+    pub fn with_args(args: impl IntoIterator<Item = String>) -> Self {
+        Self {
+            extra_args: args.into_iter().collect(),
+            connection: None,
+        }
+    }
+
+    fn borrow(&self) -> Result<&Connection> {
+        self.connection
+            .as_ref()
+            .ok_or_else(|| err(Category::Engine, "durable: the engine is not started"))
+    }
+}
+
+/// Backtick-quotes a ClickHouse identifier, so a database name holding a dash —
+/// or anything else needing quoting — is valid in DDL and cannot break out of
+/// the statement.
+///
+/// This is only for the two statements core has no argument-taking entry point
+/// for, `CREATE DATABASE` and `USE`. Backup and restore take the name as an
+/// argument and quote it themselves, which is why neither appears here.
+fn quote_identifier(name: &str) -> String {
+    format!("`{}`", name.replace('\\', "\\\\").replace('`', "\\`"))
+}
+
+impl Engine for ChdbEngine {
+    fn version(&mut self) -> Result<String> {
+        crate::version::engine_version()
+            .map(str::to_string)
+            .map_err(|e| engine_err(e, "durable: cannot read the engine version"))
+    }
+
+    fn backup_format(&mut self) -> Result<u64> {
+        // The C ABI exposes no accessor for the archive-format generation, so
+        // every release reports the V1 baseline. When core adds one, this is
+        // the single place that changes, and the reader gate starts refusing a
+        // future generation instead of assuming it can restore it.
+        Ok(BACKUP_FORMAT_BASELINE)
+    }
+
+    fn start(&mut self, options: EngineStartOptions) -> Result<()> {
+        if self.connection.is_some() {
+            return Err(err(
+                Category::Engine,
+                "durable: the engine is already started",
+            ));
+        }
+        let data = options
+            .data_path
+            .to_str()
+            .ok_or_else(|| err(Category::Engine, "durable: the scratch path is not UTF-8"))?;
+        let backups = options
+            .backups_allowed_path
+            .to_str()
+            .ok_or_else(|| err(Category::Engine, "durable: the archive path is not UTF-8"))?;
+
+        // `backups.allowed_path` is what makes backup and restore possible at
+        // all: core refuses an archive path outside it, and a connection that
+        // never set it cannot back anything up. Scoping it to this object's own
+        // scratch also means a restore cannot read an archive some other object
+        // left on disk.
+        let owned: Vec<String> = [
+            format!("--path={data}"),
+            format!("--backups.allowed_path={backups}"),
+        ]
+        .into_iter()
+        .chain(SYNCHRONOUS_SETTINGS.iter().map(|s| s.to_string()))
+        .chain(self.extra_args.iter().cloned())
+        .collect();
+        let args: Vec<&str> = owned.iter().map(String::as_str).collect();
+
+        self.connection = Some(Connection::open(&args).map_err(|e| {
+            // chDB binds one data path per process, so a second durable object
+            // in the same process arrives here. The registry's message names
+            // both paths, which is more use than anything this layer could add.
+            engine_err(e, format!("durable: cannot open an engine on {data}"))
+        })?);
+        Ok(())
+    }
+
+    fn create_database(&mut self, database: &str) -> Result<()> {
+        let sql = format!(
+            "CREATE DATABASE IF NOT EXISTS {}",
+            quote_identifier(database)
+        );
+        self.run(&sql)
+    }
+
+    fn use_database(&mut self, database: &str) -> Result<()> {
+        let sql = format!("USE {}", quote_identifier(database));
+        self.run(&sql)
+    }
+
+    fn analyze(&mut self, sql: &str, target_database: &str) -> Result<QueryAnalysis> {
+        self.borrow()?
+            .classify_query(sql, Some(target_database))
+            // The message deliberately does not include the SQL: analysis runs
+            // on statements that may embed a credential, and that is exactly
+            // the case the caller is about to be told about.
+            .map_err(|e| engine_err(e, "durable: the engine could not analyse the statement"))
+    }
+
+    fn query(&mut self, sql: &str, format: OutputFormat) -> Result<Vec<u8>> {
+        let result = self
+            .borrow()?
+            .query(sql, format)
+            .map_err(|e| engine_err(e, "durable: the engine refused a read"))?;
+        Ok(result.data_ref().to_vec())
+    }
+
+    fn run(&mut self, sql: &str) -> Result<()> {
+        self.borrow()?
+            .query(sql, OutputFormat::CSV)
+            .map(|_| ())
+            .map_err(|e| engine_err(e, "durable: the engine refused a statement"))
+    }
+
+    fn backup_database(&mut self, database: &str, file_path: &Path) -> Result<()> {
+        self.borrow()?
+            .backup_database(database, file_path)
+            .map_err(|e| engine_err(e, format!("durable: backing up {database:?} failed")))
+    }
+
+    fn restore_database(&mut self, database: &str, file_path: &Path) -> Result<()> {
+        self.borrow()?
+            .restore_database(database, file_path)
+            .map_err(|e| engine_err(e, format!("durable: restoring {database:?} failed")))
+    }
+
+    fn close(&mut self) -> Result<()> {
+        // Tolerates never having started: an open that fails partway through
+        // still has to release whatever was acquired.
+        drop(self.connection.take());
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn an_identifier_is_quoted_rather_than_interpolated() {
+        assert_eq!(quote_identifier("mem"), "`mem`");
+        assert_eq!(quote_identifier("my-db"), "`my-db`");
+        // The two characters that could end the quoting are escaped, so a name
+        // cannot carry the statement anywhere else.
+        assert_eq!(quote_identifier("we`ird"), "`we\\`ird`");
+        assert_eq!(quote_identifier("back\\slash"), "`back\\\\slash`");
+    }
+
+    #[test]
+    fn an_engine_that_never_started_says_so_rather_than_panicking() {
+        let mut engine = ChdbEngine::new();
+        let error = engine.run("SELECT 1").expect_err("no connection yet");
+        assert_eq!(error.category(), Category::Engine);
+        assert!(
+            engine.close().is_ok(),
+            "closing an unstarted engine is fine"
+        );
+    }
+}

--- a/src/durable/digest.rs
+++ b/src/durable/digest.rs
@@ -1,0 +1,253 @@
+//! Length and SHA-256 verification (contract §4.5).
+//!
+//! Both are checked before a base is restored or a WAL segment is parsed, and
+//! neither is redundant: they fail on different things. A truncated upload has
+//! the right prefix, and a replaced object has the right length.
+//!
+//! Checkpoints are hashed by streaming. A full backup must never have to sit in
+//! memory in one piece just to be measured (§5.1), so the helper here hashes
+//! and counts as it writes, and publishes a downloaded file to its final name
+//! only once both match — a caller never sees a scratch path holding unverified
+//! bytes.
+
+use std::fs::{self, File};
+use std::io::{self, Read, Write};
+use std::path::Path;
+
+use sha2::{Digest as _, Sha256};
+
+use super::errors::{backend_err, err, Category, Error, Result};
+use super::types::ObjectRef;
+
+const CHUNK: usize = 1024 * 1024;
+
+/// The length and content hash of one object.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Digest {
+    /// Length in bytes.
+    pub size: u64,
+    /// The lowercase full hex SHA-256.
+    pub sha256: String,
+}
+
+/// Hashes a buffer.
+pub(crate) fn digest_of(data: &[u8]) -> Digest {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    Digest {
+        size: data.len() as u64,
+        sha256: hex(&hasher.finalize()),
+    }
+}
+
+/// Streams a local file through SHA-256 without holding it in memory.
+pub(crate) fn digest_file(path: &Path) -> io::Result<Digest> {
+    let mut file = File::open(path)?;
+    let mut hasher = Counting::new();
+    io::copy(&mut file, &mut hasher)?;
+    Ok(hasher.finish())
+}
+
+/// Reads `source` to the end and reports what went past, without keeping it.
+///
+/// Used to settle an upload whose response was lost: the question is whether
+/// the bytes at that key are ours, and the answer is a digest.
+pub(crate) fn drain_digest(source: &mut dyn Read) -> io::Result<Digest> {
+    let mut hasher = Counting::new();
+    io::copy(source, &mut hasher)?;
+    Ok(hasher.finish())
+}
+
+/// Refuses an object that is not the one the head describes.
+pub(crate) fn assert_digest(reference: &ObjectRef, observed: &Digest, what: &str) -> Result<()> {
+    if reference.size != observed.size {
+        return Err(err(
+            Category::Corrupt,
+            format!(
+                "durable: {what} ({}) has size {}, head says {}",
+                reference.key, observed.size, reference.size
+            ),
+        ));
+    }
+    if reference.sha256 != observed.sha256 {
+        return Err(err(
+            Category::Corrupt,
+            format!(
+                "durable: {what} ({}) sha256 {} does not match head {}",
+                reference.key, observed.sha256, reference.sha256
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// Writes `source` into `staging`, verifies it against `reference`, then renames
+/// it to `final_path`.
+///
+/// On any mismatch the scratch file is removed and `final_path` is never
+/// created, so a failed verify cannot leave behind something a later step
+/// mistakes for a good archive.
+pub(crate) fn stream_to_verified_file(
+    source: &mut dyn Read,
+    reference: &ObjectRef,
+    staging: &Path,
+    final_path: &Path,
+    what: &str,
+) -> Result<()> {
+    let observed = copy_and_hash(source, staging).map_err(|e| {
+        let _ = fs::remove_file(staging);
+        backend_err(e, format!("durable: downloading {} failed", reference.key))
+    })?;
+
+    if let Err(mismatch) = assert_digest(reference, &observed, what) {
+        let _ = fs::remove_file(staging);
+        return Err(mismatch);
+    }
+
+    fs::rename(staging, final_path).map_err(|e| {
+        let _ = fs::remove_file(staging);
+        backend_err(
+            e,
+            format!("durable: publishing verified {} failed", reference.key),
+        )
+    })
+}
+
+fn copy_and_hash(source: &mut dyn Read, staging: &Path) -> io::Result<Digest> {
+    let mut file = File::options().create_new(true).write(true).open(staging)?;
+    let mut hasher = Counting::new();
+    let mut buffer = vec![0u8; CHUNK];
+    loop {
+        let read = source.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        file.write_all(&buffer[..read])?;
+        hasher.write_all(&buffer[..read])?;
+    }
+    // Flush before the name is published: bytes only in the page cache would
+    // let a crash roll back an archive this call has already reported as good.
+    file.sync_all()?;
+    Ok(hasher.finish())
+}
+
+/// Accumulates length and SHA-256 as bytes flow past.
+struct Counting {
+    hasher: Sha256,
+    size: u64,
+}
+
+impl Counting {
+    fn new() -> Self {
+        Self {
+            hasher: Sha256::new(),
+            size: 0,
+        }
+    }
+
+    fn finish(self) -> Digest {
+        Digest {
+            size: self.size,
+            sha256: hex(&self.hasher.finalize()),
+        }
+    }
+}
+
+impl Write for Counting {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.hasher.update(buf);
+        self.size += buf.len() as u64;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    bytes.iter().fold(String::with_capacity(64), |mut out, b| {
+        let _ = write!(out, "{b:02x}");
+        out
+    })
+}
+
+/// An engine-side failure reading an archive this process just wrote.
+pub(crate) fn engine_io_err(cause: io::Error, message: impl Into<String>) -> Error {
+    Error::wrap(Category::Engine, cause, message)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test_utils::tempdir;
+
+    fn reference(key: &str, digest: &Digest) -> ObjectRef {
+        ObjectRef {
+            key: key.to_string(),
+            size: digest.size,
+            sha256: digest.sha256.clone(),
+        }
+    }
+
+    #[test]
+    fn the_empty_digest_is_the_known_one() {
+        let digest = digest_of(b"");
+        assert_eq!(digest.size, 0);
+        assert_eq!(
+            digest.sha256,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn a_file_and_a_buffer_of_the_same_bytes_agree() {
+        let tmp = tempdir();
+        let path = tmp.path().join("payload");
+        let bytes = vec![7u8; CHUNK + 13];
+        fs::write(&path, &bytes).expect("a scratch file");
+        assert_eq!(digest_file(&path).expect("a digest"), digest_of(&bytes));
+    }
+
+    #[test]
+    fn a_download_that_does_not_verify_publishes_nothing() {
+        let tmp = tempdir();
+        let staging = tmp.path().join("incoming.part");
+        let published = tmp.path().join("base.tar.gz");
+        let expected = reference("checkpoints/1-1-aaaaaaaa.tar.gz", &digest_of(b"the base"));
+
+        let error = stream_to_verified_file(
+            &mut &b"not the base"[..],
+            &expected,
+            &staging,
+            &published,
+            "base checkpoint",
+        )
+        .expect_err("a body that does not match the manifest is corrupt");
+
+        assert_eq!(error.category(), Category::Corrupt);
+        assert!(!published.exists(), "nothing may be published");
+        assert!(!staging.exists(), "the scratch file goes too");
+    }
+
+    #[test]
+    fn a_download_that_verifies_is_published_under_its_final_name() -> Result<()> {
+        let tmp = tempdir();
+        let staging = tmp.path().join("incoming.part");
+        let published = tmp.path().join("base.tar.gz");
+        let expected = reference("checkpoints/1-1-aaaaaaaa.tar.gz", &digest_of(b"the base"));
+
+        stream_to_verified_file(
+            &mut &b"the base"[..],
+            &expected,
+            &staging,
+            &published,
+            "base checkpoint",
+        )?;
+
+        assert_eq!(fs::read(&published).unwrap(), b"the base");
+        assert!(!staging.exists());
+        Ok(())
+    }
+}

--- a/src/durable/digest.rs
+++ b/src/durable/digest.rs
@@ -30,6 +30,17 @@ pub struct Digest {
     pub sha256: String,
 }
 
+impl Digest {
+    /// Measures a buffer.
+    ///
+    /// Public because [`Backend`](super::Backend) is implementable outside this
+    /// crate, and `put_file_if_absent` takes the digest its caller already
+    /// computed — an implementation being tested needs a way to produce one.
+    pub fn of(data: &[u8]) -> Self {
+        digest_of(data)
+    }
+}
+
 /// Hashes a buffer.
 pub(crate) fn digest_of(data: &[u8]) -> Digest {
     let mut hasher = Sha256::new();

--- a/src/durable/engine.rs
+++ b/src/durable/engine.rs
@@ -1,0 +1,322 @@
+//! The engine seam (contract §3), and the two entry gates built on it.
+//!
+//! The durable control plane never touches a native library directly.
+//! Everything it needs from the engine goes through [`Engine`], which is why
+//! the same state machine can drive a real chDB connection or a fake in a unit
+//! test without either knowing about the other.
+//!
+//! Two rules shape the trait, and both are contract requirements rather than
+//! taste:
+//!
+//! 1. **The binding never builds management SQL.** [`Engine::backup_database`]
+//!    and [`Engine::restore_database`] take an identifier and a path; quoting
+//!    and AST construction happen in core. A binding that concatenated
+//!    `"BACKUP DATABASE " + name` would be one unusual database name away from
+//!    injection, in four languages independently.
+//! 2. **The binding never classifies SQL itself.** No prefix lists, no regular
+//!    expressions. [`Engine::analyze`] is ClickHouse's own parser answering
+//!    questions only it can answer — how many executable statements are in this
+//!    text, and does every persistent write land in the database we own. A
+//!    regex cannot see through `INSERT ... FORMAT` inline data, and it cannot
+//!    resolve an unqualified table name against the session's current database.
+//!
+//! [`Engine::backup_database`] deliberately has no incremental-base parameter
+//! even though the C ABI accepts one. V1 checkpoints are always full: an
+//! incremental archive records the *path* of its base, and that path does not
+//! exist on the machine that restores it (§3.2).
+
+use std::path::Path;
+
+use crate::admin::{QueryAnalysis, QueryClass};
+use crate::format::OutputFormat;
+
+use super::errors::{err, Category, Result};
+
+/// Where an engine puts its state for one durable object.
+#[derive(Debug, Clone)]
+pub struct EngineStartOptions {
+    /// A fresh, empty, private data directory for this object.
+    pub data_path: std::path::PathBuf,
+    /// An absolute, already-created directory the engine may read and write
+    /// archives in.
+    pub backups_allowed_path: std::path::PathBuf,
+}
+
+/// What a durable object needs from chDB.
+///
+/// Implementations own their native resources entirely; the control plane only
+/// calls these methods and [`Engine::close`].
+pub trait Engine: Send {
+    /// The exact `chdb_version()` of the loaded engine.
+    ///
+    /// It is recorded in the head as the producer version, and it is not an
+    /// exact-match gate: compatibility is checked with `backup_format` and
+    /// `min_reader`, so later chdb-core releases can restore earlier V1 full
+    /// backups. It must be answerable before [`Engine::start`] — an
+    /// incompatible engine is refused before the object takes a lease or
+    /// creates a scratch directory.
+    fn version(&mut self) -> Result<String>;
+
+    /// The highest archive-format generation this engine can restore.
+    ///
+    /// Every release so far reports the V1 baseline, because the C ABI has no
+    /// accessor for it; once core exposes one, this starts refusing archives
+    /// from a future generation instead of assuming.
+    fn backup_format(&mut self) -> Result<u64>;
+
+    /// Brings up a connection on a fresh scratch path. Called once, before
+    /// anything else.
+    fn start(&mut self, options: EngineStartOptions) -> Result<()>;
+
+    /// Creates the object's database, with core doing the quoting.
+    fn create_database(&mut self, database: &str) -> Result<()>;
+
+    /// Pins the connection's current database. Called once after restore; the
+    /// public surface can never change it, because `USE` classifies as
+    /// [`QueryClass::Control`].
+    fn use_database(&mut self, database: &str) -> Result<()>;
+
+    /// Says what a statement would do, judged against `target_database`,
+    /// without executing it.
+    fn analyze(&mut self, sql: &str, target_database: &str) -> Result<QueryAnalysis>;
+
+    /// Runs a read query and returns its formatted bytes.
+    ///
+    /// Bytes rather than a string, because a caller is free to ask for Parquet
+    /// or Arrow, and a lossy conversion of those is not a result.
+    fn query(&mut self, sql: &str, format: OutputFormat) -> Result<Vec<u8>>;
+
+    /// Runs a statement for effect.
+    ///
+    /// This is the *internal* path: it performs no analysis and appends nothing
+    /// to a WAL. Replay uses it, which is exactly why it must not be reachable
+    /// from the public surface — a replayed statement that re-entered `execute`
+    /// would be logged a second time.
+    fn run(&mut self, sql: &str) -> Result<()>;
+
+    /// Writes a full archive to a new absolute path that must not already
+    /// exist.
+    fn backup_database(&mut self, database: &str, file_path: &Path) -> Result<()>;
+
+    /// Restores an archive into a database that does not already hold its
+    /// tables.
+    fn restore_database(&mut self, database: &str, file_path: &Path) -> Result<()>;
+
+    /// Releases the native connection. Must be safe to call after a failed
+    /// [`Engine::start`].
+    fn close(&mut self) -> Result<()>;
+}
+
+/// Builds the engine for one durable object.
+///
+/// A namespace holds one and calls it per open, so a caller can substitute a
+/// fake for tests or a differently configured connection for a workload.
+pub type EngineFactory = Box<dyn Fn() -> Result<Box<dyn Engine>> + Send + Sync>;
+
+/// Applies the frozen query gate (§3.4).
+///
+/// Note what is *not* here: a secret check. A read-only statement never reaches
+/// the WAL, so a credential inside it is not a durability problem — only a
+/// logging one, which this crate handles by never echoing SQL.
+pub(crate) fn assert_query_allowed(analysis: &QueryAnalysis) -> Result<()> {
+    if analysis.class == QueryClass::Unknown {
+        // First, because text that did not parse also counts zero statements,
+        // and "could not classify" is the useful half of that answer.
+        return Err(err(
+            Category::ClassificationRefused,
+            "durable: core could not classify this statement; refusing rather than running \
+             something whose effect is unknown",
+        ));
+    }
+    if analysis.statement_count != 1 {
+        return Err(err(
+            Category::ClassificationRefused,
+            format!(
+                "durable: query takes exactly one statement, core counted {}",
+                analysis.statement_count
+            ),
+        ));
+    }
+    if analysis.class != QueryClass::ReadOnly {
+        return Err(err(
+            Category::ClassificationRefused,
+            format!(
+                "durable: query accepts only READ_ONLY statements, core classified this as {}",
+                analysis.class
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// Applies the frozen execute gate (§3.4).
+///
+/// The checks are ordered so the message names the most actionable fact first.
+/// The secret check is last and has its own category because it is the one
+/// failure a caller fixes by rewriting the statement rather than by using a
+/// different method — and because its message must describe the refusal without
+/// quoting the statement that triggered it.
+pub(crate) fn assert_execute_allowed(analysis: &QueryAnalysis, database: &str) -> Result<()> {
+    if analysis.class == QueryClass::Unknown {
+        return Err(err(
+            Category::ClassificationRefused,
+            "durable: core could not classify this statement; refusing rather than logging \
+             something whose effect is unknown",
+        ));
+    }
+    if analysis.statement_count != 1 {
+        return Err(err(
+            Category::ClassificationRefused,
+            format!(
+                "durable: execute takes exactly one statement, core counted {}. A WAL record is \
+                 one statement, so a batch has no replayable form in V1",
+                analysis.statement_count
+            ),
+        ));
+    }
+    if analysis.class != QueryClass::Mutating {
+        let mut message = format!(
+            "durable: execute accepts only MUTATING statements, core classified this as {}",
+            analysis.class
+        );
+        match analysis.class {
+            QueryClass::ReadOnly => {
+                message.push_str(". Use query(), which does not write the WAL");
+            }
+            QueryClass::MutatingGlobal => {
+                message.push_str(
+                    ". Global state lives outside every database, so a checkpoint cannot carry \
+                     it and V1 refuses it",
+                );
+            }
+            QueryClass::Control => {
+                message.push_str(
+                    ". USE/SET/SYSTEM/BACKUP/RESTORE, and writes outside the engine, are managed \
+                     by the durable object and cannot be issued through it",
+                );
+            }
+            _ => {}
+        }
+        return Err(err(Category::ClassificationRefused, message));
+    }
+    if analysis.changes_database_lifecycle {
+        return Err(err(
+            Category::ClassificationRefused,
+            format!(
+                "durable: execute cannot create, drop or rename a database; the object owns \
+                 {database:?} and its lifecycle is not a logged mutation"
+            ),
+        ));
+    }
+    if !analysis.writes_only_target_database {
+        return Err(err(
+            Category::ClassificationRefused,
+            format!(
+                "durable: core could not prove every write lands in {database:?}. A write to \
+                 another database, to system, to a table function or to a file is not captured \
+                 by this object's checkpoint"
+            ),
+        ));
+    }
+    if analysis.has_secrets {
+        return Err(err(
+            Category::SecretRefused,
+            "durable: refusing to log a mutation that embeds a credential; the WAL outlives the \
+             statement, so the credential would outlive it too",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn analysis(class: QueryClass) -> QueryAnalysis {
+        QueryAnalysis {
+            class,
+            statement_count: 1,
+            has_secrets: false,
+            writes_only_target_database: true,
+            changes_database_lifecycle: false,
+        }
+    }
+
+    #[test]
+    fn the_query_gate_takes_one_read_only_statement_and_nothing_else() {
+        assert!(assert_query_allowed(&analysis(QueryClass::ReadOnly)).is_ok());
+
+        for class in [
+            QueryClass::Mutating,
+            QueryClass::MutatingGlobal,
+            QueryClass::Control,
+            QueryClass::Unknown,
+        ] {
+            let error = assert_query_allowed(&analysis(class)).expect_err("not a read");
+            assert_eq!(error.category(), Category::ClassificationRefused, "{class}");
+        }
+
+        let mut batch = analysis(QueryClass::ReadOnly);
+        batch.statement_count = 2;
+        assert_eq!(
+            assert_query_allowed(&batch).unwrap_err().category(),
+            Category::ClassificationRefused
+        );
+    }
+
+    #[test]
+    fn the_execute_gate_takes_one_local_mutation_and_nothing_else() {
+        assert!(assert_execute_allowed(&analysis(QueryClass::Mutating), "mem").is_ok());
+
+        for class in [
+            QueryClass::ReadOnly,
+            QueryClass::MutatingGlobal,
+            QueryClass::Control,
+            QueryClass::Unknown,
+        ] {
+            let error = assert_execute_allowed(&analysis(class), "mem").expect_err("not a write");
+            assert_eq!(error.category(), Category::ClassificationRefused, "{class}");
+        }
+    }
+
+    #[test]
+    fn a_write_the_checkpoint_would_not_carry_is_refused() {
+        let mut elsewhere = analysis(QueryClass::Mutating);
+        elsewhere.writes_only_target_database = false;
+        assert_eq!(
+            assert_execute_allowed(&elsewhere, "mem")
+                .unwrap_err()
+                .category(),
+            Category::ClassificationRefused
+        );
+
+        let mut lifecycle = analysis(QueryClass::Mutating);
+        lifecycle.changes_database_lifecycle = true;
+        assert_eq!(
+            assert_execute_allowed(&lifecycle, "mem")
+                .unwrap_err()
+                .category(),
+            Category::ClassificationRefused
+        );
+    }
+
+    #[test]
+    fn a_credential_bearing_mutation_is_refused_without_echoing_it() {
+        let mut secret = analysis(QueryClass::Mutating);
+        secret.has_secrets = true;
+        let error = assert_execute_allowed(&secret, "mem").expect_err("a credential in the WAL");
+        assert_eq!(error.category(), Category::SecretRefused);
+        assert!(
+            !error.to_string().to_lowercase().contains("password"),
+            "the refusal must not quote the statement: {error}"
+        );
+    }
+
+    #[test]
+    fn a_batch_is_refused_before_its_class_is_even_considered() {
+        let mut batch = analysis(QueryClass::Mutating);
+        batch.statement_count = 2;
+        let error = assert_execute_allowed(&batch, "mem").expect_err("a batch has no WAL record");
+        assert!(error.to_string().contains("one statement"), "{error}");
+    }
+}

--- a/src/durable/errors.rs
+++ b/src/durable/errors.rs
@@ -1,0 +1,343 @@
+//! The V1 error model.
+//!
+//! The contract freezes a set of error *categories* (§6) and requires a caller
+//! to be able to tell them apart programmatically. It deliberately does not
+//! freeze type names, so this is one error type carrying a [`Category`] rather
+//! than a tree of types: the category is the wire name a cross-binding
+//! conformance run compares, and the remaining fields carry the specifics a
+//! caller would otherwise have to parse out of a message.
+//!
+//! ```no_run
+//! use chdb_rust::durable::{Category, Namespace};
+//!
+//! # let namespace = Namespace::new("file:///var/lib/chdb-durable")?;
+//! match namespace.open("tenant-1", Default::default()) {
+//!     Ok((object, _existed)) => drop(object),
+//!     Err(e) if e.category() == Category::LeaseHeld => { /* another writer has it */ }
+//!     Err(e) => return Err(e),
+//! }
+//! # Ok::<(), chdb_rust::durable::Error>(())
+//! ```
+//!
+//! Two rules the contract states outright, and this module encodes:
+//!
+//! 1. A provider precondition failure is a compare-and-set race first. It is
+//!    resolved against lease and manifest state into [`Category::LeaseHeld`],
+//!    [`Category::LeaseFenced`] or a retry — never reported as a plain
+//!    [`Category::Backend`], which is for failures that really are the
+//!    provider's: network, auth, quota.
+//! 2. Messages carry no secret-bearing SQL, no credentials and no unredacted
+//!    connection parameters. [`Category::SecretRefused`] in particular says
+//!    what was refused without echoing the statement that caused it.
+
+use std::fmt;
+
+/// A frozen V1 error category.
+///
+/// Cross-binding conformance asserts on the strings [`Category::as_str`]
+/// returns, so they are wire names rather than prose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Category {
+    /// A read-only open of an object that does not exist, or an open that
+    /// required an existing one.
+    NotFound,
+    /// Another writer holds an unexpired lease.
+    LeaseHeld,
+    /// This instance no longer owns the generation it was writing under —
+    /// through a takeover, or through fencing itself after it could not
+    /// confirm its lease in time.
+    LeaseFenced,
+    /// The object's archive format or minimum reader is beyond this engine, or
+    /// it was written by an engine that is not chDB.
+    EngineIncompatible,
+    /// A protocol version above this baseline, or a feature name this build
+    /// does not know.
+    ProtocolUnsupported,
+    /// A head that fails schema validation, or a referenced immutable object
+    /// that is missing or whose length or digest does not match. Never
+    /// downgraded into opening an older state.
+    Corrupt,
+    /// Core analysis refused a statement at a public entry point: wrong
+    /// statement count, wrong class, or a write outside the object's database.
+    ClassificationRefused,
+    /// A mutation embeds a credential. V1 has nowhere to put it other than the
+    /// WAL, which outlives the statement, so it is refused outright.
+    SecretRefused,
+    /// A core query, backup or restore failed.
+    Engine,
+    /// A provider network, auth or non-conditional failure.
+    Backend,
+    /// A deadline passed while the operation was provably still uncommitted.
+    Timeout,
+    /// Reconcile could not prove whether the remote committed. The one thing it
+    /// must never do is report success.
+    CommitAmbiguous,
+    /// SQL, a WAL segment, a head or a provider object over a declared V1 limit.
+    LimitExceeded,
+    /// An operation on an object whose close has completed.
+    Closed,
+}
+
+impl Category {
+    /// The frozen wire name, as the contract's table spells it.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NotFound => "not_found",
+            Self::LeaseHeld => "lease_held",
+            Self::LeaseFenced => "lease_fenced",
+            Self::EngineIncompatible => "engine_incompatible",
+            Self::ProtocolUnsupported => "protocol_unsupported",
+            Self::Corrupt => "corrupt",
+            Self::ClassificationRefused => "classification_refused",
+            Self::SecretRefused => "secret_refused",
+            Self::Engine => "engine",
+            Self::Backend => "backend",
+            Self::Timeout => "timeout",
+            Self::CommitAmbiguous => "commit_ambiguous",
+            Self::LimitExceeded => "limit_exceeded",
+            Self::Closed => "closed",
+        }
+    }
+}
+
+impl fmt::Display for Category {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Every failure the durable control plane reports.
+///
+/// [`Error::category`] is what callers branch on. The other accessors are
+/// populated only where they mean something, so a caller can act on the
+/// specifics without parsing the message.
+#[derive(Debug)]
+pub struct Error {
+    category: Category,
+    message: String,
+    source: Option<Box<dyn std::error::Error + Send + Sync>>,
+    /// Boxed, and absent on most errors: the specifics are read by a handful of
+    /// callers, while every `Result` in this module pays for the size of the
+    /// error variant whether or not it ever holds one.
+    details: Option<Box<Details>>,
+}
+
+#[derive(Debug, Default)]
+struct Details {
+    owner: Option<String>,
+    key: Option<String>,
+    features: Vec<String>,
+    expected: Option<String>,
+    actual: Option<String>,
+    limit: Option<u64>,
+    observed: Option<u64>,
+}
+
+impl Error {
+    /// A new error of one category.
+    ///
+    /// Public because [`Backend`](super::Backend) and [`Engine`](super::Engine)
+    /// are implementable outside this crate, and an implementation has to be
+    /// able to report a failure in the vocabulary the contract freezes. Pick the
+    /// category the contract's §6 table gives for what went wrong — a provider
+    /// failure is [`Category::Backend`], a refused statement is
+    /// [`Category::Engine`] — and leave the lease and commit categories to the
+    /// state machine, which is the only thing that can know them.
+    pub fn new(category: Category, message: impl Into<String>) -> Self {
+        Self {
+            category,
+            message: message.into(),
+            source: None,
+            details: None,
+        }
+    }
+
+    fn details(&mut self) -> &mut Details {
+        self.details.get_or_insert_with(Box::default)
+    }
+
+    /// [`Error::new`] with a cause attached, reachable through
+    /// [`std::error::Error::source`].
+    pub fn wrap(
+        category: Category,
+        cause: impl std::error::Error + Send + Sync + 'static,
+        message: impl Into<String>,
+    ) -> Self {
+        Self::new(category, message).with_source(cause)
+    }
+
+    /// Attaches a cause to an error that does not have one.
+    pub fn with_source(mut self, cause: impl std::error::Error + Send + Sync + 'static) -> Self {
+        self.source = Some(Box::new(cause));
+        self
+    }
+
+    pub(crate) fn with_owner(mut self, owner: impl Into<String>) -> Self {
+        self.details().owner = Some(owner.into());
+        self
+    }
+
+    pub(crate) fn with_key(mut self, key: impl Into<String>) -> Self {
+        self.details().key = Some(key.into());
+        self
+    }
+
+    pub(crate) fn with_features(mut self, features: Vec<String>) -> Self {
+        self.details().features = features;
+        self
+    }
+
+    pub(crate) fn with_bounds(
+        mut self,
+        expected: impl Into<String>,
+        actual: impl Into<String>,
+    ) -> Self {
+        let details = self.details();
+        details.expected = Some(expected.into());
+        details.actual = Some(actual.into());
+        self
+    }
+
+    pub(crate) fn with_limit(mut self, limit: u64, observed: u64) -> Self {
+        let details = self.details();
+        details.limit = Some(limit);
+        details.observed = Some(observed);
+        self
+    }
+
+    /// The frozen V1 category.
+    pub fn category(&self) -> Category {
+        self.category
+    }
+
+    /// The visible name recorded on a lease that blocked this operation.
+    /// Observability only — never an authority check.
+    pub fn owner(&self) -> Option<&str> {
+        self.details.as_ref()?.owner.as_deref()
+    }
+
+    /// The object key whose commit state could not be settled, for triage of a
+    /// [`Category::CommitAmbiguous`].
+    pub fn key(&self) -> Option<&str> {
+        self.details.as_ref()?.key.as_deref()
+    }
+
+    /// The unrecognised protocol feature names that blocked an open, so an
+    /// operator learns which build they need.
+    pub fn features(&self) -> &[String] {
+        self.details.as_ref().map_or(&[], |d| &d.features)
+    }
+
+    /// What the object demands, for a compatibility refusal.
+    pub fn expected(&self) -> Option<&str> {
+        self.details.as_ref()?.expected.as_deref()
+    }
+
+    /// What this process offers, for a compatibility refusal.
+    pub fn actual(&self) -> Option<&str> {
+        self.details.as_ref()?.actual.as_deref()
+    }
+
+    /// The two sides of a limit refusal, in bytes: the limit, and what was
+    /// measured against it.
+    pub fn limit(&self) -> Option<(u64, u64)> {
+        let details = self.details.as_ref()?;
+        details.limit.zip(details.observed)
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.source {
+            Some(cause) => write!(f, "{}: {cause}", self.message),
+            None => f.write_str(&self.message),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source.as_ref().map(|e| e.as_ref() as _)
+    }
+}
+
+/// The durable control plane's result type.
+pub type Result<T> = std::result::Result<T, Error>;
+
+pub(crate) fn err(category: Category, message: impl Into<String>) -> Error {
+    Error::new(category, message)
+}
+
+/// An engine failure, with the crate error underneath.
+///
+/// The message never carries SQL: everything reaching this has been through
+/// analysis, and some of it embeds a credential.
+pub(crate) fn engine_err(cause: crate::error::Error, message: impl Into<String>) -> Error {
+    Error::wrap(Category::Engine, cause, message)
+}
+
+pub(crate) fn backend_err(cause: std::io::Error, message: impl Into<String>) -> Error {
+    Error::wrap(Category::Backend, cause, message)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn every_frozen_category_keeps_its_wire_name() {
+        // The contract's §6 table, verbatim. A rename here is a protocol
+        // change, not a refactor, so it has to fail a test.
+        let names: Vec<&str> = [
+            Category::NotFound,
+            Category::LeaseHeld,
+            Category::LeaseFenced,
+            Category::EngineIncompatible,
+            Category::ProtocolUnsupported,
+            Category::Corrupt,
+            Category::ClassificationRefused,
+            Category::SecretRefused,
+            Category::Engine,
+            Category::Backend,
+            Category::Timeout,
+            Category::CommitAmbiguous,
+            Category::LimitExceeded,
+            Category::Closed,
+        ]
+        .iter()
+        .map(|c| c.as_str())
+        .collect();
+
+        assert_eq!(
+            names,
+            vec![
+                "not_found",
+                "lease_held",
+                "lease_fenced",
+                "engine_incompatible",
+                "protocol_unsupported",
+                "corrupt",
+                "classification_refused",
+                "secret_refused",
+                "engine",
+                "backend",
+                "timeout",
+                "commit_ambiguous",
+                "limit_exceeded",
+                "closed",
+            ]
+        );
+    }
+
+    #[test]
+    fn a_wrapped_cause_shows_in_the_message_and_the_source_chain() {
+        let cause = std::io::Error::other("disk on fire");
+        let error = Error::wrap(Category::Backend, cause, "durable: cannot read head.json");
+        assert_eq!(error.category(), Category::Backend);
+        assert_eq!(
+            error.to_string(),
+            "durable: cannot read head.json: disk on fire"
+        );
+        assert!(std::error::Error::source(&error).is_some());
+    }
+}

--- a/src/durable/head.rs
+++ b/src/durable/head.rs
@@ -1,0 +1,612 @@
+//! `head.json`: strict parsing and unknown-field-preserving write-back
+//! (contract §4.2, §4.3, §4.5).
+//!
+//! The single most important thing this module does is *not* rebuild the head
+//! from scratch on every write. A writer that constructs a fresh document each
+//! time silently deletes every field it does not know about, which turns the
+//! whole named-feature mechanism into a lie: a future revision's state would
+//! survive exactly until an older writer touched the object. So the parsed raw
+//! JSON travels alongside the typed view, and [`serialize_head`] patches the
+//! known fields onto a copy of it.
+//!
+//! The second thing is that "preserve unknown fields" is not "be lenient".
+//! Known fields are validated strictly — a wrong type is corrupt, not a
+//! best-effort coercion — because a head that does not mean what it says is
+//! more dangerous than one that fails to load.
+//!
+//! The lease and the manifest share one document on purpose: taking the lease,
+//! publishing a WAL segment and replacing the base are all one conditional
+//! replace, so a cold open costs a couple of round-trips and there is no window
+//! in which the lease says one thing and the manifest another.
+
+use serde_json::{Map, Number, Value};
+
+use super::errors::{err, Category, Error, Result};
+use super::keys::is_valid_object_key;
+use super::types::{
+    EngineIdentity, Head, Lease, Manifest, ObjectRef, Protocol, BACKUP_FORMAT_BASELINE,
+    MAX_HEAD_BYTES, MAX_SAFE_INTEGER,
+};
+
+/// A head as read from the backend: the typed view, its CAS token, and the raw
+/// JSON kept so unknown fields survive a write-back.
+#[derive(Debug, Clone)]
+pub(crate) struct HeadSnapshot {
+    pub(crate) head: Head,
+    pub(crate) etag: String,
+    pub(crate) raw: Map<String, Value>,
+}
+
+fn corrupt(message: impl AsRef<str>) -> Error {
+    err(
+        Category::Corrupt,
+        format!("durable: head.json {}", message.as_ref()),
+    )
+}
+
+/// Reads a field that must be present.
+///
+/// A plain lookup cannot tell an absent property from an explicit null, and for
+/// this document that distinction carries meaning: a released lease is
+/// *explicitly* three nulls, while a lease missing those keys is a truncated
+/// write. Treating the second as the first hands the object to a new writer on
+/// the strength of a corrupt head.
+fn required<'a>(object: &'a Map<String, Value>, key: &str, where_: &str) -> Result<&'a Value> {
+    object
+        .get(key)
+        .ok_or_else(|| corrupt(format!("{where_} is required")))
+}
+
+fn as_object<'a>(value: &'a Value, where_: &str) -> Result<&'a Map<String, Value>> {
+    value
+        .as_object()
+        .ok_or_else(|| corrupt(format!("{where_} must be an object")))
+}
+
+fn safe_int(value: &Value, where_: &str) -> Result<u64> {
+    value
+        .as_u64()
+        .filter(|n| *n <= MAX_SAFE_INTEGER)
+        .ok_or_else(|| corrupt(format!("{where_} must be a non-negative safe integer")))
+}
+
+fn non_empty_string(value: &Value, where_: &str) -> Result<String> {
+    match value.as_str() {
+        Some(text) if !text.is_empty() => Ok(text.to_string()),
+        _ => Err(corrupt(format!("{where_} must be a non-empty string"))),
+    }
+}
+
+fn string_array(value: &Value, where_: &str) -> Result<Vec<String>> {
+    let items = value
+        .as_array()
+        .ok_or_else(|| corrupt(format!("{where_} must be an array of strings")))?;
+    items
+        .iter()
+        .map(|item| {
+            item.as_str()
+                .map(str::to_string)
+                .ok_or_else(|| corrupt(format!("{where_} must be an array of strings")))
+        })
+        .collect()
+}
+
+fn is_sha256(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+
+fn parse_ref(value: &Value, where_: &str) -> Result<ObjectRef> {
+    let object = as_object(value, where_)?;
+
+    let key = required(object, "key", &format!("{where_}.key"))?;
+    let key = key
+        .as_str()
+        .filter(|key| is_valid_object_key(key))
+        .ok_or_else(|| {
+            corrupt(format!(
+                "{where_}.key is not a valid relative object key: {key}"
+            ))
+        })?;
+
+    let size = safe_int(
+        required(object, "size", &format!("{where_}.size"))?,
+        &format!("{where_}.size"),
+    )?;
+
+    let sha256 = required(object, "sha256", &format!("{where_}.sha256"))?;
+    let sha256 = sha256
+        .as_str()
+        .filter(|digest| is_sha256(digest))
+        .ok_or_else(|| {
+            corrupt(format!(
+                "{where_}.sha256 must be 64 lowercase hex characters"
+            ))
+        })?;
+
+    Ok(ObjectRef {
+        key: key.to_string(),
+        size,
+        sha256: sha256.to_string(),
+    })
+}
+
+/// Reads the negotiation block.
+///
+/// A missing block reads as the V1 baseline with no features, so objects
+/// written before the block existed stay readable; every other shape is
+/// validated strictly. An absent key takes its default, while a key that is
+/// *present* takes its value — including an explicit null, which then fails
+/// validation. The defaults exist for older documents, not as a way to launder
+/// bad data.
+fn parse_protocol(value: Option<&Value>) -> Result<Protocol> {
+    let Some(value) = value else {
+        return Ok(Protocol::default());
+    };
+    let object = as_object(value, "protocol")?;
+    let mut out = Protocol::default();
+    if let Some(version) = object.get("version") {
+        out.version = safe_int(version, "protocol.version")?;
+    }
+    if let Some(features) = object.get("reader_features") {
+        out.reader_features = string_array(features, "protocol.reader_features")?;
+    }
+    if let Some(features) = object.get("writer_features") {
+        out.writer_features = string_array(features, "protocol.writer_features")?;
+    }
+    Ok(out)
+}
+
+/// Reads the engine identity.
+///
+/// The block itself has no default — a head that records no engine cannot
+/// establish compatibility at all, so an absent one is a refusal rather than a
+/// wildcard. The two compatibility fields do have defaults, and both are the
+/// conservative reading of an object written before they existed:
+///
+/// * `backup_format` defaults to the V1 baseline, which is what such an object
+///   necessarily used;
+/// * `min_reader` defaults to `version`, which reproduces the old exact-match
+///   behaviour's lower bound. Defaulting it to something older would
+///   retroactively widen an object's audience on the strength of a field its
+///   writer never wrote.
+fn parse_engine(value: &Value) -> Result<EngineIdentity> {
+    let object = as_object(value, "engine")?;
+    let version = non_empty_string(
+        required(object, "version", "engine.version")?,
+        "engine.version",
+    )?;
+    let name = non_empty_string(required(object, "name", "engine.name")?, "engine.name")?;
+
+    let backup_format = match object.get("backup_format") {
+        Some(value) => safe_int(value, "engine.backup_format")?,
+        None => BACKUP_FORMAT_BASELINE,
+    };
+    let min_reader = match object.get("min_reader") {
+        Some(value) => non_empty_string(value, "engine.min_reader")?,
+        None => version.clone(),
+    };
+
+    Ok(EngineIdentity {
+        name,
+        version,
+        backup_format,
+        min_reader,
+    })
+}
+
+/// Reads the writer lease.
+///
+/// The lease is either fully held or fully released. A partial form — an owner
+/// with no expiry, an expiry with no instance — is rejected rather than
+/// normalised, because each half implies a different answer to "may I take this
+/// over", and guessing is how two writers end up believing they are the one
+/// writer.
+fn parse_lease(value: &Value) -> Result<Lease> {
+    let object = as_object(value, "lease")?;
+    let generation = safe_int(
+        required(object, "generation", "lease.generation")?,
+        "lease.generation",
+    )?;
+    let owner = required(object, "owner", "lease.owner")?;
+    let instance = required(object, "instance", "lease.instance")?;
+    let expires_at = required(object, "expires_at", "lease.expires_at")?;
+
+    if owner.is_null() && instance.is_null() && expires_at.is_null() {
+        return Ok(Lease::released(generation));
+    }
+
+    match (owner.as_str(), instance.as_str(), expires_at.as_f64()) {
+        (Some(owner), Some(instance), Some(expires_at)) if expires_at.is_finite() => Ok(Lease {
+            generation,
+            owner: Some(owner.to_string()),
+            instance: Some(instance.to_string()),
+            expires_at: Some(expires_at),
+        }),
+        (_, _, Some(_)) | (_, _, None) => Err(corrupt(
+            "lease must be either fully released (owner, instance and expires_at all null) or \
+             fully held (owner and instance strings, expires_at a finite number)",
+        )),
+    }
+}
+
+fn parse_manifest(value: &Value) -> Result<Manifest> {
+    let object = as_object(value, "manifest")?;
+    let db = non_empty_string(required(object, "db", "manifest.db")?, "manifest.db")?;
+
+    // base is the only field the protocol allows to be null; the rest are
+    // required and may not be, so an absent or nulled wal is corrupt rather
+    // than an empty replay list.
+    let base = match required(object, "base", "manifest.base")? {
+        Value::Null => None,
+        value => Some(parse_ref(value, "manifest.base")?),
+    };
+
+    let items = required(object, "wal", "manifest.wal")?
+        .as_array()
+        .ok_or_else(|| corrupt("manifest.wal must be an array"))?;
+    let wal = items
+        .iter()
+        .enumerate()
+        .map(|(index, item)| parse_ref(item, &format!("manifest.wal[{index}]")))
+        .collect::<Result<Vec<_>>>()?;
+
+    let seq = safe_int(required(object, "seq", "manifest.seq")?, "manifest.seq")?;
+
+    Ok(Manifest { db, base, wal, seq })
+}
+
+/// Validates head bytes strictly and keeps the raw JSON for round-trip.
+pub(crate) fn parse_head(data: &[u8]) -> Result<(Head, Map<String, Value>)> {
+    let size = data.len() as u64;
+    if size > MAX_HEAD_BYTES {
+        return Err(err(
+            Category::LimitExceeded,
+            format!("durable: head.json is {size} bytes, over the V1 limit of {MAX_HEAD_BYTES}"),
+        )
+        .with_limit(MAX_HEAD_BYTES, size));
+    }
+    // The protocol says UTF-8. Bytes that are not UTF-8 are corrupt rather than
+    // silently repaired: replacing a malformed byte with U+FFFD would let
+    // invalid data inside an *unknown* field parse cleanly and then be written
+    // back mangled.
+    let text = std::str::from_utf8(data).map_err(|e| {
+        Error::wrap(
+            Category::Corrupt,
+            e,
+            "durable: head.json is not valid UTF-8",
+        )
+    })?;
+
+    let raw: Value = serde_json::from_str(text)
+        .map_err(|e| Error::wrap(Category::Corrupt, e, "durable: head.json is not valid JSON"))?;
+    let raw = raw
+        .as_object()
+        .ok_or_else(|| corrupt("must be a JSON object"))?
+        .clone();
+
+    let head = Head {
+        protocol: parse_protocol(raw.get("protocol"))?,
+        engine: parse_engine(required(&raw, "engine", "engine")?)?,
+        lease: parse_lease(required(&raw, "lease", "lease")?)?,
+        manifest: parse_manifest(required(&raw, "manifest", "manifest")?)?,
+    };
+    Ok((head, raw))
+}
+
+/// Patches known fields onto whatever is stored under `key`, so an unrecognised
+/// sibling inside `protocol`, `engine`, `lease` or `manifest` survives.
+fn merge_into(base: &mut Map<String, Value>, key: &str, known: Map<String, Value>) {
+    match base.get_mut(key).and_then(Value::as_object_mut) {
+        Some(existing) => {
+            for (field, value) in known {
+                existing.insert(field, value);
+            }
+        }
+        None => {
+            base.insert(key.to_string(), Value::Object(known));
+        }
+    }
+}
+
+fn ref_to_json(reference: &ObjectRef) -> Value {
+    Value::Object(Map::from_iter([
+        ("key".to_string(), Value::String(reference.key.clone())),
+        ("size".to_string(), Value::Number(reference.size.into())),
+        (
+            "sha256".to_string(),
+            Value::String(reference.sha256.clone()),
+        ),
+    ]))
+}
+
+/// Renders `head`, preserving every unrecognised field of `raw`.
+///
+/// `manifest.base` and `manifest.wal` are replaced wholesale rather than
+/// merged: they are this build's own state, and a stale unknown key inside a
+/// reference being rewritten would describe bytes that are no longer there.
+pub(crate) fn serialize_head(head: &Head, raw: Option<&Map<String, Value>>) -> Result<Vec<u8>> {
+    // Refuse to emit a document this parser would reject. Writing one is worse
+    // than failing here: head.json is created with a conditional create and V1
+    // has no destroy, so an object published with, say, an empty manifest.db is
+    // corrupt on every subsequent open and cannot be removed.
+    for (field, value) in [
+        ("manifest.db", &head.manifest.db),
+        ("engine.name", &head.engine.name),
+        ("engine.version", &head.engine.version),
+        ("engine.min_reader", &head.engine.min_reader),
+    ] {
+        if value.is_empty() {
+            return Err(corrupt(format!("{field} must be a non-empty string")));
+        }
+    }
+
+    let mut base = raw.cloned().unwrap_or_default();
+
+    merge_into(
+        &mut base,
+        "protocol",
+        Map::from_iter([
+            (
+                "version".to_string(),
+                Value::Number(head.protocol.version.into()),
+            ),
+            (
+                "reader_features".to_string(),
+                Value::Array(
+                    head.protocol
+                        .reader_features
+                        .iter()
+                        .cloned()
+                        .map(Value::String)
+                        .collect(),
+                ),
+            ),
+            (
+                "writer_features".to_string(),
+                Value::Array(
+                    head.protocol
+                        .writer_features
+                        .iter()
+                        .cloned()
+                        .map(Value::String)
+                        .collect(),
+                ),
+            ),
+        ]),
+    );
+
+    merge_into(
+        &mut base,
+        "engine",
+        Map::from_iter([
+            ("name".to_string(), Value::String(head.engine.name.clone())),
+            (
+                "version".to_string(),
+                Value::String(head.engine.version.clone()),
+            ),
+            (
+                "backup_format".to_string(),
+                Value::Number(head.engine.backup_format.into()),
+            ),
+            (
+                "min_reader".to_string(),
+                Value::String(head.engine.min_reader.clone()),
+            ),
+        ]),
+    );
+
+    let expires_at = match head.lease.expires_at {
+        Some(seconds) => Value::Number(
+            Number::from_f64(seconds).ok_or_else(|| corrupt("lease.expires_at must be finite"))?,
+        ),
+        None => Value::Null,
+    };
+    merge_into(
+        &mut base,
+        "lease",
+        Map::from_iter([
+            (
+                "generation".to_string(),
+                Value::Number(head.lease.generation.into()),
+            ),
+            (
+                "owner".to_string(),
+                head.lease.owner.clone().map_or(Value::Null, Value::String),
+            ),
+            (
+                "instance".to_string(),
+                head.lease
+                    .instance
+                    .clone()
+                    .map_or(Value::Null, Value::String),
+            ),
+            ("expires_at".to_string(), expires_at),
+        ]),
+    );
+
+    merge_into(
+        &mut base,
+        "manifest",
+        Map::from_iter([
+            ("db".to_string(), Value::String(head.manifest.db.clone())),
+            (
+                "base".to_string(),
+                head.manifest.base.as_ref().map_or(Value::Null, ref_to_json),
+            ),
+            (
+                "wal".to_string(),
+                Value::Array(head.manifest.wal.iter().map(ref_to_json).collect()),
+            ),
+            ("seq".to_string(), Value::Number(head.manifest.seq.into())),
+        ]),
+    );
+
+    let body = serde_json::to_vec(&Value::Object(base))
+        .map_err(|e| Error::wrap(Category::Corrupt, e, "durable: head.json cannot be encoded"))?;
+    let size = body.len() as u64;
+    if size > MAX_HEAD_BYTES {
+        return Err(err(
+            Category::LimitExceeded,
+            format!(
+                "durable: head.json would be {size} bytes, over the V1 limit of {MAX_HEAD_BYTES}; \
+                 checkpoint to truncate the WAL list"
+            ),
+        )
+        .with_limit(MAX_HEAD_BYTES, size));
+    }
+    Ok(body)
+}
+
+/// The head a cold object is created with, held by the creating writer.
+pub(crate) fn cold_head(db: &str, engine_version: &str, backup_format: u64, lease: Lease) -> Head {
+    let mut head = Head::cold(db, engine_version, backup_format);
+    head.lease = lease;
+    head
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::durable::types::PROTOCOL_VERSION;
+
+    const DOCUMENT: &str = r#"{
+      "protocol": {"version": 1, "reader_features": [], "writer_features": []},
+      "engine": {"name": "chdb", "version": "26.7.2-rc.2", "backup_format": 1,
+                 "min_reader": "26.7.2-rc.2"},
+      "lease": {"generation": 3, "owner": "worker-1", "instance": "abc", "expires_at": 1788230400.0},
+      "manifest": {
+        "db": "mem",
+        "base": {"key": "checkpoints/3-8-acde1234.tar.gz", "size": 1048576,
+                 "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"},
+        "wal": [{"key": "wal/3-9-acde5678.jsonl", "size": 127,
+                 "sha256": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}],
+        "seq": 9
+      }
+    }"#;
+
+    #[test]
+    fn the_contracts_example_document_parses_to_what_it_says() -> Result<()> {
+        let (head, _) = parse_head(DOCUMENT.as_bytes())?;
+        assert_eq!(head.protocol.version, PROTOCOL_VERSION);
+        assert_eq!(head.engine.name, "chdb");
+        assert_eq!(head.engine.min_reader, "26.7.2-rc.2");
+        assert_eq!(head.lease.generation, 3);
+        assert_eq!(head.lease.owner.as_deref(), Some("worker-1"));
+        assert_eq!(head.manifest.db, "mem");
+        assert_eq!(head.manifest.seq, 9);
+        assert_eq!(head.manifest.wal.len(), 1);
+        assert_eq!(head.manifest.base.unwrap().size, 1048576);
+        Ok(())
+    }
+
+    #[test]
+    fn a_field_this_build_does_not_know_survives_a_write_back() -> Result<()> {
+        let document = DOCUMENT.replace(
+            r#""seq": 9"#,
+            r#""seq": 9, "compaction": {"generation": 4, "policy": "tiered"}"#,
+        );
+        let document = document.replace(
+            r#""protocol": {"#,
+            r#""tenancy": {"shard": 7}, "protocol": {"#,
+        );
+
+        let (head, raw) = parse_head(document.as_bytes())?;
+        let written = serialize_head(&head, Some(&raw))?;
+        let round_tripped: Value = serde_json::from_slice(&written).unwrap();
+
+        assert_eq!(round_tripped["tenancy"]["shard"], 7);
+        assert_eq!(round_tripped["manifest"]["compaction"]["policy"], "tiered");
+        // And the known fields still say what they said.
+        assert_eq!(round_tripped["manifest"]["seq"], 9);
+        assert_eq!(round_tripped["lease"]["owner"], "worker-1");
+        Ok(())
+    }
+
+    #[test]
+    fn key_order_and_whitespace_are_not_part_of_the_format() -> Result<()> {
+        let compact = r#"{"manifest":{"seq":0,"wal":[],"base":null,"db":"mem"},
+            "lease":{"expires_at":null,"instance":null,"owner":null,"generation":1},
+            "engine":{"min_reader":"26.7.2","backup_format":1,"version":"26.7.2","name":"chdb"},
+            "protocol":{"writer_features":[],"reader_features":[],"version":1}}"#;
+        let (head, _) = parse_head(compact.as_bytes())?;
+        assert_eq!(head.manifest.db, "mem");
+        assert!(!head.lease.is_held());
+        Ok(())
+    }
+
+    #[test]
+    fn a_half_released_lease_is_corrupt_rather_than_guessed_at() {
+        for lease in [
+            r#"{"generation": 1, "owner": "w", "instance": null, "expires_at": null}"#,
+            r#"{"generation": 1, "owner": null, "instance": null, "expires_at": 123.0}"#,
+            r#"{"generation": 1, "owner": "w", "instance": "i"}"#,
+            r#"{"generation": 1, "owner": "w", "instance": "i", "expires_at": "soon"}"#,
+        ] {
+            let document = DOCUMENT.replace(
+                r#""lease": {"generation": 3, "owner": "worker-1", "instance": "abc", "expires_at": 1788230400.0}"#,
+                &format!(r#""lease": {lease}"#),
+            );
+            let error = parse_head(document.as_bytes()).expect_err("a partial lease is corrupt");
+            assert_eq!(error.category(), Category::Corrupt, "{lease}");
+        }
+    }
+
+    #[test]
+    fn a_reference_that_could_leave_the_object_is_corrupt() {
+        let document = DOCUMENT.replace("checkpoints/3-8-acde1234.tar.gz", "../elsewhere.tar.gz");
+        let error = parse_head(document.as_bytes()).expect_err("a traversal is not a key");
+        assert_eq!(error.category(), Category::Corrupt);
+    }
+
+    #[test]
+    fn a_reference_without_its_checksum_is_corrupt() {
+        for broken in [
+            r#"{"key": "wal/1-1-aaaaaaaa.jsonl", "size": 1}"#,
+            r#"{"key": "wal/1-1-aaaaaaaa.jsonl", "sha256": "0123"}"#,
+            r#"{"key": "wal/1-1-aaaaaaaa.jsonl", "size": 1, "sha256": "NOTHEX"}"#,
+            r#"{"key": "wal/1-1-aaaaaaaa.jsonl", "size": -1, "sha256": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}"#,
+        ] {
+            let document = DOCUMENT.replace(
+                r#"{"key": "wal/3-9-acde5678.jsonl", "size": 127,
+                 "sha256": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}"#,
+                broken,
+            );
+            let error = parse_head(document.as_bytes()).expect_err("an unverifiable reference");
+            assert_eq!(error.category(), Category::Corrupt, "{broken}");
+        }
+    }
+
+    #[test]
+    fn a_missing_engine_block_cannot_establish_compatibility() {
+        let document = DOCUMENT.replace(r#""engine":"#, r#""engine_was":"#);
+        let error = parse_head(document.as_bytes()).expect_err("no engine, no gate");
+        assert_eq!(error.category(), Category::Corrupt);
+    }
+
+    #[test]
+    fn an_oversized_head_is_a_limit_rather_than_a_parse_failure() {
+        let padding = "x".repeat(MAX_HEAD_BYTES as usize);
+        let document = format!(r#"{{"pad": "{padding}", "engine": {{}}}}"#);
+        let error = parse_head(document.as_bytes()).expect_err("over the head limit");
+        assert_eq!(error.category(), Category::LimitExceeded);
+    }
+
+    #[test]
+    fn a_document_this_parser_would_reject_is_never_written() {
+        let mut head = Head::cold("mem", "26.7.2", BACKUP_FORMAT_BASELINE);
+        head.manifest.db = String::new();
+        let error = serialize_head(&head, None).expect_err("an empty database name");
+        assert_eq!(error.category(), Category::Corrupt);
+    }
+
+    #[test]
+    fn what_this_build_writes_it_can_read_back() -> Result<()> {
+        let head = Head::cold("mem", "26.7.2", BACKUP_FORMAT_BASELINE);
+        let (round_tripped, _) = parse_head(&serialize_head(&head, None)?)?;
+        assert_eq!(round_tripped, head);
+        Ok(())
+    }
+}

--- a/src/durable/keys.rs
+++ b/src/durable/keys.rs
@@ -1,0 +1,117 @@
+//! Object key construction and validation (contract §4.1).
+//!
+//! Two separate jobs live here, and they are separate on purpose:
+//!
+//! * *Minting* a key for something this writer is about to publish. Every
+//!   attempt gets a fresh key, including a retry of an attempt that may already
+//!   have landed. That is what makes an ambiguous upload resolvable rather than
+//!   destructive: a retry can never overwrite the bytes the first try published
+//!   (§5.8).
+//! * *Validating* a key read out of someone else's head. A reference is a
+//!   relative key inside the object prefix and nothing else. Rejecting `..`,
+//!   absolute paths and empty segments here is what stops a hostile or broken
+//!   head from steering a download outside the object — the local backend
+//!   resolves keys against a directory, so a traversal would be a real escape.
+
+use uuid::Uuid;
+
+use super::errors::{err, Category, Result};
+
+/// The one mutable key in an object.
+pub const HEAD_KEY: &str = "head.json";
+
+/// The first 8 hex digits of a UUID4, per the frozen key shape.
+///
+/// Random rather than a counter because two writers minting the same suffix in
+/// the same generation and sequence would collide on a key that has to be
+/// unique per attempt.
+pub(crate) fn uuid8() -> String {
+    Uuid::new_v4().simple().to_string()[..8].to_string()
+}
+
+/// Mints `checkpoints/<generation>-<seq>-<uuid8>.tar.gz`.
+pub(crate) fn checkpoint_key(generation: u64, seq: u64) -> String {
+    format!("checkpoints/{generation}-{seq}-{}.tar.gz", uuid8())
+}
+
+/// Mints `wal/<generation>-<seq>-<uuid8>.jsonl`.
+pub(crate) fn wal_key(generation: u64, seq: u64) -> String {
+    format!("wal/{generation}-{seq}-{}.jsonl", uuid8())
+}
+
+/// Is this a relative, `/`-separated key with no empty, `.` or `..` segments?
+///
+/// Backslashes are rejected too: on a POSIX filesystem a backslash is an
+/// ordinary character, so a key holding one would name a different file here
+/// than it does on a provider that normalises it — and an object is supposed to
+/// mean the same thing wherever it is opened.
+pub fn is_valid_object_key(key: &str) -> bool {
+    if key.is_empty() || key.starts_with('/') {
+        return false;
+    }
+    if key.contains('\\') || key.contains('\0') {
+        return false;
+    }
+    key.split('/')
+        .all(|segment| !matches!(segment, "" | "." | ".."))
+}
+
+/// An object id must be a single path segment, so it cannot climb out of its
+/// namespace or contain another id's prefix.
+pub(crate) fn validate_object_id(id: &str) -> Result<()> {
+    let bad = id.is_empty()
+        || id.contains('/')
+        || id.contains('\\')
+        || id.contains('\0')
+        || id == "."
+        || id == "..";
+    if bad {
+        return Err(err(
+            Category::Backend,
+            format!("durable: object id must be a single non-empty path segment, got {id:?}"),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn a_minted_key_carries_its_generation_sequence_and_a_fresh_suffix() {
+        let first = wal_key(3, 9);
+        let second = wal_key(3, 9);
+        assert!(first.starts_with("wal/3-9-"), "{first}");
+        assert!(first.ends_with(".jsonl"), "{first}");
+        assert_ne!(first, second, "every attempt has to mint its own key");
+        assert!(checkpoint_key(3, 9).starts_with("checkpoints/3-9-"));
+        assert!(checkpoint_key(3, 9).ends_with(".tar.gz"));
+        assert!(is_valid_object_key(&first));
+    }
+
+    #[test]
+    fn a_key_that_could_leave_the_object_is_not_a_key() {
+        for key in [
+            "",
+            "/checkpoints/1.tar.gz",
+            "../other/head.json",
+            "wal/../../escape",
+            "wal//1.jsonl",
+            "wal/./1.jsonl",
+            "wal\\1.jsonl",
+        ] {
+            assert!(!is_valid_object_key(key), "{key:?} should be refused");
+        }
+        assert!(is_valid_object_key("head.json"));
+        assert!(is_valid_object_key("wal/3-9-acde5678.jsonl"));
+    }
+
+    #[test]
+    fn an_object_id_is_one_segment() {
+        for id in ["", ".", "..", "a/b", "a\\b"] {
+            assert!(validate_object_id(id).is_err(), "{id:?} should be refused");
+        }
+        assert!(validate_object_id("tenant-123").is_ok());
+    }
+}

--- a/src/durable/lease.rs
+++ b/src/durable/lease.rs
@@ -1,0 +1,237 @@
+//! Lease acquisition, cold creation and release (contract §5.2, §5.7).
+//!
+//! These run before an object exists, which is why they are functions rather
+//! than methods: an open that fails while taking the lease has nothing to hang
+//! state on, and the unwind has to work anyway.
+
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use uuid::Uuid;
+
+use super::backend::{Backend, PutOutcome, ReplaceOutcome};
+use super::errors::{err, Category, Result};
+use super::head::{cold_head, parse_head, serialize_head, HeadSnapshot};
+use super::keys::HEAD_KEY;
+use super::negotiate::{assert_engine_compatible, assert_readable, assert_writable, RunningEngine};
+use super::object::Tuning;
+use super::types::Lease;
+
+/// Identifies one live instance of a writer.
+///
+/// The owner name is for humans and may repeat — two replicas of the same
+/// deployment, a restarted process with the same name. The instance is what the
+/// fence compares, so it has to be unique per live handle.
+pub(crate) fn new_instance_id() -> String {
+    Uuid::new_v4().simple().to_string()
+}
+
+/// The current time as epoch seconds, the form a lease records.
+pub(crate) fn now_seconds() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|since| since.as_secs_f64())
+        // A clock before the epoch cannot produce a usable expiry, and treating
+        // it as zero at least makes every lease look long expired rather than
+        // eternally held.
+        .unwrap_or(0.0)
+}
+
+/// Reads and validates the head, if there is one.
+pub(crate) fn read_head(backend: &dyn Backend) -> Result<Option<HeadSnapshot>> {
+    let Some(tagged) = backend.get_bytes_with_etag(HEAD_KEY)? else {
+        return Ok(None);
+    };
+    let (head, raw) = parse_head(&tagged.data)?;
+    Ok(Some(HeadSnapshot {
+        head,
+        etag: tagged.etag,
+        raw,
+    }))
+}
+
+pub(crate) struct LeaseParams<'a> {
+    pub(crate) instance: &'a str,
+    pub(crate) owner: &'a str,
+    pub(crate) tuning: &'a Tuning,
+    pub(crate) force: bool,
+}
+
+pub(crate) struct ColdParams<'a> {
+    pub(crate) id: &'a str,
+    pub(crate) database: &'a str,
+    pub(crate) running: &'a RunningEngine,
+    pub(crate) instance: &'a str,
+    pub(crate) owner: &'a str,
+    pub(crate) tuning: &'a Tuning,
+}
+
+/// Atomically creates a cold object and takes generation 1 in the same write.
+pub(crate) fn create_cold(backend: &dyn Backend, params: ColdParams<'_>) -> Result<HeadSnapshot> {
+    let head = cold_head(
+        params.database,
+        &params.running.version,
+        params.running.backup_format,
+        Lease {
+            generation: 1,
+            owner: Some(params.owner.to_string()),
+            instance: Some(params.instance.to_string()),
+            expires_at: Some(now_seconds() + params.tuning.lease_ttl.as_secs_f64()),
+        },
+    );
+    let outcome = backend.put_bytes_if_absent(HEAD_KEY, &serialize_head(&head, None)?)?;
+
+    // Read back on every path, including success. The ETag of what was created
+    // is what the next commit has to present, and a conditional create does not
+    // always report one.
+    let fresh = read_head(backend)?;
+
+    if outcome == PutOutcome::Created {
+        return fresh.ok_or_else(|| {
+            err(
+                Category::Corrupt,
+                format!(
+                    "durable: created {HEAD_KEY} at {} but it cannot be read back",
+                    backend.describe()
+                ),
+            )
+        });
+    }
+
+    // Lost the race, or the response was lost. Either way the answer is in the
+    // object: if the head that is there names this instance, the create landed.
+    let Some(fresh) = fresh else {
+        return Err(err(
+            Category::CommitAmbiguous,
+            format!(
+                "durable: could not determine whether object {} was created at {}",
+                params.id,
+                backend.describe()
+            ),
+        )
+        .with_key(HEAD_KEY));
+    };
+    if fresh.head.lease.instance_is(params.instance) {
+        return Ok(fresh);
+    }
+
+    // Someone else created it. It is now an existing object, so it goes through
+    // the same gates any existing object would.
+    assert_readable(&fresh.head)?;
+    assert_engine_compatible(&fresh.head, params.running)?;
+    assert_writable(&fresh.head)?;
+    acquire_lease(
+        backend,
+        fresh,
+        LeaseParams {
+            instance: params.instance,
+            owner: params.owner,
+            tuning: params.tuning,
+            force: false,
+        },
+    )
+}
+
+/// Takes the writer lease by compare-and-swap.
+///
+/// An unheld lease is free. A held one is only takeable once its recorded expiry
+/// is behind us by more than the clock-skew allowance — the allowance is there
+/// because the two writers' clocks are not the same clock, and a lease that
+/// looks expired by a second might not be. Taking a lease that has not expired
+/// is possible, but only as an explicit force, never as a retry.
+pub(crate) fn acquire_lease(
+    backend: &dyn Backend,
+    start: HeadSnapshot,
+    params: LeaseParams<'_>,
+) -> Result<HeadSnapshot> {
+    let mut current = start;
+    let deadline = Instant::now() + params.tuning.commit_deadline;
+
+    for attempt in 1.. {
+        let lease = current.head.lease.clone();
+        if lease.is_held() && !params.force {
+            let takeable_at = lease.expires_at.unwrap_or(f64::INFINITY)
+                + params.tuning.clock_skew_allowance.as_secs_f64();
+            if now_seconds() < takeable_at {
+                let owner = lease.owner.clone().unwrap_or_default();
+                return Err(err(
+                    Category::LeaseHeld,
+                    format!(
+                        "durable: {owner:?} holds the writer lease (generation {})",
+                        lease.generation
+                    ),
+                )
+                .with_owner(owner));
+            }
+        }
+
+        let mut candidate = current.head.clone();
+        candidate.lease = Lease {
+            generation: lease.generation + 1,
+            owner: Some(params.owner.to_string()),
+            instance: Some(params.instance.to_string()),
+            expires_at: Some(now_seconds() + params.tuning.lease_ttl.as_secs_f64()),
+        };
+        let body = serialize_head(&candidate, Some(&current.raw))?;
+
+        if let ReplaceOutcome::Done { etag } =
+            backend.replace_if_match(HEAD_KEY, &body, &current.etag)?
+        {
+            return Ok(HeadSnapshot {
+                head: candidate,
+                etag,
+                raw: current.raw,
+            });
+        }
+
+        let fresh = read_head(backend)?.ok_or_else(|| {
+            err(
+                Category::Corrupt,
+                format!(
+                    "durable: {HEAD_KEY} disappeared from {} while taking the lease",
+                    backend.describe()
+                ),
+            )
+        })?;
+        if fresh.head.lease.instance_is(params.instance) {
+            // The write landed and its response was lost.
+            return Ok(fresh);
+        }
+
+        if attempt >= params.tuning.max_commit_attempts || Instant::now() >= deadline {
+            let mut held = err(
+                Category::LeaseHeld,
+                format!(
+                    "durable: could not take the writer lease after {attempt} attempts; \
+                     generation is now {}",
+                    fresh.head.lease.generation
+                ),
+            );
+            if let Some(owner) = fresh.head.lease.owner.clone() {
+                held = held.with_owner(owner);
+            }
+            return Err(held);
+        }
+        current = fresh;
+    }
+    unreachable!("the attempt loop returns from inside")
+}
+
+/// Gives the lease back, best effort, when an open failed part-way through.
+///
+/// A failure after the lease was taken must not strand it until the TTL
+/// expires, but the release has to be conditional on still owning it: a head
+/// that has moved on belongs to someone else, and writing over it would undo
+/// their acquisition.
+pub(crate) fn release_lease(backend: &dyn Backend, instance: &str) -> Result<()> {
+    let Some(fresh) = read_head(backend)? else {
+        return Ok(());
+    };
+    if !fresh.head.lease.instance_is(instance) {
+        return Ok(());
+    }
+    let mut candidate = fresh.head.clone();
+    candidate.lease = Lease::released(fresh.head.lease.generation);
+    let body = serialize_head(&candidate, Some(&fresh.raw))?;
+    backend.replace_if_match(HEAD_KEY, &body, &fresh.etag)?;
+    Ok(())
+}

--- a/src/durable/mod.rs
+++ b/src/durable/mod.rs
@@ -1,0 +1,129 @@
+//! chDB **Durable V1**: a database whose authoritative state lives in storage
+//! you own.
+//!
+//! A durable object is one chDB database whose committed state is a full
+//! checkpoint plus a chain of write-ahead-log segments, published as immutable
+//! objects under a prefix, with one compare-and-set `head.json` naming the
+//! current manifest and holding the writer lease. Local MergeTree is the hot
+//! working copy; the object itself is a folder of open-format files you can
+//! move between machines.
+//!
+//! ```no_run
+//! use chdb_rust::durable::{Namespace, OpenOptions};
+//! use chdb_rust::format::OutputFormat;
+//!
+//! let namespace = Namespace::new("file:///var/lib/chdb-durable")?.with_owner("worker-1");
+//! let (object, existed) = namespace.open("tenant-123", OpenOptions {
+//!     database: Some("mem".to_string()),
+//!     ..OpenOptions::default()
+//! })?;
+//!
+//! if !existed {
+//!     object.execute("CREATE TABLE events (id UInt64, at DateTime) ENGINE = MergeTree ORDER BY id")?;
+//! }
+//! let ticket = object.execute("INSERT INTO events VALUES (1, '2026-09-07 00:00:00')")?;
+//! object.flush_through(ticket)?;        // now it survives losing this machine
+//! let rows = object.query("SELECT count() FROM events", OutputFormat::CSV)?;
+//! object.checkpoint()?;                 // fold base + WAL into a fresh base
+//! object.close()?;
+//! # Ok::<(), chdb_rust::durable::Error>(())
+//! ```
+//!
+//! # What execute guarantees, and what it does not
+//!
+//! [`DurableObject::execute`] means the statement ran locally and joined the WAL
+//! buffer. It does not mean the write left the machine. Durability is
+//! [`DurableObject::flush`], or [`DurableObject::flush_through`] for one
+//! statement's watermark. A service that answers a client before flushing is
+//! choosing to lose that write if the process dies, and it should choose that
+//! knowingly rather than by accident.
+//!
+//! # What the engine decides, and what this module decides
+//!
+//! Whether a statement may run at all is not this module's judgement. Every
+//! [`query`](DurableObject::query) and [`execute`](DurableObject::execute) is
+//! put to ClickHouse's own parser first — how many executable statements is
+//! this, what class are they, does every persistent write land in the database
+//! this object owns, does the text embed a credential — and the answer is the
+//! gate. There is no prefix list and no regular expression anywhere here,
+//! because neither can see through `INSERT ... FORMAT` inline data or resolve an
+//! unqualified table name. Likewise `BACKUP` and `RESTORE` are never assembled
+//! as text: core takes the database name and the path as arguments and does its
+//! own quoting. See [`crate::admin`] for those three entry points.
+//!
+//! That needs chdb-core v26.7.2-rc.2 or later, which is where they were added.
+//!
+//! # Determinism is the caller's job
+//!
+//! Recovery re-executes logged SQL, so a statement must produce the same result
+//! on replay as it did originally. Log literals: compute a timestamp or an id in
+//! the caller and log the value, not `now()`, `rand()`, `generateUUIDv4()`, or
+//! an `INSERT ... SELECT` from a volatile source. V1 promises ordered replay of
+//! the original statement text and nothing more. Non-deterministic or bulk
+//! transformations belong in a [`checkpoint`](DurableObject::checkpoint), which
+//! snapshots actual state.
+//!
+//! # One object per process
+//!
+//! chdb-core binds one data path per process, so one process holds one open
+//! durable object at a time. Opening a second returns an error naming both
+//! paths. Fan-out across many objects is sequential, or spread across worker
+//! processes; this module does not pretend otherwise.
+//!
+//! # Version compatibility
+//!
+//! An object records the exact `chdb_version()` that wrote it, and that is not a
+//! gate. Compatibility is decided by two explicit fields — the archive-format
+//! generation and the minimum reader version — so an object written by
+//! v26.7.2-rc.2 opens on every later chdb-core release that can still restore
+//! its archive.
+//!
+//! # Security scope
+//!
+//! This module provides single-writer *coordination* — the lease plus the
+//! compare-and-set fence — not security. Access control is entirely your
+//! storage's: anyone who can write the object's prefix can read, modify or take
+//! its lease. There is no application-level auth, no client-side encryption, and
+//! no tamper protection beyond the length and SHA-256 checks that detect a
+//! damaged archive. For multi-tenant use, give each tenant credentials scoped to
+//! its own prefix.
+//!
+//! # Where the specification lives
+//!
+//! The protocol is specified in [`CHDB_DURABLE_V1_CONTRACT.md`][contract] in the
+//! chdb repository, and that document — not this implementation — is the source
+//! of truth. Semantics change there first, and the same fixtures are read by the
+//! Python, Node and Go bindings.
+//!
+//! [contract]: https://github.com/chdb-io/chdb/blob/main/dev-docs/CHDB_DURABLE_V1_CONTRACT.md
+
+mod backend;
+mod backends;
+mod chdb_engine;
+mod digest;
+mod engine;
+mod errors;
+mod head;
+mod keys;
+mod lease;
+mod namespace;
+mod negotiate;
+mod object;
+mod types;
+mod version;
+mod wal;
+
+pub use backend::{Backend, PutOutcome, ReplaceOutcome, Tagged};
+pub use backends::LocalBackend;
+pub use chdb_engine::ChdbEngine;
+pub use digest::Digest;
+pub use engine::{Engine, EngineFactory, EngineStartOptions};
+pub use errors::{Category, Error, Result};
+pub use keys::{is_valid_object_key, HEAD_KEY};
+pub use namespace::{BackendFactory, Namespace};
+pub use object::{DurableObject, OpenOptions, Stats, Tuning, WriteTicket};
+pub use types::{
+    EngineIdentity, Head, Lease, Manifest, ObjectRef, Protocol, BACKUP_FORMAT_BASELINE,
+    ENGINE_NAME, MAX_HEAD_BYTES, MAX_SQL_BYTES, MAX_WAL_SEGMENT_BYTES, PROTOCOL_VERSION,
+};
+pub use version::compare_engine_versions;

--- a/src/durable/mod.rs
+++ b/src/durable/mod.rs
@@ -115,6 +115,8 @@ mod wal;
 
 pub use backend::{Backend, PutOutcome, ReplaceOutcome, Tagged};
 pub use backends::LocalBackend;
+#[cfg(feature = "durable-s3")]
+pub use backends::{Credentials, S3Backend, S3Options, MAX_SINGLE_PUT_BYTES};
 pub use chdb_engine::ChdbEngine;
 pub use digest::Digest;
 pub use engine::{Engine, EngineFactory, EngineStartOptions};

--- a/src/durable/namespace.rs
+++ b/src/durable/namespace.rs
@@ -1,0 +1,254 @@
+//! Namespaces: the entry point to the durable control plane.
+//!
+//! A namespace is a location plus an engine factory. The location says where
+//! objects live and which backend implements the conditional operations; the
+//! factory says how to bring up an engine for whichever object is being opened.
+//!
+//! One constraint is not the namespace's to hide: chdb-core binds one data path
+//! per process, so one process holds one open durable object at a time. Opening
+//! a second returns an error naming both paths. Fan-out across objects is
+//! therefore sequential, or spread across worker processes; a registry here
+//! that pretended otherwise would only move the failure somewhere less obvious
+//! (§3.6).
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use super::backend::Backend;
+use super::backends::LocalBackend;
+use super::engine::EngineFactory;
+use super::errors::{err, Category, Result};
+use super::keys::validate_object_id;
+use super::object::{open_object, DurableObject, OpenOptions, Tuning};
+use super::ChdbEngine;
+
+/// Builds a backend for one object, given its id.
+///
+/// A namespace owns one and hands each object its own scoped backend, so no
+/// code below the namespace can address a key outside its object. Supplying one
+/// directly is also how a provider this crate does not ship — an S3-compatible
+/// store, a fault-injecting wrapper — is plugged in.
+pub type BackendFactory = Box<dyn Fn(&str) -> Result<Arc<dyn Backend>> + Send + Sync>;
+
+/// Addresses durable objects on one backend.
+pub struct Namespace {
+    location: String,
+    backend_factory: BackendFactory,
+    engine_factory: EngineFactory,
+    owner: Option<String>,
+    scratch_root: Option<PathBuf>,
+    tuning: Tuning,
+}
+
+impl std::fmt::Debug for Namespace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Namespace")
+            .field("location", &self.location)
+            .field("owner", &self.owner)
+            .finish_non_exhaustive()
+    }
+}
+
+/// The directory a `file://` or `local:` URL names, or a plain absolute path.
+///
+/// A typo in a configuration file fails here rather than at the first open.
+fn local_root(url: &str) -> Result<PathBuf> {
+    let path = url
+        .strip_prefix("file://")
+        .or_else(|| url.strip_prefix("file:"))
+        .or_else(|| url.strip_prefix("local://"))
+        .or_else(|| url.strip_prefix("local:"))
+        .unwrap_or(url);
+    if let Some(scheme_end) = path.find("://") {
+        return Err(err(
+            Category::Backend,
+            format!(
+                "durable: this build has no backend for the {:?} scheme; pass a backend factory \
+                 with Namespace::with_backend for anything but a local directory",
+                &path[..scheme_end]
+            ),
+        ));
+    }
+    let path = Path::new(path);
+    if !path.is_absolute() {
+        return Err(err(
+            Category::Backend,
+            format!("durable: a local namespace needs an absolute path, got {url:?}"),
+        ));
+    }
+    Ok(path.to_path_buf())
+}
+
+impl Namespace {
+    /// Binds a namespace to a local directory.
+    ///
+    /// ```no_run
+    /// use chdb_rust::durable::Namespace;
+    ///
+    /// let namespace = Namespace::new("file:///var/lib/chdb-durable")?;
+    /// # Ok::<(), chdb_rust::durable::Error>(())
+    /// ```
+    ///
+    /// `file:///abs/path`, `local:/abs/path` and a bare `/abs/path` all name a
+    /// directory holding one subdirectory per object. That backend is for
+    /// development, tests and single-host use: recovery on another machine
+    /// needs storage neither machine owns, which is an object store. Point a
+    /// namespace at one with [`Self::with_backend`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Category::Backend`] for a relative path or a scheme this build
+    /// has no backend for.
+    pub fn new(url: &str) -> Result<Self> {
+        let root = local_root(url)?;
+        Ok(Self::with_backend(Box::new(move |id| {
+            Ok(Arc::new(LocalBackend::new(root.join(id))?))
+        }))
+        .named(url))
+    }
+
+    /// Binds a namespace to a backend of your own.
+    ///
+    /// The factory is called once per open with the object id, and must return a
+    /// backend scoped to that object's prefix — nothing below this point checks
+    /// that one object cannot address another's keys.
+    pub fn with_backend(backend_factory: BackendFactory) -> Self {
+        Self {
+            location: "<custom backend>".to_string(),
+            backend_factory,
+            engine_factory: Box::new(|| Ok(Box::new(ChdbEngine::new()))),
+            owner: None,
+            scratch_root: None,
+            tuning: Tuning::default(),
+        }
+    }
+
+    fn named(mut self, location: &str) -> Self {
+        self.location = location.to_string();
+        self
+    }
+
+    /// Uses a different engine for every object this namespace opens.
+    ///
+    /// The default runs the chDB engine this process linked. A test double or a
+    /// connection with extra arguments goes here.
+    pub fn with_engine(mut self, engine_factory: EngineFactory) -> Self {
+        self.engine_factory = engine_factory;
+        self
+    }
+
+    /// The default writer name recorded in the lease of every object this
+    /// namespace opens. Observability only.
+    pub fn with_owner(mut self, owner: impl Into<String>) -> Self {
+        self.owner = Some(owner.into());
+        self
+    }
+
+    /// The default parent directory for scratch trees.
+    pub fn with_scratch_root(mut self, root: impl Into<PathBuf>) -> Self {
+        self.scratch_root = Some(root.into());
+        self
+    }
+
+    /// The default lease and commit parameters for every object this namespace
+    /// opens.
+    ///
+    /// A per-open [`OpenOptions::tuning`] wins, unless it is exactly
+    /// [`Tuning::default`] — which is what an [`OpenOptions`] built with
+    /// `..Default::default()` carries, and means "whatever the namespace says".
+    pub fn with_tuning(mut self, tuning: Tuning) -> Self {
+        self.tuning = tuning;
+        self
+    }
+
+    /// Where this namespace points.
+    pub fn location(&self) -> &str {
+        &self.location
+    }
+
+    /// Opens one object, reporting whether it already existed.
+    ///
+    /// A caller creating a tenant on first use needs to tell "restored" from
+    /// "created" without a separate probe, which is what the flag is for. A
+    /// writer lease is taken unless [`OpenOptions::read_only`] is set.
+    ///
+    /// ```no_run
+    /// use chdb_rust::durable::{Namespace, OpenOptions};
+    /// use chdb_rust::format::OutputFormat;
+    ///
+    /// let namespace = Namespace::new("file:///var/lib/chdb-durable")?.with_owner("worker-1");
+    /// let (object, existed) = namespace.open("tenant-123", OpenOptions {
+    ///     database: Some("mem".to_string()),
+    ///     ..OpenOptions::default()
+    /// })?;
+    ///
+    /// if !existed {
+    ///     object.execute("CREATE TABLE events (id UInt64) ENGINE = MergeTree ORDER BY id")?;
+    /// }
+    /// let ticket = object.execute("INSERT INTO events VALUES (1)")?;
+    /// object.flush_through(ticket)?;   // now it survives losing this machine
+    /// let rows = object.query("SELECT count() FROM events", OutputFormat::CSV)?;
+    /// object.close()?;
+    /// # Ok::<(), chdb_rust::durable::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// An open that fails leaves nothing behind: any lease it took is released,
+    /// the engine is closed and the scratch directory is removed. See
+    /// [`Category`](super::Category) for what the failures mean; the common ones
+    /// are [`Category::NotFound`] for a read-only open of a missing object and
+    /// [`Category::LeaseHeld`] when another writer has it.
+    pub fn open(&self, id: &str, options: OpenOptions) -> Result<(DurableObject, bool)> {
+        validate_object_id(id)?;
+        let backend = (self.backend_factory)(id)?;
+        let options = OpenOptions {
+            owner: options.owner.or_else(|| self.owner.clone()),
+            scratch_root: options.scratch_root.or_else(|| self.scratch_root.clone()),
+            tuning: if options.tuning == Tuning::default() {
+                self.tuning.clone()
+            } else {
+                options.tuning
+            },
+            ..options
+        };
+        open_object(id, backend, &self.engine_factory, options)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn a_local_url_names_a_directory_in_three_spellings() -> Result<()> {
+        assert_eq!(local_root("file:///var/lib/x")?, Path::new("/var/lib/x"));
+        assert_eq!(local_root("local:/var/lib/x")?, Path::new("/var/lib/x"));
+        assert_eq!(local_root("/var/lib/x")?, Path::new("/var/lib/x"));
+        Ok(())
+    }
+
+    #[test]
+    fn a_scheme_this_build_cannot_serve_fails_at_configuration_time() {
+        let error = local_root("s3://bucket/prefix").expect_err("no S3 backend here");
+        assert_eq!(error.category(), Category::Backend);
+        assert!(error.to_string().contains("backend factory"), "{error}");
+    }
+
+    #[test]
+    fn a_relative_root_is_refused() {
+        assert!(local_root("file://relative/path").is_err());
+        assert!(local_root("chdb-durable").is_err());
+    }
+
+    #[test]
+    fn an_object_id_cannot_address_another_objects_prefix() {
+        let namespace = Namespace::new("/tmp/chdb-durable-test").expect("a local namespace");
+        for id in ["", "..", "a/b"] {
+            let error = namespace
+                .open(id, OpenOptions::default())
+                .expect_err("an id that is not one segment");
+            assert_eq!(error.category(), Category::Backend, "{id:?}");
+        }
+    }
+}

--- a/src/durable/namespace.rs
+++ b/src/durable/namespace.rs
@@ -49,10 +49,83 @@ impl std::fmt::Debug for Namespace {
     }
 }
 
+/// The query parameters of a namespace URL, percent-decoded.
+#[cfg(feature = "durable-s3")]
+///
+/// Decoded because an `endpoint` value carries `://`, and a caller that
+/// escaped it — as any URL builder would — should get the same backend as one
+/// who did not.
+fn query_of(url: &str) -> Vec<(String, String)> {
+    let Some((_, query)) = url.split_once('?') else {
+        return Vec::new();
+    };
+    query
+        .split('&')
+        .filter(|pair| !pair.is_empty())
+        .map(|pair| {
+            let (name, value) = pair.split_once('=').unwrap_or((pair, ""));
+            (percent_decode(name), percent_decode(value))
+        })
+        .collect()
+}
+
+#[cfg(feature = "durable-s3")]
+fn percent_decode(value: &str) -> String {
+    let bytes = value.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'%' if index + 2 < bytes.len() => {
+                let hex = std::str::from_utf8(&bytes[index + 1..index + 3]).unwrap_or("");
+                match u8::from_str_radix(hex, 16) {
+                    Ok(byte) => {
+                        out.push(byte);
+                        index += 3;
+                    }
+                    // Not an escape after all: a literal `%` is not an error,
+                    // and mangling it would be worse than passing it through.
+                    Err(_) => {
+                        out.push(b'%');
+                        index += 1;
+                    }
+                }
+            }
+            byte => {
+                out.push(byte);
+                index += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// The bucket and base prefix an `s3://` URL names.
+#[cfg(feature = "durable-s3")]
+fn s3_location(url: &str) -> Result<(String, String)> {
+    let location = url
+        .trim_start_matches("s3://")
+        .split('?')
+        .next()
+        .unwrap_or_default();
+    let (bucket, prefix) = match location.split_once('/') {
+        Some((bucket, prefix)) => (bucket, prefix.trim_matches('/')),
+        None => (location, ""),
+    };
+    if bucket.is_empty() {
+        return Err(err(
+            Category::Backend,
+            format!("durable: an s3 namespace URL needs a bucket, got {url:?}"),
+        ));
+    }
+    Ok((bucket.to_string(), prefix.to_string()))
+}
+
 /// The directory a `file://` or `local:` URL names, or a plain absolute path.
 ///
 /// A typo in a configuration file fails here rather than at the first open.
 fn local_root(url: &str) -> Result<PathBuf> {
+    let url = url.split('?').next().unwrap_or(url);
     let path = url
         .strip_prefix("file://")
         .or_else(|| url.strip_prefix("file:"))
@@ -100,11 +173,78 @@ impl Namespace {
     /// Returns [`Category::Backend`] for a relative path or a scheme this build
     /// has no backend for.
     pub fn new(url: &str) -> Result<Self> {
+        if url.starts_with("s3://") {
+            return Self::s3(url);
+        }
         let root = local_root(url)?;
         Ok(Self::with_backend(Box::new(move |id| {
             Ok(Arc::new(LocalBackend::new(root.join(id))?))
         }))
         .named(url))
+    }
+
+    /// Binds a namespace to an S3-compatible bucket.
+    ///
+    /// ```text
+    /// AWS    s3://my-bucket/durable?region=eu-central-1
+    /// R2     s3://my-bucket/durable?region=auto&endpoint=https://<id>.r2.cloudflarestorage.com
+    /// MinIO  s3://my-bucket/durable?endpoint=http://127.0.0.1:9000
+    /// ```
+    ///
+    /// Credentials are deliberately not among the parameters. They come from
+    /// the environment or the shared credentials file, because a namespace URL
+    /// is the sort of thing that gets logged, put in a config file and pasted
+    /// into an issue. See [`Credentials::resolve`](super::Credentials::resolve)
+    /// for the order, and for what to do with an SSO profile.
+    #[cfg(feature = "durable-s3")]
+    fn s3(url: &str) -> Result<Self> {
+        use super::backends::{S3Backend, S3Options};
+
+        let (bucket, base_prefix) = s3_location(url)?;
+        let query = query_of(url);
+        let value = |name: &str| {
+            query
+                .iter()
+                .find(|(key, _)| key == name)
+                .map(|(_, value)| value.clone())
+                .filter(|value| !value.is_empty())
+        };
+        // `pathStyle` too, because that is what the Go binding's URLs use and
+        // the same configuration string should work in both.
+        let path_style = value("path_style")
+            .or_else(|| value("pathStyle"))
+            .map(|raw| raw == "true" || raw == "1");
+
+        let region = value("region");
+        let endpoint = value("endpoint");
+        Ok(Self::with_backend(Box::new(move |id| {
+            let prefix = if base_prefix.is_empty() {
+                id.to_string()
+            } else {
+                format!("{base_prefix}/{id}")
+            };
+            Ok(Arc::new(S3Backend::new(S3Options {
+                bucket: bucket.clone(),
+                prefix,
+                region: region.clone(),
+                endpoint: endpoint.clone(),
+                path_style,
+                ..S3Options::default()
+            })?))
+        }))
+        .named(url))
+    }
+
+    /// The `s3` scheme needs the `durable-s3` feature, which is what carries
+    /// the HTTP and TLS stack it signs requests with.
+    #[cfg(not(feature = "durable-s3"))]
+    fn s3(url: &str) -> Result<Self> {
+        Err(err(
+            Category::Backend,
+            format!(
+                "durable: {url:?} needs the `durable-s3` feature, which is off in this build;                  enable it, or pass your own backend to Namespace::with_backend"
+            ),
+        ))
     }
 
     /// Binds a namespace to a backend of your own.
@@ -230,9 +370,49 @@ mod test {
 
     #[test]
     fn a_scheme_this_build_cannot_serve_fails_at_configuration_time() {
-        let error = local_root("s3://bucket/prefix").expect_err("no S3 backend here");
+        let error = local_root("gs://bucket/prefix").expect_err("no GCS backend here");
         assert_eq!(error.category(), Category::Backend);
         assert!(error.to_string().contains("backend factory"), "{error}");
+    }
+
+    #[cfg(feature = "durable-s3")]
+    #[test]
+    fn an_s3_url_splits_into_a_bucket_and_a_prefix() {
+        assert_eq!(
+            s3_location("s3://my-bucket/durable/objects?region=eu-central-1").unwrap(),
+            ("my-bucket".to_string(), "durable/objects".to_string())
+        );
+        assert_eq!(
+            s3_location("s3://my-bucket").unwrap(),
+            ("my-bucket".to_string(), String::new()),
+            "a bucket with no prefix is the bucket root"
+        );
+        assert_eq!(
+            s3_location("s3://my-bucket/").unwrap(),
+            ("my-bucket".to_string(), String::new())
+        );
+        assert_eq!(
+            s3_location("s3://").unwrap_err().category(),
+            Category::Backend
+        );
+    }
+
+    #[cfg(feature = "durable-s3")]
+    #[test]
+    fn a_query_value_survives_being_escaped_by_a_url_builder() {
+        let query = query_of("s3://b/p?region=auto&endpoint=https%3A%2F%2Fx.example&pathStyle=1");
+        assert_eq!(query[0], ("region".to_string(), "auto".to_string()));
+        assert_eq!(
+            query[1],
+            ("endpoint".to_string(), "https://x.example".to_string()),
+            "an escaped endpoint has to mean the same as an unescaped one"
+        );
+        assert_eq!(query[2], ("pathStyle".to_string(), "1".to_string()));
+
+        assert!(query_of("s3://b/p").is_empty());
+        // A stray percent is a literal, not a reason to fail a configuration.
+        assert_eq!(percent_decode("100%"), "100%");
+        assert_eq!(percent_decode("a%2Fb"), "a/b");
     }
 
     #[test]

--- a/src/durable/negotiate.rs
+++ b/src/durable/negotiate.rs
@@ -1,0 +1,251 @@
+//! Version and feature negotiation (contract §4.3) and engine identity (§4.2).
+//!
+//! V1 uses named features rather than a monotonic minimum-version number. A
+//! monotonic number requires features to be linearly ordered, and with several
+//! bindings developed in parallel they are not: a client can implement B
+//! without A, and under a version floor it would be locked out of an object
+//! that only ever used B.
+//!
+//! The asymmetry between the two feature lists is the whole point. An unknown
+//! *reader* feature means bytes in this object cannot be interpreted, so the
+//! object does not open at all. An unknown *writer* feature means only that
+//! writing correctly needs something this build cannot do — reading is still
+//! sound, so a read-only open is allowed and only the lease is refused.
+
+use std::cmp::Ordering;
+
+use super::errors::{err, Category, Result};
+use super::types::{
+    Head, ENGINE_NAME, KNOWN_READER_FEATURES, KNOWN_WRITER_FEATURES, PROTOCOL_VERSION,
+};
+use super::version::{compare_engine_versions, max_engine_version};
+
+/// What the engine in this process can offer, for the compatibility gate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RunningEngine {
+    /// `chdb_version()` of the loaded library.
+    pub(crate) version: String,
+    /// The highest archive-format generation it can restore.
+    pub(crate) backup_format: u64,
+}
+
+fn unknown_features(declared: &[String], known: &[&str]) -> Vec<String> {
+    declared
+        .iter()
+        .filter(|feature| !known.contains(&feature.as_str()))
+        .cloned()
+        .collect()
+}
+
+/// Gates a read: refuses a protocol version above this baseline, or any
+/// unrecognised reader feature, naming the offenders so the operator knows
+/// which build they need.
+pub(crate) fn assert_readable(head: &Head) -> Result<()> {
+    if head.protocol.version > PROTOCOL_VERSION {
+        return Err(err(
+            Category::ProtocolUnsupported,
+            format!(
+                "durable: object uses protocol version {}, this build implements {PROTOCOL_VERSION}",
+                head.protocol.version
+            ),
+        ));
+    }
+    let missing = unknown_features(&head.protocol.reader_features, KNOWN_READER_FEATURES);
+    if !missing.is_empty() {
+        return Err(err(
+            Category::ProtocolUnsupported,
+            format!(
+                "durable: object requires reader features this build does not implement: {}",
+                missing.join(", ")
+            ),
+        )
+        .with_features(missing));
+    }
+    Ok(())
+}
+
+/// Gates taking the writer lease. Assumes [`assert_readable`] has already
+/// passed, and only adds the writer-side feature check.
+pub(crate) fn assert_writable(head: &Head) -> Result<()> {
+    let missing = unknown_features(&head.protocol.writer_features, KNOWN_WRITER_FEATURES);
+    if !missing.is_empty() {
+        return Err(err(
+            Category::ProtocolUnsupported,
+            format!(
+                "durable: object requires writer features this build does not implement: {}; \
+                 it can still be opened read-only",
+                missing.join(", ")
+            ),
+        )
+        .with_features(missing));
+    }
+    Ok(())
+}
+
+/// Applies the frozen engine gate:
+///
+/// ```text
+/// backup_format > reader baseline   -> engine_incompatible
+/// running_version < min_reader      -> engine_incompatible
+/// otherwise                         -> open
+/// ```
+///
+/// Note what is deliberately absent: a comparison against `engine.version`.
+/// That field records which build produced the object, for diagnosis, and is
+/// explicitly not a gate. An exact match would refuse every later release,
+/// which is the opposite of what the compatibility promise says — a newer
+/// chdb-core restores full backups made by an earlier one, so an object written
+/// by 26.7.2-rc.2 opens on 26.7.3 and everything after it.
+///
+/// The two checks guard different failures and neither subsumes the other.
+/// `min_reader` catches a reader that is simply too old. `backup_format` is the
+/// escape hatch for the day the promise itself is withdrawn: version numbers
+/// keep increasing whether or not the format still works, so a broken format
+/// needs its own signal, or a reader would compare a larger version, conclude
+/// it is fine, and discover otherwise partway through `RESTORE`.
+pub(crate) fn assert_engine_compatible(head: &Head, running: &RunningEngine) -> Result<()> {
+    if head.engine.name != ENGINE_NAME {
+        return Err(err(
+            Category::EngineIncompatible,
+            format!(
+                "durable: object was written by engine {:?}, not {ENGINE_NAME:?}",
+                head.engine.name
+            ),
+        )
+        .with_bounds(head.engine.name.clone(), ENGINE_NAME));
+    }
+    if head.engine.backup_format > running.backup_format {
+        return Err(err(
+            Category::EngineIncompatible,
+            format!(
+                "durable: object uses archive format generation {}, and this engine restores up \
+                 to {}; a newer chdb-core is required, since the format generation only moves \
+                 when older archives can no longer be restored",
+                head.engine.backup_format, running.backup_format
+            ),
+        )
+        .with_bounds(
+            head.engine.backup_format.to_string(),
+            running.backup_format.to_string(),
+        ));
+    }
+    if compare_engine_versions(&running.version, &head.engine.min_reader)? == Ordering::Less {
+        return Err(err(
+            Category::EngineIncompatible,
+            format!(
+                "durable: object requires chdb {} or later to read, and this process runs {} \
+                 (written by {})",
+                head.engine.min_reader, running.version, head.engine.version
+            ),
+        )
+        .with_bounds(head.engine.min_reader.clone(), running.version.clone()));
+    }
+    Ok(())
+}
+
+/// Records this engine's requirements on a head being written, without ever
+/// relaxing what is already stored.
+///
+/// The protocol says a writer must not lower either requirement. Taking the
+/// maximum rather than overwriting is what enforces that: an object whose base
+/// was produced by a newer engine keeps demanding that engine even if an older
+/// one somehow reaches a write, instead of quietly advertising itself as
+/// readable by a build that cannot restore it.
+pub(crate) fn raise_compatibility_floor(mut head: Head, running: &RunningEngine) -> Result<Head> {
+    head.engine.version = running.version.clone();
+    if running.backup_format > head.engine.backup_format {
+        head.engine.backup_format = running.backup_format;
+    }
+    head.engine.min_reader = max_engine_version(&head.engine.min_reader, &running.version)?;
+    Ok(head)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::durable::types::BACKUP_FORMAT_BASELINE;
+
+    fn running() -> RunningEngine {
+        RunningEngine {
+            version: "26.7.2".to_string(),
+            backup_format: BACKUP_FORMAT_BASELINE,
+        }
+    }
+
+    fn head() -> Head {
+        Head::cold("mem", "26.7.2-rc.2", BACKUP_FORMAT_BASELINE)
+    }
+
+    #[test]
+    fn a_producer_on_an_earlier_release_is_not_a_refusal() {
+        // The whole point of min_reader: 26.7.2 opens what 26.7.2-rc.2 wrote.
+        assert!(assert_engine_compatible(&head(), &running()).is_ok());
+    }
+
+    #[test]
+    fn a_reader_below_min_reader_is_refused() {
+        let mut head = head();
+        head.engine.min_reader = "26.8.0".to_string();
+        let error = assert_engine_compatible(&head, &running()).expect_err("too old to read");
+        assert_eq!(error.category(), Category::EngineIncompatible);
+        assert_eq!(error.expected(), Some("26.8.0"));
+        assert_eq!(error.actual(), Some("26.7.2"));
+    }
+
+    #[test]
+    fn an_archive_generation_beyond_this_engine_is_refused() {
+        let mut head = head();
+        head.engine.backup_format = BACKUP_FORMAT_BASELINE + 1;
+        let error = assert_engine_compatible(&head, &running()).expect_err("format too new");
+        assert_eq!(error.category(), Category::EngineIncompatible);
+    }
+
+    #[test]
+    fn another_engines_object_is_not_ours_to_open() {
+        let mut head = head();
+        head.engine.name = "duckdb".to_string();
+        let error = assert_engine_compatible(&head, &running()).expect_err("not chdb");
+        assert_eq!(error.category(), Category::EngineIncompatible);
+    }
+
+    #[test]
+    fn an_unknown_reader_feature_closes_the_object_and_a_writer_one_only_closes_the_lease() {
+        let mut reader_side = head();
+        reader_side.protocol.reader_features = vec!["parquet-wal".to_string()];
+        let error = assert_readable(&reader_side).expect_err("cannot interpret the bytes");
+        assert_eq!(error.category(), Category::ProtocolUnsupported);
+        assert_eq!(error.features(), ["parquet-wal"]);
+
+        let mut writer_side = head();
+        writer_side.protocol.writer_features = vec!["preamble".to_string()];
+        assert!(assert_readable(&writer_side).is_ok(), "reading stays sound");
+        assert_eq!(
+            assert_writable(&writer_side).unwrap_err().category(),
+            Category::ProtocolUnsupported
+        );
+    }
+
+    #[test]
+    fn a_future_protocol_version_closes_the_object() {
+        let mut head = head();
+        head.protocol.version = PROTOCOL_VERSION + 1;
+        assert_eq!(
+            assert_readable(&head).unwrap_err().category(),
+            Category::ProtocolUnsupported
+        );
+    }
+
+    #[test]
+    fn the_floor_only_ever_rises() {
+        let mut head = head();
+        head.engine.min_reader = "26.9.0".to_string();
+        let raised = raise_compatibility_floor(head, &running()).unwrap();
+        // The running engine is older than the stored floor, so the floor stays
+        // where the newer producer left it.
+        assert_eq!(raised.engine.min_reader, "26.9.0");
+        assert_eq!(
+            raised.engine.version, "26.7.2",
+            "the producer is still recorded"
+        );
+    }
+}

--- a/src/durable/object.rs
+++ b/src/durable/object.rs
@@ -1,0 +1,1558 @@
+//! The Durable V1 object state machine (contract §5).
+//!
+//! Everything the protocol calls hard lives here: lease acquisition and
+//! fencing, the operation queue, WAL publication, checkpoint, and the reconcile
+//! that decides whether a request whose response vanished actually committed.
+//! None of it touches a native library — the engine arrives as an
+//! [`Engine`](super::Engine), the object store as a [`Backend`].
+//!
+//! A few invariants are worth stating up front, because most of the code below
+//! exists to hold one of them:
+//!
+//! * **[`DurableObject::execute`] succeeding does not mean the write is
+//!   durable.** It means the statement ran locally and joined the buffer.
+//!   Durability is [`DurableObject::flush`]. A product that answers a client
+//!   before flushing is choosing to lose that write on a crash, and it should
+//!   choose that knowingly.
+//! * **Nothing is ever reported as committed without proof.** Every commit path
+//!   can end in [`Category::CommitAmbiguous`], which is an honest answer.
+//!   Reporting a lost response as success would be the one failure mode a
+//!   caller cannot defend against.
+//! * **A writer that cannot confirm its lease stops writing.** Not on the next
+//!   error — at the moment its locally believed validity window lapses. The
+//!   alternative is two processes each convinced they are the only writer.
+//! * **Local resources are always released.** A close that fails to flush still
+//!   closes the connection and removes the scratch directory, and still reports
+//!   the failure.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
+use std::sync::{Arc, Condvar, Mutex, MutexGuard};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant, SystemTime};
+
+use serde_json::{Map, Value};
+
+use crate::format::OutputFormat;
+
+use super::backend::{Backend, PutOutcome};
+use super::digest::{
+    assert_digest, digest_file, digest_of, drain_digest, engine_io_err, stream_to_verified_file,
+    Digest,
+};
+use super::engine::{assert_execute_allowed, assert_query_allowed, Engine, EngineStartOptions};
+use super::errors::{backend_err, err, Category, Result};
+use super::head::{parse_head, serialize_head, HeadSnapshot};
+use super::keys::{checkpoint_key, uuid8, wal_key, HEAD_KEY};
+use super::lease::{
+    acquire_lease, create_cold, new_instance_id, now_seconds, read_head, release_lease, ColdParams,
+    LeaseParams,
+};
+use super::negotiate::{
+    assert_engine_compatible, assert_readable, assert_writable, raise_compatibility_floor,
+    RunningEngine,
+};
+use super::types::{Head, Lease, Manifest, ObjectRef, MAX_WAL_SEGMENT_BYTES};
+use super::wal::{assert_statement_within_limit, decode_segment, encode_segment, line_bytes};
+use super::EngineFactory;
+
+/// The lease and commit parameters.
+///
+/// The contract lets a binding choose these but requires the defaults, their
+/// units and their rules to be documented — so they are, here, and the same
+/// values drive the tests.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Tuning {
+    /// How long a lease stays valid after a successful head write. Default 30s.
+    pub lease_ttl: Duration,
+    /// How often the writer renews. Must be at most a third of the TTL, so two
+    /// consecutive heartbeat failures still leave a window to notice and fence.
+    /// Default 10s.
+    pub heartbeat_interval: Duration,
+    /// How far past a recorded expiry another writer waits before treating a
+    /// lease as abandoned. This is a bound on disagreement between two
+    /// machines' clocks, not a grace period for a slow writer. Default 5s.
+    pub clock_skew_allowance: Duration,
+    /// How long a single commit may spend retrying and reconciling. Default 30s.
+    pub commit_deadline: Duration,
+    /// How many attempts a commit makes inside that deadline before giving up.
+    /// Default 5.
+    pub max_commit_attempts: u32,
+}
+
+impl Default for Tuning {
+    fn default() -> Self {
+        Self {
+            lease_ttl: Duration::from_secs(30),
+            heartbeat_interval: Duration::from_secs(10),
+            clock_skew_allowance: Duration::from_secs(5),
+            commit_deadline: Duration::from_secs(30),
+            max_commit_attempts: 5,
+        }
+    }
+}
+
+impl Tuning {
+    fn validate(&self) -> Result<()> {
+        // Every one of these ends up in arithmetic that decides whether this
+        // process still owns the object, so a nonsensical value is refused
+        // rather than propagated into an expiry nobody can take over.
+        for (name, value) in [
+            ("lease_ttl", self.lease_ttl),
+            ("heartbeat_interval", self.heartbeat_interval),
+            ("clock_skew_allowance", self.clock_skew_allowance),
+            ("commit_deadline", self.commit_deadline),
+        ] {
+            if value.is_zero() {
+                return Err(err(
+                    Category::Backend,
+                    format!("durable: Tuning::{name} must be a positive duration"),
+                ));
+            }
+        }
+        if self.max_commit_attempts == 0 {
+            return Err(err(
+                Category::Backend,
+                "durable: Tuning::max_commit_attempts must be positive",
+            ));
+        }
+        if self.heartbeat_interval * 3 > self.lease_ttl {
+            return Err(err(
+                Category::Backend,
+                format!(
+                    "durable: Tuning::heartbeat_interval ({:?}) must be at most a third of \
+                     lease_ttl ({:?}); the contract requires room for a retry before expiry",
+                    self.heartbeat_interval, self.lease_ttl
+                ),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// How one object is opened.
+#[derive(Debug, Clone, Default)]
+pub struct OpenOptions {
+    /// Open without a writer lease. A read-only handle serves the manifest as
+    /// it stood at open.
+    pub read_only: bool,
+    /// Take an unexpired lease from its current holder.
+    ///
+    /// This is an administrator action: the previous writer's unflushed local
+    /// work is lost, and it learns this only when its next commit is fenced.
+    /// Never reach for it as a retry.
+    pub force: bool,
+    /// Refuse to create the object if it does not exist.
+    pub existing_only: bool,
+    /// The visible writer name recorded in the lease. Observability only.
+    /// Defaults to a name derived from the process id.
+    pub owner: Option<String>,
+    /// The database this object holds. Only used when creating a cold object;
+    /// an existing object's head is authoritative. Defaults to `default`.
+    pub database: Option<String>,
+    /// The parent directory for the scratch tree. Defaults to the system
+    /// temporary directory.
+    pub scratch_root: Option<PathBuf>,
+    /// The lease and commit parameters.
+    pub tuning: Tuning,
+}
+
+/// A watermark for one executed statement.
+///
+/// [`DurableObject::flush_through`] turns it into a durability barrier, which is
+/// what lets a caller that expands one request into several statements answer
+/// the request as a whole without the protocol having to know about requests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct WriteTicket {
+    /// The ordinal of the statement within this open session, starting at 1.
+    pub statement: u64,
+}
+
+/// A consistent snapshot of an object's runtime state.
+///
+/// Taken as a whole rather than field by field, so what it reports is
+/// internally consistent: reading a generation and a sequence number through
+/// separate accessors can straddle a commit and describe a state that never
+/// existed.
+///
+/// It carries no credentials and no SQL, so it is safe to log verbatim.
+#[derive(Debug, Clone)]
+pub struct Stats {
+    /// The object's id within its namespace.
+    pub id: String,
+    /// The database this object holds.
+    pub database: String,
+    /// Whether this handle holds a lease.
+    pub read_only: bool,
+    /// `open`, `closing` or `closed`.
+    pub state: &'static str,
+    /// True once this writer has lost, or given up on, its lease.
+    pub fenced: bool,
+    /// The lease generation currently recorded in the head.
+    pub generation: u64,
+    /// The visible writer name.
+    pub owner: String,
+    /// This live instance's id, which is what the fence compares.
+    pub instance: String,
+    /// `manifest.seq` as last committed.
+    pub committed_seq: u64,
+    /// The current base checkpoint, if the object has one.
+    pub base_key: Option<String>,
+    /// How many WAL segments the manifest names.
+    pub wal_segments: usize,
+    /// How many statements this handle has run since it opened.
+    pub executed_statements: u64,
+    /// How many of those are in a committed WAL segment or a committed base.
+    pub committed_statements: u64,
+    /// How many statements have run locally but are not yet published.
+    pub pending_statements: usize,
+    /// The encoded size of those statements, so a caller can apply its own
+    /// backpressure rather than discovering the segment ceiling by hitting it.
+    pub pending_bytes: u64,
+    /// When the last flush committed.
+    pub last_flush_at: Option<SystemTime>,
+    /// When the last checkpoint committed.
+    pub last_checkpoint_at: Option<SystemTime>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Lifecycle {
+    Open,
+    Closing,
+    Closed,
+}
+
+impl Lifecycle {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Closing => "closing",
+            Self::Closed => "closed",
+        }
+    }
+}
+
+/// The object's private directory tree.
+#[derive(Debug, Clone)]
+struct Scratch {
+    root: PathBuf,
+    data: PathBuf,
+    backups: PathBuf,
+    staging: PathBuf,
+}
+
+fn make_scratch(root: Option<&Path>) -> std::io::Result<Scratch> {
+    let parent = root.map_or_else(std::env::temp_dir, Path::to_path_buf);
+    fs::create_dir_all(&parent)?;
+    let base = parent.join(format!("chdb-durable-{}", uuid8()));
+    // A unique, empty directory per open (§5.2 step 4). create_dir refuses an
+    // existing one, so two opens can never share a data path.
+    fs::create_dir(&base)?;
+    let scratch = Scratch {
+        data: base.join("data"),
+        backups: base.join("backups"),
+        staging: base.join("staging"),
+        root: base,
+    };
+    // The engine validates that a backup target's parent directory exists, and
+    // its allowed-path guard resolves a relative value somewhere nobody wants,
+    // so all three are created up front and always absolute.
+    for dir in [&scratch.data, &scratch.backups, &scratch.staging] {
+        if let Err(e) = fs::create_dir_all(dir) {
+            let _ = fs::remove_dir_all(&scratch.root);
+            return Err(e);
+        }
+    }
+    Ok(scratch)
+}
+
+/// Everything that changes while an object is open.
+struct State {
+    head: Head,
+    etag: String,
+    raw: Map<String, Value>,
+    wal_buffer: Vec<String>,
+    wal_buffer_bytes: u64,
+    statement_counter: u64,
+    committed_statements: u64,
+    last_flush_at: Option<SystemTime>,
+    last_checkpoint_at: Option<SystemTime>,
+    lifecycle: Lifecycle,
+    fenced: bool,
+    /// When this writer stops believing its lease. `None` for a read-only open.
+    lease_deadline: Option<Instant>,
+}
+
+/// The shared half of an object: everything the heartbeat thread also touches.
+struct Core {
+    id: String,
+    read_only: bool,
+    backend: Arc<dyn Backend>,
+    engine: Mutex<Box<dyn Engine>>,
+    scratch: Scratch,
+    tuning: Tuning,
+    instance: String,
+    owner: String,
+    running: RunningEngine,
+
+    /// Serializes whole logical operations: execute, query, flush, checkpoint,
+    /// close.
+    ///
+    /// There are two gates rather than one, and the split is the interesting
+    /// part. If one gate covered both, a checkpoint of a large database would
+    /// block the heartbeat for the whole backup and upload, and the writer
+    /// would fence itself out of an object it was legitimately checkpointing.
+    /// With the split, the heartbeat only ever contends for `head_gate`, which
+    /// is held for a single conditional write — while the checkpoint's own
+    /// final commit takes that same gate and therefore sees the ETag the
+    /// heartbeat just produced.
+    ops: Mutex<()>,
+    /// Serializes a single compare-and-swap against `head.json`, including the
+    /// heartbeat's.
+    head_gate: Mutex<()>,
+
+    state: Mutex<State>,
+    stop: (Mutex<bool>, Condvar),
+    heartbeat: Mutex<Option<JoinHandle<()>>>,
+    /// Set once local resources have gone, so `Drop` does not repeat the work.
+    reclaimed: AtomicBool,
+}
+
+/// Locks that survive a poisoned mutex.
+///
+/// A panic while a durable object holds one of these leaves the process with an
+/// engine and a scratch tree to release; refusing to take the lock afterwards
+/// would strand both.
+fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+impl Core {
+    // ---------------------------------------------------------- guards
+
+    /// Refuses an operation on a closed or fenced object.
+    ///
+    /// `Closing` is refused too, so a caller that arrived while close was
+    /// draining the queue does not get to run one more statement against an
+    /// object whose connection is about to go. Close's own flush passes
+    /// `allow_closing`, being the one operation that belongs in that window.
+    fn assert_usable(&self, allow_closing: bool) -> Result<()> {
+        let state = lock(&self.state);
+        let usable = state.lifecycle == Lifecycle::Open
+            || (allow_closing && state.lifecycle == Lifecycle::Closing);
+        if !usable {
+            return Err(err(
+                Category::Closed,
+                format!("durable: object {} is closed", self.id),
+            ));
+        }
+        if state.fenced {
+            return Err(err(
+                Category::LeaseFenced,
+                format!(
+                    "durable: object {} lost its lease (generation {}); this handle cannot be \
+                     used again",
+                    self.id, state.head.lease.generation
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Additionally refuses a read-only handle, and self-fences a writer whose
+    /// lease has lapsed.
+    fn assert_writer(&self, allow_closing: bool) -> Result<()> {
+        self.assert_usable(allow_closing)?;
+        if self.read_only {
+            return Err(err(
+                Category::ClassificationRefused,
+                format!(
+                    "durable: object {} is open read-only; only READ_ONLY statements are accepted",
+                    self.id
+                ),
+            ));
+        }
+        let lapsed = lock(&self.state)
+            .lease_deadline
+            .is_none_or(|deadline| Instant::now() >= deadline);
+        if lapsed {
+            // Self-fence. The lease may in fact still be ours, but we cannot
+            // show that it is, and "probably still the writer" is not a state
+            // to write from.
+            self.fence();
+            return Err(err(
+                Category::LeaseFenced,
+                format!(
+                    "durable: object {} could not confirm its lease before it lapsed; the writer \
+                     has fenced itself",
+                    self.id
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Marks this writer as no longer the writer, and stops renewing.
+    ///
+    /// It signals the heartbeat rather than waiting for it, because a failed
+    /// renewal is one of the ways an object gets fenced — and that runs *on*
+    /// the heartbeat thread, which cannot wait for itself.
+    fn fence(&self) {
+        lock(&self.state).fenced = true;
+        self.signal_stop();
+    }
+
+    fn signal_stop(&self) {
+        let (flag, condvar) = &self.stop;
+        *lock(flag) = true;
+        condvar.notify_all();
+    }
+
+    // ------------------------------------------------------------ restore
+
+    /// Brings the manifest's state into the scratch engine: base, then WAL in
+    /// order.
+    ///
+    /// Both are verified against length and SHA-256 before use, and a missing or
+    /// mismatched object stops the open rather than yielding a partially
+    /// recovered database (§4.5).
+    fn restore(&self) -> Result<()> {
+        let head = lock(&self.state).head.clone();
+        let db = head.manifest.db.clone();
+        let mut engine = lock(&self.engine);
+
+        match &head.manifest.base {
+            None => engine.create_database(&db)?,
+            Some(base) => {
+                let mut reader = self.backend.open_reader(&base.key)?.ok_or_else(|| {
+                    err(
+                        Category::Corrupt,
+                        format!(
+                            "durable: manifest names base {}, which is not present at {}",
+                            base.key,
+                            self.backend.describe()
+                        ),
+                    )
+                })?;
+                let staged = self.scratch.staging.join(format!("base-{}.part", uuid8()));
+                // Keep the archive extension: ClickHouse decides "archive or
+                // directory" from it, so a .tar.gz restored from a path without
+                // one is reported as simply not being a backup.
+                let archive = self
+                    .scratch
+                    .backups
+                    .join(format!("base-{}.tar.gz", uuid8()));
+                stream_to_verified_file(&mut reader, base, &staged, &archive, "base checkpoint")?;
+                drop(reader);
+
+                // A restore is where an incompatible archive actually surfaces.
+                // The gate already established that this engine is allowed to
+                // read the object, so a RESTORE that fails anyway means the
+                // compatibility promise was violated rather than that the
+                // engine hit an ordinary error. The distinction is the caller's
+                // next move: upgrade the engine, or report a core defect.
+                engine.restore_database(&db, &archive).map_err(|cause| {
+                    err(
+                        Category::EngineIncompatible,
+                        format!(
+                            "durable: restoring base {} into {db:?} failed on chdb {}. The \
+                             archive was produced by {} and the object declares min_reader {} at \
+                             archive format {}, so this restore was expected to be supported: \
+                             {cause}",
+                            base.key,
+                            self.running.version,
+                            head.engine.version,
+                            head.engine.min_reader,
+                            head.engine.backup_format
+                        ),
+                    )
+                    .with_bounds(head.engine.version.clone(), self.running.version.clone())
+                })?;
+                let _ = fs::remove_file(&archive);
+            }
+        }
+
+        engine.use_database(&db)?;
+
+        for reference in &head.manifest.wal {
+            let segment = self.backend.get_bytes(&reference.key)?.ok_or_else(|| {
+                err(
+                    Category::Corrupt,
+                    format!(
+                        "durable: manifest names WAL segment {}, which is not present at {}",
+                        reference.key,
+                        self.backend.describe()
+                    ),
+                )
+            })?;
+            assert_digest(reference, &digest_of(&segment), "WAL segment")?;
+            for sql in decode_segment(&segment, &reference.key)? {
+                // Replay goes straight to the engine. Routing it back through
+                // the public execute would re-analyse statements core already
+                // accepted and, worse, append every one of them to the WAL a
+                // second time.
+                engine.run(&sql)?;
+            }
+        }
+        Ok(())
+    }
+
+    // ------------------------------------------------------ read and write
+
+    fn query(&self, sql: &str, format: OutputFormat) -> Result<Vec<u8>> {
+        let _ops = lock(&self.ops);
+        // A fenced writer may still read: the local database is exactly what
+        // this instance restored and wrote, and §5.7 fences writes, not reads.
+        // So this is the lifecycle check on its own, not assert_usable.
+        if lock(&self.state).lifecycle != Lifecycle::Open {
+            return Err(err(
+                Category::Closed,
+                format!("durable: object {} is closed", self.id),
+            ));
+        }
+        let database = self.database();
+        let mut engine = lock(&self.engine);
+        let analysis = engine.analyze(sql, &database)?;
+        assert_query_allowed(&analysis)?;
+        engine.query(sql, format)
+    }
+
+    fn execute(&self, sql: &str) -> Result<WriteTicket> {
+        let _ops = lock(&self.ops);
+        self.assert_writer(false)?;
+        let database = self.database();
+
+        let analysis = lock(&self.engine).analyze(sql, &database)?;
+        assert_execute_allowed(&analysis, &database)?;
+
+        // Both limits are checked here rather than at flush, and before the
+        // statement runs rather than after.
+        //
+        // The ordering is the point. A statement that has executed cannot be
+        // un-executed, so a buffer that has grown past what a segment can hold
+        // can no longer be flushed at all — every flush would fail encoding
+        // while the local database has already moved on. Checkpoint can still
+        // rescue it, since it archives the database rather than the buffer, but
+        // a caller has to know that, and nothing would have warned it. Worse,
+        // that state is reachable from a single transient failure: a flush that
+        // fails leaves the buffer intact by design, and a caller that keeps
+        // writing walks straight into it.
+        assert_statement_within_limit(sql)?;
+        let line = line_bytes(sql);
+        let projected = lock(&self.state).wal_buffer_bytes + line;
+        if projected > MAX_WAL_SEGMENT_BYTES {
+            return Err(err(
+                Category::LimitExceeded,
+                format!(
+                    "durable: this statement would take the unflushed buffer to {projected} \
+                     bytes, over the {MAX_WAL_SEGMENT_BYTES}-byte WAL segment limit; flush or \
+                     checkpoint first"
+                ),
+            )
+            .with_limit(MAX_WAL_SEGMENT_BYTES, projected));
+        }
+
+        lock(&self.engine).run(sql)?;
+
+        let mut state = lock(&self.state);
+        state.wal_buffer.push(sql.to_string());
+        state.wal_buffer_bytes += line;
+        state.statement_counter += 1;
+        Ok(WriteTicket {
+            statement: state.statement_counter,
+        })
+    }
+
+    fn flush(&self) -> Result<Option<ObjectRef>> {
+        let _ops = lock(&self.ops);
+        self.flush_locked(false)
+    }
+
+    fn flush_through(&self, ticket: WriteTicket) -> Result<()> {
+        if ticket.statement <= lock(&self.state).committed_statements {
+            return Ok(());
+        }
+        let _ops = lock(&self.ops);
+        // Checked again inside the queue: the flush that covers this ticket may
+        // be the one that just finished ahead of us, which is what makes
+        // concurrent callers coalesce onto a single head write.
+        if ticket.statement <= lock(&self.state).committed_statements {
+            return Ok(());
+        }
+        self.flush_locked(false).map(|_| ())
+    }
+
+    /// Publishes the buffered statements as one immutable WAL segment and
+    /// commits the reference. Assumes the operation gate is held.
+    fn flush_locked(&self, closing: bool) -> Result<Option<ObjectRef>> {
+        self.assert_writer(closing)?;
+
+        let (statements, generation, next_seq) = {
+            let state = lock(&self.state);
+            (
+                state.wal_buffer.clone(),
+                state.head.lease.generation,
+                state.head.manifest.seq + 1,
+            )
+        };
+        if statements.is_empty() {
+            return Ok(None);
+        }
+
+        let data = encode_segment(&statements)?;
+        let digest = digest_of(&data);
+        let reference = ObjectRef {
+            key: wal_key(generation, next_seq),
+            size: digest.size,
+            sha256: digest.sha256,
+        };
+
+        self.publish_bytes(&reference, &data)?;
+        // The upload is I/O and can outlast the lease. Checking only at entry
+        // would let a writer that was required to self-fence mid-upload go on
+        // to commit the manifest anyway.
+        self.assert_writer(closing)?;
+
+        let published = reference.clone();
+        self.commit_head(
+            &reference.key,
+            |current| {
+                let mut next = current.clone();
+                next.manifest.wal.push(published.clone());
+                next.manifest.seq = current.manifest.seq + 1;
+                next
+            },
+            |observed| observed.manifest.wal.iter().any(|w| w.key == reference.key),
+            false,
+        )?;
+
+        let mut state = lock(&self.state);
+        state.wal_buffer.drain(..statements.len());
+        state.wal_buffer_bytes = state.wal_buffer.iter().map(|sql| line_bytes(sql)).sum();
+        state.committed_statements += statements.len() as u64;
+        state.last_flush_at = Some(SystemTime::now());
+        Ok(Some(reference))
+    }
+
+    fn checkpoint(&self) -> Result<ObjectRef> {
+        let _ops = lock(&self.ops);
+        self.checkpoint_locked()
+    }
+
+    /// Replaces the base with a full backup of the current local database and
+    /// clears the WAL list. Assumes the operation gate is held.
+    ///
+    /// V1 has no garbage collection, by design — it also has no destroy, so
+    /// nothing here may delete. A superseded base, the folded WAL segments and
+    /// any orphans left by an indeterminate commit all stay in object storage;
+    /// only the current base and live WAL are referenced.
+    fn checkpoint_locked(&self) -> Result<ObjectRef> {
+        self.assert_writer(false)?;
+
+        let (database, generation, next_seq) = {
+            let state = lock(&self.state);
+            (
+                state.head.manifest.db.clone(),
+                state.head.lease.generation,
+                state.head.manifest.seq + 1,
+            )
+        };
+
+        let archive = self
+            .scratch
+            .backups
+            .join(format!("checkpoint-{}.tar.gz", uuid8()));
+        // Core builds the BACKUP statement and quotes both the database and the
+        // path itself (§3.2) — no SQL is assembled here.
+        lock(&self.engine)
+            .backup_database(&database, &archive)
+            .inspect_err(|_| {
+                let _ = fs::remove_file(&archive);
+            })?;
+
+        let outcome = self.publish_checkpoint(&archive, generation, next_seq);
+        let _ = fs::remove_file(&archive);
+        let reference = outcome?;
+
+        // A full backup plus its upload is the longest thing this object does,
+        // easily longer than a lease TTL. Ownership was checked before it
+        // started; it has to hold now, when the commit actually happens.
+        self.assert_writer(false)?;
+
+        let covered = lock(&self.state).wal_buffer.len();
+        let published = reference.clone();
+        self.commit_head(
+            &reference.key,
+            |current| {
+                let mut next = current.clone();
+                next.manifest.base = Some(published.clone());
+                next.manifest.wal = Vec::new();
+                next.manifest.seq = current.manifest.seq + 1;
+                next
+            },
+            |observed| {
+                observed
+                    .manifest
+                    .base
+                    .as_ref()
+                    .is_some_and(|base| base.key == reference.key)
+            },
+            false,
+        )?;
+
+        // Only now. Until the head names this base, the old base plus the old
+        // WAL is still the authoritative state, and these statements are only
+        // recoverable from the buffer.
+        let mut state = lock(&self.state);
+        state.wal_buffer.drain(..covered);
+        state.wal_buffer_bytes = state.wal_buffer.iter().map(|sql| line_bytes(sql)).sum();
+        state.committed_statements += covered as u64;
+        state.last_checkpoint_at = Some(SystemTime::now());
+        Ok(reference)
+    }
+
+    fn publish_checkpoint(
+        &self,
+        archive: &Path,
+        generation: u64,
+        next_seq: u64,
+    ) -> Result<ObjectRef> {
+        let digest = digest_file(archive)
+            .map_err(|e| engine_io_err(e, "durable: cannot read the archive just written"))?;
+        let reference = ObjectRef {
+            key: checkpoint_key(generation, next_seq),
+            size: digest.size,
+            sha256: digest.sha256.clone(),
+        };
+        self.publish_file(&reference, archive, &digest)?;
+        Ok(reference)
+    }
+
+    // -------------------------------------------------- immutable publish
+
+    fn publish_bytes(&self, reference: &ObjectRef, data: &[u8]) -> Result<()> {
+        match self.backend.put_bytes_if_absent(&reference.key, data)? {
+            PutOutcome::Created => Ok(()),
+            outcome => self.reconcile_upload(reference, outcome),
+        }
+    }
+
+    fn publish_file(&self, reference: &ObjectRef, local: &Path, digest: &Digest) -> Result<()> {
+        match self
+            .backend
+            .put_file_if_absent(&reference.key, local, digest)?
+        {
+            PutOutcome::Created => Ok(()),
+            outcome => self.reconcile_upload(reference, outcome),
+        }
+    }
+
+    /// Settles an upload that did not cleanly create (§5.8).
+    ///
+    /// The key is unique to this attempt, so "already exists" can only mean an
+    /// earlier try by this same writer landed. Re-reading and comparing the
+    /// digest is what turns a lost response into a fact: matching bytes are the
+    /// bytes we meant to publish, different bytes are corruption, and an absent
+    /// object means the write genuinely did not happen.
+    fn reconcile_upload(&self, reference: &ObjectRef, outcome: PutOutcome) -> Result<()> {
+        let Some(mut reader) = self.backend.open_reader(&reference.key)? else {
+            if outcome == PutOutcome::AlreadyExists {
+                return Err(err(
+                    Category::Corrupt,
+                    format!(
+                        "durable: {} was reported as existing but cannot be read from {}",
+                        reference.key,
+                        self.backend.describe()
+                    ),
+                ));
+            }
+            return Err(err(
+                Category::CommitAmbiguous,
+                format!(
+                    "durable: could not determine whether {} was uploaded to {}",
+                    reference.key,
+                    self.backend.describe()
+                ),
+            )
+            .with_key(reference.key.clone()));
+        };
+        let observed = drain_digest(&mut reader)
+            .map_err(|e| backend_err(e, format!("durable: cannot re-read {}", reference.key)))?;
+        assert_digest(reference, &observed, "published object")
+    }
+
+    // ------------------------------------------------------- head commit
+
+    /// The single path through which this object writes `head.json`.
+    ///
+    /// Every caller supplies two things: how to build the next head, and how to
+    /// recognise its own intent in a head it did not write. The second is what
+    /// makes a lost response recoverable — after re-reading, either the intent
+    /// is visible and this committed, or ownership is gone and this is fenced,
+    /// or neither is true and it can try again inside the deadline.
+    ///
+    /// `skip_ownership_after` allows a commit to be recognised as landed even
+    /// though this instance no longer owns the lease. Only lease release sets
+    /// it, because success there *is* the loss of ownership.
+    fn commit_head(
+        &self,
+        key: &str,
+        build: impl Fn(&Head) -> Head,
+        committed: impl Fn(&Head) -> bool,
+        skip_ownership_after: bool,
+    ) -> Result<()> {
+        let _gate = lock(&self.head_gate);
+        let deadline = Instant::now() + self.tuning.commit_deadline;
+        let mut saw_ambiguous = false;
+
+        for attempt in 1.. {
+            let (current, etag, raw, generation) = {
+                let state = lock(&self.state);
+                (
+                    state.head.clone(),
+                    state.etag.clone(),
+                    state.raw.clone(),
+                    state.head.lease.generation,
+                )
+            };
+
+            let candidate = raise_compatibility_floor(build(&current), &self.running)?;
+            let body = serialize_head(&candidate, Some(&raw))?;
+
+            match self.backend.replace_if_match(HEAD_KEY, &body, &etag)? {
+                super::backend::ReplaceOutcome::Done { etag } => {
+                    self.adopt(candidate, etag, None);
+                    return Ok(());
+                }
+                super::backend::ReplaceOutcome::Ambiguous => saw_ambiguous = true,
+                super::backend::ReplaceOutcome::NotMatched => {}
+            }
+
+            // Either someone else wrote, or the answer was lost. Both are
+            // settled the same way: look at what is actually there.
+            let fresh = read_head(&*self.backend)?.ok_or_else(|| {
+                err(
+                    Category::Corrupt,
+                    format!(
+                        "durable: {HEAD_KEY} disappeared from {} while committing",
+                        self.backend.describe()
+                    ),
+                )
+            })?;
+
+            let still_ours = fresh.head.lease.instance_is(&self.instance)
+                && fresh.head.lease.generation == generation;
+
+            if committed(&fresh.head) && (still_ours || skip_ownership_after) {
+                self.adopt(fresh.head, fresh.etag, Some(fresh.raw));
+                return Ok(());
+            }
+            if !still_ours {
+                self.fence();
+                return Err(err(
+                    Category::LeaseFenced,
+                    format!(
+                        "durable: object {} was taken over (generation {}); this writer can no \
+                         longer commit",
+                        self.id, fresh.head.lease.generation
+                    ),
+                ));
+            }
+
+            // Ownership intact and the intent is not there: our ETag was stale.
+            // Adopt the current one and retry within the deadline.
+            self.adopt(fresh.head, fresh.etag, Some(fresh.raw));
+
+            if attempt >= self.tuning.max_commit_attempts || Instant::now() >= deadline {
+                // Two different answers, and the caller acts on them
+                // differently. If every attempt came back as a definite
+                // refusal, the commit provably did not happen and retrying
+                // later is safe. If any attempt was ambiguous, it may have
+                // landed, and a blind retry could publish twice.
+                if saw_ambiguous {
+                    return Err(err(
+                        Category::CommitAmbiguous,
+                        format!(
+                            "durable: gave up committing {key} after {attempt} attempts without \
+                             proving the outcome"
+                        ),
+                    )
+                    .with_key(key.to_string()));
+                }
+                return Err(err(
+                    Category::Timeout,
+                    format!(
+                        "durable: could not commit {key} within {:?} ({attempt} attempts, each \
+                         definitively refused); nothing was committed",
+                        self.tuning.commit_deadline
+                    ),
+                ));
+            }
+        }
+        unreachable!("the attempt loop returns from inside")
+    }
+
+    /// Records a head as the committed one.
+    ///
+    /// When `raw` is `None` the candidate was this build's own construction, so
+    /// the raw document is re-derived from it — the same merge that produced the
+    /// bytes just written, which keeps the unknown fields that went out with
+    /// them.
+    fn adopt(&self, head: Head, etag: String, raw: Option<Map<String, Value>>) {
+        let mut state = lock(&self.state);
+        let raw = raw.or_else(|| {
+            // Neither step can fail here: these are the inputs serialize_head
+            // accepted a moment ago, and its output is what parse_head
+            // validates. If one somehow did, keeping the previous raw is
+            // harmless rather than lossy — every known field is patched from
+            // the typed head on the next write.
+            serialize_head(&head, Some(&state.raw))
+                .ok()
+                .and_then(|body| parse_head(&body).ok())
+                .map(|(_, parsed)| parsed)
+        });
+        if let Some(raw) = raw {
+            state.raw = raw;
+        }
+        if !self.read_only {
+            // The stored expiry is authoritative, including when a commit
+            // reconciled onto a head written by an earlier attempt whose expiry
+            // is older than this one's. A released lease leaves the deadline
+            // alone; release_lease_locked clears it explicitly.
+            if let Some(deadline) = lease_deadline_from(&head.lease, self.tuning.lease_ttl) {
+                state.lease_deadline = Some(deadline);
+            }
+        }
+        state.head = head;
+        state.etag = etag;
+    }
+
+    // ------------------------------------------------------------- lease
+
+    /// Extends the expiry, leaving generation and seq untouched.
+    fn renew_lease(&self) -> Result<()> {
+        {
+            let state = lock(&self.state);
+            if self.read_only || state.fenced || state.lifecycle == Lifecycle::Closed {
+                return Ok(());
+            }
+        }
+        let owner = self.owner.clone();
+        let instance = self.instance.clone();
+        let ttl = self.tuning.lease_ttl.as_secs_f64();
+
+        self.commit_head(
+            HEAD_KEY,
+            move |current| {
+                // The expiry is computed inside the commit, not before waiting
+                // for the head gate. Computed early and then delayed behind a
+                // long checkpoint commit, the value written could already be in
+                // the past — while the local deadline was refreshed from the
+                // current clock. The object would then keep writing under a
+                // lease other writers are entitled to take.
+                let mut next = current.clone();
+                next.lease.owner = Some(owner.clone());
+                next.lease.instance = Some(instance.clone());
+                next.lease.expires_at = Some(now_seconds() + ttl);
+                next
+            },
+            |observed| observed.lease.instance_is(&self.instance),
+            false,
+        )?;
+
+        // Believe what is actually stored, not what a fresh clock would allow:
+        // reconciliation can settle on a head written by an earlier attempt
+        // whose expiry is older than this one's.
+        let mut state = lock(&self.state);
+        state.lease_deadline = lease_deadline_from(&state.head.lease, self.tuning.lease_ttl);
+        Ok(())
+    }
+
+    fn release_lease_locked(&self) -> Result<()> {
+        self.commit_head(
+            HEAD_KEY,
+            |current| {
+                let mut next = current.clone();
+                next.lease = Lease::released(current.lease.generation);
+                next
+            },
+            |observed| observed.lease.instance.is_none(),
+            // Releasing is the last thing this instance does; after it succeeds
+            // the ownership check would fail by construction.
+            true,
+        )?;
+        let mut state = lock(&self.state);
+        state.fenced = false;
+        state.lease_deadline = None;
+        Ok(())
+    }
+
+    // ------------------------------------------------------------- close
+
+    fn close(&self) -> Result<()> {
+        {
+            let mut state = lock(&self.state);
+            if state.lifecycle != Lifecycle::Open {
+                return Ok(());
+            }
+            state.lifecycle = Lifecycle::Closing;
+        }
+        self.stop_heartbeat();
+
+        // Taking the queue is the drain: whatever was in flight finishes
+        // first, and it is held until the engine is gone, so nothing can slip
+        // in behind the durability barrier.
+        let _ops = lock(&self.ops);
+        let mut failure = None;
+
+        if !self.read_only {
+            // Read inside the queue rather than before it: another thread may
+            // have executed or been fenced while close was waiting.
+            let (fenced, pending) = {
+                let state = lock(&self.state);
+                (state.fenced, state.wal_buffer.len())
+            };
+            if fenced {
+                if pending > 0 {
+                    failure = Some(err(
+                        Category::LeaseFenced,
+                        format!(
+                            "durable: object {} lost its lease; {pending} buffered statement(s) \
+                             were not persisted",
+                            self.id
+                        ),
+                    ));
+                }
+            } else {
+                failure = self
+                    .flush_locked(true)
+                    .and_then(|_| self.release_lease_locked())
+                    .err();
+            }
+        }
+
+        // The native connection and the scratch tree go back whatever happened
+        // above: a remote failure is a durability problem, not a reason to leak
+        // a connection or a temp tree.
+        if let Err(e) = self.reclaim() {
+            failure = failure.or(Some(e));
+        }
+        lock(&self.state).lifecycle = Lifecycle::Closed;
+        match failure {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
+    }
+
+    /// Releases the engine and the scratch tree. Touches no network.
+    fn reclaim(&self) -> Result<()> {
+        if self.reclaimed.swap(true, AtomicOrdering::SeqCst) {
+            return Ok(());
+        }
+        let closed = lock(&self.engine).close();
+        let removed = fs::remove_dir_all(&self.scratch.root).map_err(|e| {
+            backend_err(
+                e,
+                "durable: cannot remove the scratch directory".to_string(),
+            )
+        });
+        closed.and(removed)
+    }
+
+    fn stop_heartbeat(&self) {
+        self.signal_stop();
+        if let Some(handle) = lock(&self.heartbeat).take() {
+            let _ = handle.join();
+        }
+    }
+
+    // -------------------------------------------------------- accessors
+
+    fn database(&self) -> String {
+        lock(&self.state).head.manifest.db.clone()
+    }
+
+    fn stats(&self) -> Stats {
+        let state = lock(&self.state);
+        Stats {
+            id: self.id.clone(),
+            database: state.head.manifest.db.clone(),
+            read_only: self.read_only,
+            state: state.lifecycle.as_str(),
+            fenced: state.fenced,
+            generation: state.head.lease.generation,
+            owner: self.owner.clone(),
+            instance: self.instance.clone(),
+            committed_seq: state.head.manifest.seq,
+            base_key: state.head.manifest.base.as_ref().map(|b| b.key.clone()),
+            wal_segments: state.head.manifest.wal.len(),
+            executed_statements: state.statement_counter,
+            committed_statements: state.committed_statements,
+            pending_statements: state.wal_buffer.len(),
+            pending_bytes: state.wal_buffer_bytes,
+            last_flush_at: state.last_flush_at,
+            last_checkpoint_at: state.last_checkpoint_at,
+        }
+    }
+}
+
+/// When this writer stops believing a lease it just wrote.
+///
+/// The earlier of what is stored and what the local clock allows. Trusting only
+/// the stored value would extend the deadline past the TTL if a remote clock
+/// runs fast; trusting only the local clock would extend it past what another
+/// writer will honour.
+fn lease_deadline_from(lease: &Lease, ttl: Duration) -> Option<Instant> {
+    let expires_at = lease.expires_at?;
+    let local = Instant::now() + ttl;
+    let remaining = expires_at - now_seconds();
+    if remaining <= 0.0 {
+        return Some(Instant::now());
+    }
+    let stored = Instant::now() + Duration::from_secs_f64(remaining);
+    Some(stored.min(local))
+}
+
+/// One open durable object.
+///
+/// Every public operation serializes on the object's own queue, together with
+/// the heartbeat's head compare-and-swap (§5.3). The contract is explicit that
+/// "the runtime happens to serialize this" is not an argument, so the queue is
+/// real rather than notional, and the handle is `Send + Sync`.
+pub struct DurableObject {
+    core: Arc<Core>,
+}
+
+impl std::fmt::Debug for DurableObject {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DurableObject")
+            .field("id", &self.core.id)
+            .field("read_only", &self.core.read_only)
+            .finish_non_exhaustive()
+    }
+}
+
+impl DurableObject {
+    /// The object's id within its namespace.
+    pub fn id(&self) -> &str {
+        &self.core.id
+    }
+
+    /// Whether this handle holds a lease.
+    pub fn read_only(&self) -> bool {
+        self.core.read_only
+    }
+
+    /// The database this object holds, fixed for its lifetime.
+    pub fn database(&self) -> String {
+        self.core.database()
+    }
+
+    /// The lease generation currently recorded in the head.
+    pub fn generation(&self) -> u64 {
+        lock(&self.core.state).head.lease.generation
+    }
+
+    /// A copy of the committed manifest. Observability; never authority.
+    pub fn manifest(&self) -> Manifest {
+        lock(&self.core.state).head.manifest.clone()
+    }
+
+    /// The absolute path of this object's private scratch tree.
+    pub fn scratch_path(&self) -> &Path {
+        &self.core.scratch.root
+    }
+
+    /// Whether this writer has lost, or given up on, its lease.
+    pub fn is_fenced(&self) -> bool {
+        lock(&self.core.state).fenced
+    }
+
+    /// A point-in-time snapshot for a status endpoint or a log line.
+    pub fn stats(&self) -> Stats {
+        self.core.stats()
+    }
+
+    /// Runs one read-only statement and returns its formatted bytes.
+    ///
+    /// It is refused unless core proves the text is exactly one `READ_ONLY`
+    /// statement: the method name is not the gate, the analysis is. Nothing is
+    /// added to the WAL, and read-only SQL carrying a credential runs — but a
+    /// failure from it is reported without the statement text.
+    pub fn query(&self, sql: &str, format: OutputFormat) -> Result<Vec<u8>> {
+        self.core.query(sql, format)
+    }
+
+    /// Runs one mutating statement locally and buffers it for the WAL.
+    ///
+    /// Returning does **not** mean the statement is durable — it means it ran
+    /// here and is queued to be published. The returned ticket is the watermark
+    /// to pass to [`Self::flush_through`] when a caller needs the write to
+    /// survive losing this machine before it answers someone.
+    pub fn execute(&self, sql: &str) -> Result<WriteTicket> {
+        self.core.execute(sql)
+    }
+
+    /// Publishes the buffered statements as one immutable WAL segment and
+    /// commits the reference (§5.4).
+    ///
+    /// Returns the published reference, or `None` when there was nothing
+    /// buffered. A returned reference means the head commit is confirmed — this
+    /// is the recovery point another process would restore to.
+    pub fn flush(&self) -> Result<Option<ObjectRef>> {
+        self.core.flush()
+    }
+
+    /// A durability barrier for one ticket.
+    ///
+    /// Returns immediately if that statement is already committed, which is
+    /// what makes concurrent callers coalesce onto a single head write: the
+    /// first through the queue publishes the segment covering all of them, and
+    /// the rest find their watermark already met.
+    pub fn flush_through(&self, ticket: WriteTicket) -> Result<()> {
+        self.core.flush_through(ticket)
+    }
+
+    /// Folds base and WAL into a fresh base and clears the WAL list (§5.5).
+    ///
+    /// Checkpoints are *full* snapshots. An incremental backup records its base
+    /// by local path, which does not survive object storage, so a portable
+    /// incremental chain is V2 work.
+    ///
+    /// It holds the operation queue for its whole duration, so nothing new is
+    /// executed into a database that is being archived. The heartbeat is
+    /// unaffected: it contends only for the head gate, which this takes just
+    /// for the final commit.
+    pub fn checkpoint(&self) -> Result<ObjectRef> {
+        self.core.checkpoint()
+    }
+
+    /// Drains, flushes, releases the lease, then releases local resources.
+    ///
+    /// Local cleanup happens whether or not the remote steps worked, and a
+    /// remote failure is still returned: a close that swallowed a failed flush
+    /// would be reporting a durability barrier it did not reach.
+    ///
+    /// This consumes the handle, because it is the durability barrier and there
+    /// is nothing useful to do with the object afterwards. Dropping without
+    /// closing reclaims local resources only — see the `Drop` implementation.
+    pub fn close(self) -> Result<()> {
+        self.core.close()
+    }
+}
+
+impl Drop for DurableObject {
+    /// Reclaims local resources only — never a stand-in for [`Self::close`].
+    ///
+    /// §5.6 allows a destructor to tidy up but not to impersonate a durability
+    /// barrier, so this touches no network: it will not flush, and it will not
+    /// release the lease, which then expires on its own TTL. It exists so a
+    /// forgotten `close` does not leave a multi-gigabyte scratch directory and
+    /// an open engine behind.
+    fn drop(&mut self) {
+        if lock(&self.core.state).lifecycle == Lifecycle::Closed {
+            return;
+        }
+        self.core.stop_heartbeat();
+        let _ = self.core.reclaim();
+        lock(&self.core.state).lifecycle = Lifecycle::Closed;
+    }
+}
+
+/// Runs the writer and read-only open sequences of contract §5.2.
+pub(crate) fn open_object(
+    id: &str,
+    backend: Arc<dyn Backend>,
+    factory: &EngineFactory,
+    options: OpenOptions,
+) -> Result<(DurableObject, bool)> {
+    let tuning = options.tuning.clone();
+    tuning.validate()?;
+
+    let owner = options
+        .owner
+        .clone()
+        .unwrap_or_else(|| format!("chdb-rust-{}", std::process::id()));
+    let instance = new_instance_id();
+    let mut engine = factory()?;
+
+    // Compatibility is settled before anything is created or claimed: an object
+    // this engine cannot read should cost nothing but two strings.
+    let probed = (|| -> Result<(RunningEngine, Option<HeadSnapshot>)> {
+        let running = RunningEngine {
+            version: engine.version()?,
+            backup_format: engine.backup_format()?,
+        };
+        let existing = read_head(&*backend)?;
+        match &existing {
+            Some(snapshot) => {
+                assert_readable(&snapshot.head)?;
+                assert_engine_compatible(&snapshot.head, &running)?;
+                if !options.read_only {
+                    assert_writable(&snapshot.head)?;
+                }
+            }
+            None if options.read_only || options.existing_only => {
+                return Err(err(
+                    Category::NotFound,
+                    format!(
+                        "durable: object {id} does not exist at {}",
+                        backend.describe()
+                    ),
+                ))
+            }
+            None => {}
+        }
+        Ok((running, existing))
+    })();
+    let (running, existing) = match probed {
+        Ok(value) => value,
+        Err(e) => {
+            let _ = engine.close();
+            return Err(e);
+        }
+    };
+    let existed = existing.is_some();
+
+    // Take the lease (or create the object) before any local resource exists,
+    // so losing the race costs nothing but the round-trips.
+    let snapshot = if options.read_only {
+        existing.expect("a read-only open of a missing object was refused above")
+    } else {
+        let database = options.database.clone().unwrap_or_else(|| "default".into());
+        let taken = match existing {
+            Some(existing) => acquire_lease(
+                &*backend,
+                existing,
+                LeaseParams {
+                    instance: &instance,
+                    owner: &owner,
+                    tuning: &tuning,
+                    force: options.force,
+                },
+            ),
+            None => create_cold(
+                &*backend,
+                ColdParams {
+                    id,
+                    database: &database,
+                    running: &running,
+                    instance: &instance,
+                    owner: &owner,
+                    tuning: &tuning,
+                },
+            ),
+        };
+        match taken {
+            Ok(snapshot) => snapshot,
+            Err(e) => {
+                let _ = engine.close();
+                return Err(e);
+            }
+        }
+    };
+
+    let scratch = match make_scratch(options.scratch_root.as_deref()) {
+        Ok(scratch) => scratch,
+        Err(e) => {
+            let _ = engine.close();
+            if !options.read_only {
+                let _ = release_lease(&*backend, &instance);
+            }
+            return Err(backend_err(
+                e,
+                "durable: cannot create a scratch directory".to_string(),
+            ));
+        }
+    };
+
+    if let Err(e) = engine.start(EngineStartOptions {
+        data_path: scratch.data.clone(),
+        backups_allowed_path: scratch.backups.clone(),
+    }) {
+        let _ = engine.close();
+        let _ = fs::remove_dir_all(&scratch.root);
+        if !options.read_only {
+            let _ = release_lease(&*backend, &instance);
+        }
+        return Err(e);
+    }
+
+    let lease_deadline = if options.read_only {
+        None
+    } else {
+        lease_deadline_from(&snapshot.head.lease, tuning.lease_ttl)
+    };
+    let core = Arc::new(Core {
+        id: id.to_string(),
+        read_only: options.read_only,
+        backend,
+        engine: Mutex::new(engine),
+        scratch,
+        tuning,
+        instance,
+        owner,
+        running,
+        ops: Mutex::new(()),
+        head_gate: Mutex::new(()),
+        state: Mutex::new(State {
+            head: snapshot.head,
+            etag: snapshot.etag,
+            raw: snapshot.raw,
+            wal_buffer: Vec::new(),
+            wal_buffer_bytes: 0,
+            statement_counter: 0,
+            committed_statements: 0,
+            last_flush_at: None,
+            last_checkpoint_at: None,
+            lifecycle: Lifecycle::Open,
+            fenced: false,
+            lease_deadline,
+        }),
+        stop: (Mutex::new(false), Condvar::new()),
+        heartbeat: Mutex::new(None),
+        reclaimed: AtomicBool::new(false),
+    });
+
+    let opened = core.restore().and_then(|()| {
+        if core.read_only {
+            // No lease, no heartbeat: the manifest read above is the snapshot
+            // this handle serves for its whole life. Immutable references make
+            // that safe even while a writer keeps committing.
+            return Ok(());
+        }
+        // Restore can outlast a lease. Confirming ownership before the handle
+        // escapes is what stops a writer from starting work on a database
+        // someone else has already taken over (§5.2 step 7).
+        core.renew_lease()
+    });
+
+    if let Err(e) = opened {
+        let _ = core.reclaim();
+        lock(&core.state).lifecycle = Lifecycle::Closed;
+        if !core.read_only {
+            // Leaving a lease stranded until its TTL would block the next
+            // writer for no reason — the object was never opened.
+            let _ = release_lease(&*core.backend, &core.instance);
+        }
+        return Err(e);
+    }
+
+    if !core.read_only {
+        start_heartbeat(&core);
+    }
+    Ok((DurableObject { core }, existed))
+}
+
+/// Renews the lease on a cadence, and stops writing if renewal fails.
+///
+/// A renewal is a head commit like any other, so it queues behind whatever
+/// commit is running rather than racing it for the ETag (§5.7). A renewal that
+/// fails is not fatal on its own — the next attempt may succeed. What is fatal
+/// is reaching the locally believed expiry without a confirmation, and
+/// `assert_writer` checks exactly that before every write.
+fn start_heartbeat(core: &Arc<Core>) {
+    let worker = Arc::clone(core);
+    let interval = core.tuning.heartbeat_interval;
+    let handle = std::thread::Builder::new()
+        .name(format!("chdb-durable-lease-{}", core.id))
+        .spawn(move || loop {
+            let (flag, condvar) = &worker.stop;
+            let stopped = {
+                let guard = lock(flag);
+                let (guard, _timeout) = condvar
+                    .wait_timeout(guard, interval)
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                *guard
+            };
+            if stopped {
+                return;
+            }
+            {
+                let state = lock(&worker.state);
+                if state.lifecycle != Lifecycle::Open || state.fenced {
+                    return;
+                }
+            }
+            if let Err(e) = worker.renew_lease() {
+                if e.category() == Category::LeaseFenced {
+                    return; // commit_head has already fenced this writer
+                }
+            }
+        });
+    match handle {
+        Ok(handle) => *lock(&core.heartbeat) = Some(handle),
+        // A process that cannot spawn a thread still has a valid lease for one
+        // TTL; without renewal the writer will fence itself when it lapses,
+        // which is the safe outcome rather than a silent unbounded lease.
+        Err(_) => core.fence(),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn a_heartbeat_slower_than_a_third_of_the_ttl_is_refused() {
+        let tuning = Tuning {
+            lease_ttl: Duration::from_secs(30),
+            heartbeat_interval: Duration::from_secs(11),
+            ..Tuning::default()
+        };
+        let error = tuning.validate().expect_err("no room for a lost renewal");
+        assert!(error.to_string().contains("at most a third"), "{error}");
+
+        assert!(Tuning::default().validate().is_ok());
+    }
+
+    #[test]
+    fn a_zero_duration_would_put_an_expiry_in_the_past() {
+        for tuning in [
+            Tuning {
+                lease_ttl: Duration::ZERO,
+                ..Tuning::default()
+            },
+            Tuning {
+                heartbeat_interval: Duration::ZERO,
+                ..Tuning::default()
+            },
+            Tuning {
+                commit_deadline: Duration::ZERO,
+                ..Tuning::default()
+            },
+            Tuning {
+                max_commit_attempts: 0,
+                ..Tuning::default()
+            },
+        ] {
+            assert!(tuning.validate().is_err(), "{tuning:?}");
+        }
+    }
+
+    #[test]
+    fn a_lease_deadline_is_the_earlier_of_the_clock_and_the_document() {
+        let ttl = Duration::from_secs(30);
+        // An expiry an hour out is not believed past the local TTL.
+        let generous = Lease {
+            generation: 1,
+            owner: Some("w".into()),
+            instance: Some("i".into()),
+            expires_at: Some(now_seconds() + 3600.0),
+        };
+        let deadline = lease_deadline_from(&generous, ttl).expect("a held lease has a deadline");
+        assert!(deadline <= Instant::now() + ttl + Duration::from_secs(1));
+
+        // An expiry already behind us is not extended by the local clock.
+        let lapsed = Lease {
+            expires_at: Some(now_seconds() - 1.0),
+            ..generous
+        };
+        assert!(lease_deadline_from(&lapsed, ttl).expect("still a deadline") <= Instant::now());
+
+        assert!(lease_deadline_from(&Lease::released(1), ttl).is_none());
+    }
+}

--- a/src/durable/types.rs
+++ b/src/durable/types.rs
@@ -1,0 +1,203 @@
+//! The frozen wire types of Durable V1 (contract §4).
+//!
+//! Everything here is FROZEN: another binding has to be able to read what this
+//! one writes. The JSON is compared semantically, not byte for byte — key order
+//! and whitespace are free — but field names, types and meanings are not.
+
+/// The protocol baseline this build implements. A higher version in a head
+/// means "do not open".
+pub const PROTOCOL_VERSION: u64 = 1;
+
+/// V1 defines no non-empty feature names, so anything appearing in a head's
+/// feature lists comes from a future revision and the negotiation rules in
+/// [`super::negotiate`] apply.
+pub const KNOWN_READER_FEATURES: &[&str] = &[];
+
+/// The writer-side counterpart of [`KNOWN_READER_FEATURES`].
+pub const KNOWN_WRITER_FEATURES: &[&str] = &[];
+
+/// What a chDB writer records in `head.engine.name`.
+pub const ENGINE_NAME: &str = "chdb";
+
+/// The archive-format generation this build understands. V1's baseline is 1.
+///
+/// It exists to be the one explicit signal that the backward-compatibility
+/// promise has been withdrawn: core increments it when a later release can no
+/// longer restore earlier full backups, and a reader refuses anything above its
+/// own baseline. Without it a reader compares version numbers, sees a larger
+/// one, concludes it is fine, and walks into a `RESTORE` that fails halfway
+/// through recovery.
+///
+/// The running engine's own value is not available yet — the C ABI exposes no
+/// accessor — so every engine reports this baseline until one does.
+pub const BACKUP_FORMAT_BASELINE: u64 = 1;
+
+/// The ceiling on one statement, in UTF-8 bytes (§4.4).
+pub const MAX_SQL_BYTES: u64 = 64 * 1024 * 1024;
+
+/// The ceiling on one uncompressed WAL segment (§4.4).
+pub const MAX_WAL_SEGMENT_BYTES: u64 = 128 * 1024 * 1024;
+
+/// The ceiling on `head.json` (§4.5).
+pub const MAX_HEAD_BYTES: u64 = 1024 * 1024;
+
+/// The largest integer every JSON implementation holds exactly.
+///
+/// The contract requires all integers in a head to stay inside it, so a value
+/// beyond it is refused rather than read differently by the next binding to
+/// open the object.
+pub const MAX_SAFE_INTEGER: u64 = (1u64 << 53) - 1;
+
+/// The version and feature negotiation block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Protocol {
+    /// The protocol revision the object was written against.
+    pub version: u64,
+    /// Features a reader must implement to interpret the object at all.
+    pub reader_features: Vec<String>,
+    /// Features a writer must implement to commit to the object.
+    pub writer_features: Vec<String>,
+}
+
+impl Default for Protocol {
+    fn default() -> Self {
+        Self {
+            version: PROTOCOL_VERSION,
+            reader_features: Vec::new(),
+            writer_features: Vec::new(),
+        }
+    }
+}
+
+/// Which engine produced the object, and what a reader needs to restore it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EngineIdentity {
+    /// Always `chdb` for an object this crate can open.
+    pub name: String,
+    /// `chdb_version()` of the writer that last touched the object. Recorded
+    /// for diagnosis and audit; explicitly *not* the compatibility gate.
+    pub version: String,
+    /// The archive-format generation. A reader refuses anything above its own
+    /// baseline.
+    pub backup_format: u64,
+    /// The oldest chDB release that may read the current state.
+    pub min_reader: String,
+}
+
+/// A reference to one immutable object.
+///
+/// The size and digest are not decoration: base and WAL are verified against
+/// both before anything is restored or replayed, and they are what makes an
+/// ambiguous upload resolvable (§5.8).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObjectRef {
+    /// Relative to `<namespace>/<object-id>/`, `/`-separated, no leading slash.
+    pub key: String,
+    /// Length in bytes.
+    pub size: u64,
+    /// The lowercase full hex SHA-256.
+    pub sha256: String,
+}
+
+/// The writer lease.
+///
+/// A released lease is the all-null form: owner, instance and expiry absent
+/// while the generation stays, so the next acquirer knows what to increment
+/// past.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Lease {
+    /// Moves forward only on a real change of owner: acquiring from released,
+    /// taking over an expired lease, or a force takeover. A heartbeat renews
+    /// the expiry and leaves this alone.
+    pub generation: u64,
+    /// A human-visible name. Observability only; never an authority check.
+    pub owner: Option<String>,
+    /// One live instance. This, with the generation, is the fence.
+    pub instance: Option<String>,
+    /// Epoch seconds, fractional allowed.
+    pub expires_at: Option<f64>,
+}
+
+impl Lease {
+    /// A lease nobody holds, at the given generation.
+    pub(crate) fn released(generation: u64) -> Self {
+        Self {
+            generation,
+            owner: None,
+            instance: None,
+            expires_at: None,
+        }
+    }
+
+    /// Does this lease name a live owner?
+    pub(crate) fn is_held(&self) -> bool {
+        self.owner.is_some()
+    }
+
+    /// Does this lease belong to the given instance?
+    pub(crate) fn instance_is(&self, instance: &str) -> bool {
+        self.instance.as_deref() == Some(instance)
+    }
+}
+
+/// The object's committed state: one database, one base, and the WAL to replay
+/// over it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Manifest {
+    /// The one database this object holds.
+    pub db: String,
+    /// The full checkpoint the WAL is replayed onto, or `None` for an object
+    /// that has never been checkpointed.
+    pub base: Option<ObjectRef>,
+    /// Segments in replay order.
+    pub wal: Vec<ObjectRef>,
+    /// Advances on every published reference, which is what makes a lost CAS
+    /// response resolvable.
+    pub seq: u64,
+}
+
+/// The typed view of `head.json`.
+///
+/// Unknown fields are not represented here — they travel separately in the raw
+/// document, because dropping them would silently strip a future revision's
+/// state (§4.2, §4.3).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Head {
+    /// Version and feature negotiation.
+    pub protocol: Protocol,
+    /// Who wrote the object, and who may read it.
+    pub engine: EngineIdentity,
+    /// The writer lease.
+    pub lease: Lease,
+    /// The committed manifest.
+    pub manifest: Manifest,
+}
+
+impl Head {
+    /// The head a brand-new object starts from: no base, no WAL, generation 1.
+    ///
+    /// The lease is left released here and filled in by the creating writer,
+    /// since a cold create and lease acquisition are one conditional write
+    /// (§5.2) — publishing an unheld head first would leave a window in which a
+    /// second process could take a lease on a manifest nobody has restored yet.
+    pub(crate) fn cold(db: &str, engine_version: &str, backup_format: u64) -> Self {
+        Self {
+            protocol: Protocol::default(),
+            engine: EngineIdentity {
+                name: ENGINE_NAME.to_string(),
+                version: engine_version.to_string(),
+                backup_format,
+                // A fresh object can only be read by this engine or later: its
+                // base will be produced by this engine.
+                min_reader: engine_version.to_string(),
+            },
+            lease: Lease::released(1),
+            manifest: Manifest {
+                db: db.to_string(),
+                base: None,
+                wal: Vec::new(),
+                seq: 0,
+            },
+        }
+    }
+}

--- a/src/durable/version.rs
+++ b/src/durable/version.rs
@@ -1,0 +1,270 @@
+//! chDB release precedence.
+//!
+//! The V1 engine gate compares versions, and it compares them by release
+//! precedence rather than as strings. The difference is not academic: as
+//! strings, `26.10.0 < 26.7.0` and `26.7.2-rc.2 > 26.7.2`, both of which are
+//! backwards, and both of which would let a reader open an object it cannot
+//! actually restore.
+//!
+//! The ordering is semver's:
+//!
+//! ```text
+//! 26.7.2-rc.1  <  26.7.2-rc.2  <  26.7.2  <  26.7.3  <  26.8.1  <  27.0.0
+//! ```
+//!
+//! A pre-release sorts *below* the release it leads to, which is what makes an
+//! object written by 26.7.2-rc.2 — the release that first exported the durable
+//! ABI, and what `chdb_version()` reports there — readable by 26.7.2 and
+//! everything after it.
+//!
+//! The parser is semver-shaped rather than a match on the two shapes chDB
+//! happens to ship today. A future `26.7.2-beta.1` sorts correctly here, where
+//! a tighter pattern would refuse an object it could have opened safely — the
+//! wrong place to fail closed. Failing closed belongs where nothing can be
+//! concluded: a string that does not parse at all is refused rather than
+//! guessed at, because an unrecognised version is not evidence of
+//! compatibility.
+
+use std::cmp::Ordering;
+
+use super::errors::{err, Category, Result};
+
+/// A version string decomposed for comparison.
+#[derive(Debug, PartialEq, Eq)]
+struct Parsed {
+    /// The numeric components, e.g. `[26, 7, 2]`. At least one.
+    release: Vec<u64>,
+    /// The dot-separated pre-release identifiers, e.g. `["rc", "2"]`. `None`
+    /// for a final release, which sorts above every pre-release of the same
+    /// numbers.
+    prerelease: Option<Vec<PreIdent>>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum PreIdent {
+    Numeric(u64),
+    Text(String),
+}
+
+/// Decomposes a chDB version string, or reports that it is not one.
+fn parse(value: &str) -> Option<Parsed> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    // Build metadata takes no part in precedence, as semver requires, but it
+    // still has to be well formed to be ignored.
+    let (value, build) = match value.split_once('+') {
+        Some((head, build)) => (head, Some(build)),
+        None => (value, None),
+    };
+    if let Some(build) = build {
+        if build.is_empty() || !build.chars().all(is_identifier_char) {
+            return None;
+        }
+    }
+
+    let (release, prerelease) = match value.split_once('-') {
+        Some((release, pre)) => (release, Some(pre)),
+        None => (value, None),
+    };
+
+    let mut numbers = Vec::new();
+    for part in release.split('.') {
+        if part.is_empty() || !part.bytes().all(|b| b.is_ascii_digit()) {
+            return None;
+        }
+        numbers.push(part.parse::<u64>().ok()?);
+    }
+
+    let identifiers = match prerelease {
+        None => None,
+        Some(pre) => {
+            if pre.is_empty() {
+                return None;
+            }
+            let mut out = Vec::new();
+            for identifier in pre.split('.') {
+                if identifier.is_empty() || !identifier.chars().all(is_identifier_char) {
+                    return None;
+                }
+                out.push(match identifier.parse::<u64>() {
+                    Ok(number) => PreIdent::Numeric(number),
+                    Err(_) => PreIdent::Text(identifier.to_string()),
+                });
+            }
+            Some(out)
+        }
+    };
+
+    Some(Parsed {
+        release: numbers,
+        prerelease: identifiers,
+    })
+}
+
+fn is_identifier_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '-' || c == '.'
+}
+
+fn compare_prerelease(left: &[PreIdent], right: &[PreIdent]) -> Ordering {
+    for index in 0..left.len().max(right.len()) {
+        // A shorter identifier list sorts lower when all shared parts are
+        // equal: rc.1 comes before rc.1.1.
+        let (a, b) = match (left.get(index), right.get(index)) {
+            (None, _) => return Ordering::Less,
+            (_, None) => return Ordering::Greater,
+            (Some(a), Some(b)) => (a, b),
+        };
+        let ordering = match (a, b) {
+            (PreIdent::Numeric(a), PreIdent::Numeric(b)) => a.cmp(b),
+            // Numeric identifiers always sort below alphanumeric ones.
+            (PreIdent::Numeric(_), PreIdent::Text(_)) => Ordering::Less,
+            (PreIdent::Text(_), PreIdent::Numeric(_)) => Ordering::Greater,
+            (PreIdent::Text(a), PreIdent::Text(b)) => a.cmp(b),
+        };
+        if ordering != Ordering::Equal {
+            return ordering;
+        }
+    }
+    Ordering::Equal
+}
+
+fn compare_precedence(left: &Parsed, right: &Parsed) -> Ordering {
+    for index in 0..left.release.len().max(right.release.len()) {
+        // A missing component is zero, so 26.7 and 26.7.0 are one release.
+        let a = left.release.get(index).copied().unwrap_or(0);
+        let b = right.release.get(index).copied().unwrap_or(0);
+        if a != b {
+            return a.cmp(&b);
+        }
+    }
+    match (&left.prerelease, &right.prerelease) {
+        (None, None) => Ordering::Equal,
+        // No pre-release outranks any pre-release of the same numbers.
+        (None, Some(_)) => Ordering::Greater,
+        (Some(_), None) => Ordering::Less,
+        (Some(a), Some(b)) => compare_prerelease(a, b),
+    }
+}
+
+/// Orders two chDB version strings by release precedence, refusing either one
+/// it cannot parse rather than guessing.
+///
+/// ```
+/// use std::cmp::Ordering;
+/// use chdb_rust::durable::compare_engine_versions;
+///
+/// assert_eq!(compare_engine_versions("26.7.2-rc.2", "26.7.2")?, Ordering::Less);
+/// assert_eq!(compare_engine_versions("26.10.0", "26.7.0")?, Ordering::Greater);
+/// assert_eq!(compare_engine_versions("26.7", "26.7.0")?, Ordering::Equal);
+/// assert!(compare_engine_versions("not-a-version...", "26.7.0").is_err());
+/// # Ok::<(), chdb_rust::durable::Error>(())
+/// ```
+///
+/// # Errors
+///
+/// Returns [`Category::EngineIncompatible`] when either string cannot be
+/// ordered. An unreadable version is not evidence of compatibility, and
+/// treating it as one is how a reader restores an archive from a release
+/// nothing has tested it against.
+pub fn compare_engine_versions(left: &str, right: &str) -> Result<Ordering> {
+    match (parse(left), parse(right)) {
+        (Some(a), Some(b)) => Ok(compare_precedence(&a, &b)),
+        (a, _) => {
+            let unreadable = if a.is_some() { right } else { left };
+            Err(err(
+                Category::EngineIncompatible,
+                format!(
+                    "durable: cannot order chdb version {unreadable:?} by release precedence, so \
+                     compatibility cannot be established; refusing rather than guessing"
+                ),
+            ))
+        }
+    }
+}
+
+/// The later of two version strings by precedence.
+pub(crate) fn max_engine_version(left: &str, right: &str) -> Result<String> {
+    Ok(match compare_engine_versions(left, right)? {
+        Ordering::Less => right.to_string(),
+        _ => left.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn ordered(pairs: &[(&str, &str)]) {
+        for (earlier, later) in pairs {
+            assert_eq!(
+                compare_engine_versions(earlier, later).unwrap(),
+                Ordering::Less,
+                "{earlier} should precede {later}"
+            );
+            assert_eq!(
+                compare_engine_versions(later, earlier).unwrap(),
+                Ordering::Greater,
+                "{later} should follow {earlier}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_prerelease_precedes_the_release_it_leads_to() {
+        ordered(&[
+            ("26.7.2-rc.1", "26.7.2-rc.2"),
+            ("26.7.2-rc.2", "26.7.2"),
+            ("26.7.2-alpha.1", "26.7.2-rc.1"),
+            ("26.7.2-rc.1", "26.7.2-rc.1.1"),
+        ]);
+    }
+
+    #[test]
+    fn release_numbers_order_numerically_not_lexically() {
+        ordered(&[
+            ("26.7.0", "26.10.0"),
+            ("26.7.2", "26.7.3"),
+            ("26.7.2", "26.8.1"),
+            ("26.8.1", "27.0.0"),
+            ("26.7.2", "26.7.2.59"),
+        ]);
+    }
+
+    #[test]
+    fn a_missing_component_is_zero() {
+        assert_eq!(
+            compare_engine_versions("26.7", "26.7.0").unwrap(),
+            Ordering::Equal
+        );
+        assert_eq!(
+            compare_engine_versions("26.7.2", "26.7.2+build.7").unwrap(),
+            Ordering::Equal
+        );
+    }
+
+    #[test]
+    fn an_unreadable_version_is_refused_rather_than_ordered() {
+        for bad in [
+            "", "   ", "v26.7.2", "26.7.x", "26..7", "26.7.2-", "26.7.2+",
+        ] {
+            let error = compare_engine_versions(bad, "26.7.2")
+                .expect_err("an unorderable version cannot establish compatibility");
+            assert_eq!(error.category(), Category::EngineIncompatible);
+        }
+    }
+
+    #[test]
+    fn the_maximum_never_lowers_a_floor() {
+        assert_eq!(
+            max_engine_version("26.7.2", "26.7.2-rc.2").unwrap(),
+            "26.7.2"
+        );
+        assert_eq!(
+            max_engine_version("26.7.2-rc.2", "26.7.2").unwrap(),
+            "26.7.2"
+        );
+        assert_eq!(max_engine_version("26.7.2", "26.7.2").unwrap(), "26.7.2");
+    }
+}

--- a/src/durable/wal.rs
+++ b/src/durable/wal.rs
@@ -1,0 +1,220 @@
+//! WAL segment encoding and decoding (contract §4.4).
+//!
+//! The format is deliberately dull: UTF-8 JSONL, one `{"sql": "..."}` object
+//! per line, newline-terminated, replayed in manifest order then line order.
+//! Being dull is what lets four language bindings agree on it.
+//!
+//! Two limits are enforced on the write side and tolerated on the read side, as
+//! the contract requires: a reader must be able to load anything a conforming
+//! writer could have produced, so it refuses only what is over the *frozen*
+//! ceiling, never a lower local preference.
+//!
+//! What this module does not do is make statements deterministic. `now()`,
+//! `rand()` and reads of mutable external sources are replayed verbatim and
+//! will produce whatever they produce; V1 promises ordered replay of the
+//! original statement text and nothing more. Materialising those values before
+//! calling `execute` is the caller's job.
+
+use serde_json::{json, Value};
+
+use super::errors::{err, Category, Error, Result};
+use super::types::{MAX_SQL_BYTES, MAX_WAL_SEGMENT_BYTES};
+
+/// One statement as a segment holds it, without the terminating newline.
+fn encode_line(sql: &str) -> String {
+    // serde_json does not escape `<`, `>` or `&`, so SQL containing them is
+    // stored as written. A WAL line is the most likely thing an operator ever
+    // reads by hand.
+    json!({ "sql": sql }).to_string()
+}
+
+/// How many bytes a statement occupies in a segment, counting its newline.
+///
+/// This has to stay exactly consistent with [`encode_segment`]: it is what the
+/// object layer budgets against before executing, and a budget that disagrees
+/// with the encoder by even one byte per line puts the boundary in the wrong
+/// place. A test asserts the two agree.
+pub(crate) fn line_bytes(sql: &str) -> u64 {
+    encode_line(sql).len() as u64 + 1
+}
+
+/// Refuses a statement that could not be written into a conforming segment.
+pub(crate) fn assert_statement_within_limit(sql: &str) -> Result<()> {
+    let size = sql.len() as u64;
+    if size > MAX_SQL_BYTES {
+        return Err(err(
+            Category::LimitExceeded,
+            format!(
+                "durable: statement is {size} UTF-8 bytes, over the V1 per-statement limit of \
+                 {MAX_SQL_BYTES}"
+            ),
+        )
+        .with_limit(MAX_SQL_BYTES, size));
+    }
+    Ok(())
+}
+
+/// Encodes buffered statements into one segment.
+///
+/// It refuses an oversized segment rather than splitting: a segment boundary is
+/// a commit boundary, so splitting silently would turn one caller-visible flush
+/// into two, and a crash between them would commit a prefix the caller was
+/// never told about.
+pub(crate) fn encode_segment(statements: &[String]) -> Result<Vec<u8>> {
+    let mut out = String::new();
+    for sql in statements {
+        assert_statement_within_limit(sql)?;
+        out.push_str(&encode_line(sql));
+        out.push('\n');
+    }
+    let size = out.len() as u64;
+    if size > MAX_WAL_SEGMENT_BYTES {
+        return Err(err(
+            Category::LimitExceeded,
+            format!(
+                "durable: WAL segment would be {size} bytes, over the V1 limit of \
+                 {MAX_WAL_SEGMENT_BYTES}; flush more often"
+            ),
+        )
+        .with_limit(MAX_WAL_SEGMENT_BYTES, size));
+    }
+    Ok(out.into_bytes())
+}
+
+/// Decodes a verified segment into its statements.
+///
+/// Strict on every count the contract names: exactly one JSON object per line,
+/// a string `sql`, and a terminating newline. A tolerant reader here would be
+/// the worst kind of bug — it would skip a statement and hand back a database
+/// that looks fine and is missing a write.
+pub(crate) fn decode_segment(data: &[u8], key: &str) -> Result<Vec<String>> {
+    let size = data.len() as u64;
+    if size > MAX_WAL_SEGMENT_BYTES {
+        return Err(err(
+            Category::LimitExceeded,
+            format!(
+                "durable: WAL segment {key} is {size} bytes, over the V1 limit of \
+                 {MAX_WAL_SEGMENT_BYTES}"
+            ),
+        )
+        .with_limit(MAX_WAL_SEGMENT_BYTES, size));
+    }
+    if data.is_empty() {
+        return Ok(Vec::new());
+    }
+    if data[data.len() - 1] != b'\n' {
+        return Err(err(
+            Category::Corrupt,
+            format!("durable: WAL segment {key} does not end with a newline; it may be truncated"),
+        ));
+    }
+    let text = std::str::from_utf8(&data[..data.len() - 1]).map_err(|e| {
+        Error::wrap(
+            Category::Corrupt,
+            e,
+            format!("durable: WAL segment {key} is not valid UTF-8"),
+        )
+    })?;
+
+    let mut statements = Vec::new();
+    for (index, line) in text.split('\n').enumerate() {
+        let lineno = index + 1;
+        let record: Value = serde_json::from_str(line).map_err(|e| {
+            Error::wrap(
+                Category::Corrupt,
+                e,
+                format!("durable: WAL segment {key} line {lineno} is not a JSON object"),
+            )
+        })?;
+        let sql = record
+            .as_object()
+            .and_then(|record| record.get("sql"))
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                err(
+                    Category::Corrupt,
+                    format!("durable: WAL segment {key} line {lineno} has no string \"sql\" field"),
+                )
+            })?;
+        // The per-statement ceiling is part of the frozen format, so it binds
+        // the reader too. A conforming writer cannot produce a larger
+        // statement, and the segment ceiling alone leaves room for a single
+        // statement twice the allowed size.
+        assert_statement_within_limit(sql)?;
+        statements.push(sql.to_string());
+    }
+    Ok(statements)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn a_segment_round_trips_through_the_frozen_shape() -> Result<()> {
+        let statements = vec![
+            "INSERT INTO t VALUES (1)".to_string(),
+            "INSERT INTO t VALUES ('a\nb')".to_string(),
+            "ALTER TABLE t UPDATE n = 2 WHERE id < 5 AND tag = 'a&b'".to_string(),
+        ];
+        let segment = encode_segment(&statements)?;
+
+        assert_eq!(segment.last(), Some(&b'\n'));
+        assert_eq!(segment.iter().filter(|b| **b == b'\n').count(), 3);
+        // Neither the embedded newline nor the ampersand may leak or be escaped
+        // into a different spelling.
+        let text = String::from_utf8(segment.clone()).unwrap();
+        assert!(text.contains(r#"'a\nb'"#), "{text}");
+        assert!(text.contains("a&b"), "{text}");
+
+        assert_eq!(
+            decode_segment(&segment, "wal/1-1-aaaaaaaa.jsonl")?,
+            statements
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn the_budget_agrees_with_the_encoder_byte_for_byte() -> Result<()> {
+        let statements = vec![
+            "INSERT INTO t VALUES (1)".to_string(),
+            "INSERT INTO t VALUES ('ünïcøde \" quoted')".to_string(),
+        ];
+        let budgeted: u64 = statements.iter().map(|sql| line_bytes(sql)).sum();
+        assert_eq!(budgeted, encode_segment(&statements)?.len() as u64);
+        Ok(())
+    }
+
+    #[test]
+    fn an_empty_segment_replays_nothing() -> Result<()> {
+        assert!(encode_segment(&[])?.is_empty());
+        assert!(decode_segment(b"", "wal/1-1-aaaaaaaa.jsonl")?.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn a_segment_that_does_not_parse_is_corrupt_rather_than_skipped() {
+        for body in [
+            &b"{\"sql\":\"SELECT 1\"}"[..], // no trailing newline
+            &b"{\"sql\":\"SELECT 1\"}\nnot json\n"[..],
+            &b"{\"statement\":\"SELECT 1\"}\n"[..], // wrong field
+            &b"{\"sql\":42}\n"[..],                 // wrong type
+            &b"[\"SELECT 1\"]\n"[..],               // not an object
+        ] {
+            let error = decode_segment(body, "wal/1-1-aaaaaaaa.jsonl")
+                .expect_err("a segment that does not parse cannot be replayed");
+            assert_eq!(error.category(), Category::Corrupt, "{body:?}");
+        }
+    }
+
+    #[test]
+    fn an_oversized_statement_is_refused_on_both_sides() {
+        let huge = "x".repeat(MAX_SQL_BYTES as usize + 1);
+        let error = assert_statement_within_limit(&huge).expect_err("over the per-statement limit");
+        assert_eq!(error.category(), Category::LimitExceeded);
+        assert_eq!(error.limit(), Some((MAX_SQL_BYTES, MAX_SQL_BYTES + 1)));
+
+        let error = encode_segment(std::slice::from_ref(&huge)).expect_err("nor may it be encoded");
+        assert_eq!(error.category(), Category::LimitExceeded);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@
 //! - **Arrow bulk insert** (feature `arrow`, on by default): [`insert_record_batch`](arrow_insert::insert_record_batch) via `ArrowStream('name')`. Use [`chdb_rust::arrow`](arrow) types so your Arrow version matches the crate.
 //! - **Thread-safe**: Connections and results can be safely sent between threads
 //! - **Version accessors** ([`version`]): which chdb-core release is linked, where it came from, and which ClickHouse it carries
+//! - **Backup, restore and statement analysis** ([`admin`]): the chdb-core management ABI, on any engine that exports it
 //!
 //! ## Examples
 //!
@@ -38,6 +39,8 @@
 //! This crate uses `unsafe` code to interface with the C library, but provides a safe Rust API.
 //! All public functions are safe to call, and the crate ensures proper resource cleanup.
 
+#[cfg(has_durable_abi)]
+pub mod admin;
 pub mod arg;
 #[cfg(feature = "arrow")]
 pub mod arrow_insert;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@
 //! - **Thread-safe**: Connections and results can be safely sent between threads
 //! - **Version accessors** ([`version`]): which chdb-core release is linked, where it came from, and which ClickHouse it carries
 //! - **Backup, restore and statement analysis** ([`admin`]): the chdb-core management ABI, on any engine that exports it
+//! - **Durable objects** (feature `durable`, [`durable`]): a database whose authoritative state is a checkpoint plus a statement WAL in storage you own
 //!
 //! ## Examples
 //!
@@ -70,6 +71,17 @@ mod bindings {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
 pub mod connection;
+// The `durable` feature needs the chdb-core management ABI, and a library that
+// does not export it cannot serve a durable object at all. Saying so at compile
+// time beats a link error naming three symbols.
+#[cfg(all(feature = "durable", not(has_durable_abi)))]
+compile_error!(
+    "the `durable` feature needs a libchdb with the Durable V1 ABI (chdb_backup_database_n, \
+     chdb_restore_database_n, chdb_classify_query_n), which is chdb-core v26.7.2-rc.2 or newer. \
+     Update the engine with ./update_libchdb.sh, or point CHDB_LIB_DIR at a newer one."
+);
+#[cfg(all(feature = "durable", has_durable_abi))]
+pub mod durable;
 pub mod error;
 pub mod format;
 pub mod log_level;

--- a/tests/durable_conformance.rs
+++ b/tests/durable_conformance.rs
@@ -1,0 +1,1444 @@
+//! Durable V1 conformance: the frozen format, the entry gates, and the fault
+//! matrix (contract §7).
+//!
+//! These run against a fake engine and a fault-injecting backend, which is what
+//! lets them cover the cases a real engine cannot reach in one process: a second
+//! live writer, a lost commit response, a takeover. What the *real* engine
+//! decides — statement classification, backup and restore — is covered in
+//! `durable_engine.rs`, against ClickHouse's own parser.
+//!
+//! The fixtures are hand-written `head.json` documents rather than documents
+//! this crate produced, for the same reason: an object another binding wrote is
+//! the case that matters, and a round-trip through our own writer would not
+//! exercise it.
+
+use std::collections::HashMap;
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use chdb_rust::admin::{QueryAnalysis, QueryClass};
+use chdb_rust::durable::{
+    Backend, Category, Digest, DurableObject, Engine, EngineStartOptions, LocalBackend, Namespace,
+    OpenOptions, PutOutcome, ReplaceOutcome, Result, Tagged, Tuning, HEAD_KEY,
+};
+use chdb_rust::format::OutputFormat;
+
+mod common;
+
+// ---------------------------------------------------------------- fake engine
+
+/// A stand-in for chDB: it records the statements applied to it and can archive
+/// and restore that record.
+///
+/// Its classification is a prefix match, which is exactly what the contract
+/// forbids a real binding from doing — the point of a fake is to make the state
+/// machine testable without an engine, and `durable_engine.rs` is where the
+/// gates meet the real parser.
+#[derive(Clone, Default)]
+struct Applied(Arc<Mutex<Vec<String>>>);
+
+impl Applied {
+    fn statements(&self) -> Vec<String> {
+        self.0.lock().unwrap().clone()
+    }
+}
+
+struct FakeEngine {
+    version: String,
+    backup_format: u64,
+    applied: Applied,
+    started: bool,
+    /// Fails the next restore, for the partial-recovery test.
+    fail_restore: bool,
+    /// Fails any statement whose text contains this, for the replay-failure test.
+    fail_statements_containing: Option<String>,
+}
+
+impl FakeEngine {
+    fn factory(applied: &Applied) -> chdb_rust::durable::EngineFactory {
+        Self::factory_with(applied, "26.7.2", 1, false, None)
+    }
+
+    fn factory_with(
+        applied: &Applied,
+        version: &str,
+        backup_format: u64,
+        fail_restore: bool,
+        fail_statements_containing: Option<&str>,
+    ) -> chdb_rust::durable::EngineFactory {
+        let applied = applied.clone();
+        let version = version.to_string();
+        let fail_statements_containing = fail_statements_containing.map(str::to_string);
+        Box::new(move || {
+            Ok(Box::new(FakeEngine {
+                version: version.clone(),
+                backup_format,
+                applied: applied.clone(),
+                started: false,
+                fail_restore,
+                fail_statements_containing: fail_statements_containing.clone(),
+            }))
+        })
+    }
+}
+
+fn engine_error(message: &str) -> chdb_rust::durable::Error {
+    chdb_rust::durable::Error::new(Category::Engine, message.to_string())
+}
+
+impl Engine for FakeEngine {
+    fn version(&mut self) -> Result<String> {
+        Ok(self.version.clone())
+    }
+
+    fn backup_format(&mut self) -> Result<u64> {
+        Ok(self.backup_format)
+    }
+
+    fn start(&mut self, options: EngineStartOptions) -> Result<()> {
+        assert!(options.data_path.is_dir(), "the scratch data path exists");
+        assert!(
+            options.backups_allowed_path.is_dir(),
+            "the archive path exists"
+        );
+        self.started = true;
+        self.applied.0.lock().unwrap().clear();
+        Ok(())
+    }
+
+    fn create_database(&mut self, _database: &str) -> Result<()> {
+        Ok(())
+    }
+
+    fn use_database(&mut self, _database: &str) -> Result<()> {
+        Ok(())
+    }
+
+    fn analyze(&mut self, sql: &str, target_database: &str) -> Result<QueryAnalysis> {
+        Ok(classify(sql, target_database))
+    }
+
+    fn query(&mut self, _sql: &str, _format: OutputFormat) -> Result<Vec<u8>> {
+        Ok(self.applied.statements().join("\n").into_bytes())
+    }
+
+    fn run(&mut self, sql: &str) -> Result<()> {
+        if let Some(needle) = &self.fail_statements_containing {
+            if sql.contains(needle.as_str()) {
+                return Err(engine_error("the fake engine refused a statement"));
+            }
+        }
+        self.applied.0.lock().unwrap().push(sql.to_string());
+        Ok(())
+    }
+
+    fn backup_database(&mut self, _database: &str, file_path: &Path) -> Result<()> {
+        assert!(file_path.is_absolute(), "an archive path is absolute");
+        assert!(!file_path.exists(), "an archive is never overwritten");
+        fs::write(file_path, self.applied.statements().join("\n"))
+            .map_err(|_| engine_error("the fake engine could not write an archive"))
+    }
+
+    fn restore_database(&mut self, _database: &str, file_path: &Path) -> Result<()> {
+        if self.fail_restore {
+            return Err(engine_error("the fake engine refused to restore"));
+        }
+        let body = fs::read_to_string(file_path)
+            .map_err(|_| engine_error("the fake engine could not read an archive"))?;
+        let mut applied = self.applied.0.lock().unwrap();
+        applied.extend(body.lines().filter(|l| !l.is_empty()).map(str::to_string));
+        Ok(())
+    }
+
+    fn close(&mut self) -> Result<()> {
+        self.started = false;
+        Ok(())
+    }
+}
+
+fn classify(sql: &str, target_database: &str) -> QueryAnalysis {
+    let statement_count = sql
+        .split(';')
+        .filter(|part| !part.trim().is_empty())
+        .count() as u32;
+    let head = sql.trim_start().to_uppercase();
+    let (class, lifecycle) = if head.starts_with("SELECT") || head.starts_with("SHOW") {
+        (QueryClass::ReadOnly, false)
+    } else if head.starts_with("CREATE DATABASE")
+        || head.starts_with("DROP DATABASE")
+        || head.starts_with("RENAME DATABASE")
+    {
+        (QueryClass::Mutating, true)
+    } else if head.starts_with("CREATE FUNCTION") || head.starts_with("CREATE USER") {
+        (QueryClass::MutatingGlobal, false)
+    } else if head.starts_with("USE")
+        || head.starts_with("SET")
+        || head.starts_with("SYSTEM")
+        || head.starts_with("BACKUP")
+        || head.starts_with("RESTORE")
+    {
+        (QueryClass::Control, false)
+    } else if head.starts_with("INSERT")
+        || head.starts_with("CREATE TABLE")
+        || head.starts_with("ALTER")
+        || head.starts_with("DROP TABLE")
+        || head.starts_with("OPTIMIZE")
+    {
+        (QueryClass::Mutating, false)
+    } else {
+        (QueryClass::Unknown, false)
+    };
+    QueryAnalysis {
+        class,
+        statement_count: if class == QueryClass::Unknown {
+            0
+        } else {
+            statement_count
+        },
+        has_secrets: sql.to_uppercase().contains("PASSWORD"),
+        writes_only_target_database: !sql.contains("elsewhere.") && !target_database.is_empty(),
+        changes_database_lifecycle: lifecycle,
+    }
+}
+
+// ------------------------------------------------------------ fault backend
+
+/// What a wrapped call should do instead of what it would have done.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+enum Fault {
+    #[default]
+    None,
+    /// Do the work, then claim not to know whether it happened.
+    LoseTheResponse,
+    /// Do nothing and claim not to know whether it happened.
+    Unknowable,
+    /// Do nothing and report a lost race.
+    Refuse,
+}
+
+/// A [`LocalBackend`] that can be told to misbehave, for the §7.4 matrix.
+struct FaultyBackend {
+    inner: LocalBackend,
+    put: Mutex<Fault>,
+    replace: Mutex<Fault>,
+    replaces: AtomicUsize,
+}
+
+impl FaultyBackend {
+    fn new(root: PathBuf) -> Arc<Self> {
+        Arc::new(Self {
+            inner: LocalBackend::new(root).expect("a local backend"),
+            put: Mutex::new(Fault::None),
+            replace: Mutex::new(Fault::None),
+            replaces: AtomicUsize::new(0),
+        })
+    }
+
+    fn on_put(&self, fault: Fault) {
+        *self.put.lock().unwrap() = fault;
+    }
+
+    fn on_replace(&self, fault: Fault) {
+        *self.replace.lock().unwrap() = fault;
+    }
+}
+
+impl Backend for FaultyBackend {
+    fn describe(&self) -> String {
+        self.inner.describe()
+    }
+
+    fn get_bytes(&self, key: &str) -> Result<Option<Vec<u8>>> {
+        self.inner.get_bytes(key)
+    }
+
+    fn get_bytes_with_etag(&self, key: &str) -> Result<Option<Tagged>> {
+        self.inner.get_bytes_with_etag(key)
+    }
+
+    fn open_reader(&self, key: &str) -> Result<Option<Box<dyn Read + Send>>> {
+        self.inner.open_reader(key)
+    }
+
+    fn put_bytes_if_absent(&self, key: &str, data: &[u8]) -> Result<PutOutcome> {
+        match *self.put.lock().unwrap() {
+            Fault::None => self.inner.put_bytes_if_absent(key, data),
+            Fault::LoseTheResponse => {
+                self.inner.put_bytes_if_absent(key, data)?;
+                Ok(PutOutcome::Ambiguous)
+            }
+            Fault::Unknowable | Fault::Refuse => Ok(PutOutcome::Ambiguous),
+        }
+    }
+
+    fn put_file_if_absent(
+        &self,
+        key: &str,
+        local_path: &Path,
+        digest: &Digest,
+    ) -> Result<PutOutcome> {
+        match *self.put.lock().unwrap() {
+            Fault::None => self.inner.put_file_if_absent(key, local_path, digest),
+            Fault::LoseTheResponse => {
+                self.inner.put_file_if_absent(key, local_path, digest)?;
+                Ok(PutOutcome::Ambiguous)
+            }
+            Fault::Unknowable | Fault::Refuse => Ok(PutOutcome::Ambiguous),
+        }
+    }
+
+    fn replace_if_match(&self, key: &str, data: &[u8], etag: &str) -> Result<ReplaceOutcome> {
+        self.replaces.fetch_add(1, Ordering::SeqCst);
+        match *self.replace.lock().unwrap() {
+            Fault::None => self.inner.replace_if_match(key, data, etag),
+            Fault::LoseTheResponse => {
+                self.inner.replace_if_match(key, data, etag)?;
+                Ok(ReplaceOutcome::Ambiguous)
+            }
+            Fault::Unknowable => Ok(ReplaceOutcome::Ambiguous),
+            Fault::Refuse => Ok(ReplaceOutcome::NotMatched),
+        }
+    }
+}
+
+// ----------------------------------------------------------------- helpers
+
+/// Tuning that keeps a whole test inside a few hundred milliseconds.
+fn brisk() -> Tuning {
+    Tuning {
+        lease_ttl: std::time::Duration::from_secs(3),
+        heartbeat_interval: std::time::Duration::from_secs(1),
+        clock_skew_allowance: std::time::Duration::from_millis(50),
+        commit_deadline: std::time::Duration::from_millis(400),
+        max_commit_attempts: 3,
+    }
+}
+
+fn namespace(root: &Path, applied: &Applied) -> Namespace {
+    Namespace::new(root.to_str().expect("a UTF-8 root"))
+        .expect("a local namespace")
+        .with_engine(FakeEngine::factory(applied))
+        .with_owner("conformance")
+        .with_tuning(brisk())
+}
+
+fn writer(root: &Path, applied: &Applied) -> (DurableObject, bool) {
+    namespace(root, applied)
+        .open(
+            "tenant",
+            OpenOptions {
+                database: Some("mem".to_string()),
+                ..OpenOptions::default()
+            },
+        )
+        .expect("a writer")
+}
+
+/// The object's directory inside the namespace root.
+fn object_dir(root: &Path) -> PathBuf {
+    root.join("tenant")
+}
+
+fn head_json(root: &Path) -> serde_json::Value {
+    let backend = LocalBackend::new(object_dir(root)).expect("a backend");
+    let bytes = backend
+        .get_bytes(HEAD_KEY)
+        .expect("a readable head")
+        .expect("a head");
+    serde_json::from_slice(&bytes).expect("valid JSON")
+}
+
+/// Writes a hand-made `head.json`, as another binding would have left it.
+fn plant_head(root: &Path, document: &str) {
+    let dir = object_dir(root);
+    fs::create_dir_all(&dir).expect("an object directory");
+    fs::write(dir.join(HEAD_KEY), document).expect("a planted head");
+}
+
+const COLD_DOCUMENT: &str = r#"{
+  "protocol": {"version": 1, "reader_features": [], "writer_features": []},
+  "engine": {"name": "chdb", "version": "26.7.2-rc.2", "backup_format": 1,
+             "min_reader": "26.7.2-rc.2"},
+  "lease": {"generation": 4, "owner": null, "instance": null, "expires_at": null},
+  "manifest": {"db": "mem", "base": null, "wal": [], "seq": 0}
+}"#;
+
+fn document_with(replacements: &[(&str, &str)]) -> String {
+    let mut out = COLD_DOCUMENT.to_string();
+    for (from, to) in replacements {
+        assert!(out.contains(from), "the fixture has no {from:?} to replace");
+        out = out.replace(from, to);
+    }
+    out
+}
+
+// ------------------------------------------------------- §7.2 format fixtures
+
+#[test]
+fn a_cold_object_is_created_and_reopened_with_its_state() {
+    let tmp = common::tempdir();
+    let applied = Applied::default();
+
+    let (object, existed) = writer(tmp.path(), &applied);
+    assert!(!existed, "nothing was there");
+    assert_eq!(
+        object.generation(),
+        1,
+        "a cold object starts at generation 1"
+    );
+    assert_eq!(object.database(), "mem");
+
+    object.execute("INSERT INTO t VALUES (1)").expect("a write");
+    object.execute("INSERT INTO t VALUES (2)").expect("a write");
+    assert_eq!(object.stats().pending_statements, 2);
+    let segment = object.flush().expect("a flush").expect("a segment");
+    assert!(segment.key.starts_with("wal/1-1-"), "{}", segment.key);
+    assert_eq!(object.stats().pending_statements, 0);
+    object.close().expect("a clean close");
+
+    // The head is released, and the manifest names the segment.
+    let head = head_json(tmp.path());
+    assert!(head["lease"]["owner"].is_null(), "the lease was released");
+    assert_eq!(head["lease"]["generation"], 1);
+    assert_eq!(head["manifest"]["wal"].as_array().unwrap().len(), 1);
+    assert_eq!(head["manifest"]["seq"], 1);
+
+    // A second open replays the WAL onto an empty engine.
+    let reopened = Applied::default();
+    let (object, existed) = writer(tmp.path(), &reopened);
+    assert!(existed, "the object was there this time");
+    assert_eq!(
+        reopened.statements(),
+        vec!["INSERT INTO t VALUES (1)", "INSERT INTO t VALUES (2)"]
+    );
+    assert_eq!(object.generation(), 2, "taking the lease moved the fence");
+    object.close().expect("a clean close");
+}
+
+#[test]
+fn a_checkpoint_folds_the_wal_into_a_base_that_restores_alone() {
+    let tmp = common::tempdir();
+    let applied = Applied::default();
+
+    let (object, _) = writer(tmp.path(), &applied);
+    object.execute("INSERT INTO t VALUES (1)").expect("a write");
+    object.flush().expect("a flush");
+    object.execute("INSERT INTO t VALUES (2)").expect("a write");
+    let base = object.checkpoint().expect("a checkpoint");
+    assert!(base.key.starts_with("checkpoints/1-"), "{}", base.key);
+    assert_eq!(
+        object.stats().pending_statements,
+        0,
+        "the backup already holds the buffered statement"
+    );
+    object.close().expect("a clean close");
+
+    let head = head_json(tmp.path());
+    assert_eq!(head["manifest"]["base"]["key"], base.key.as_str());
+    assert!(
+        head["manifest"]["wal"].as_array().unwrap().is_empty(),
+        "the WAL list is cleared by a checkpoint"
+    );
+
+    let reopened = Applied::default();
+    let (object, _) = writer(tmp.path(), &reopened);
+    assert_eq!(
+        reopened.statements(),
+        vec!["INSERT INTO t VALUES (1)", "INSERT INTO t VALUES (2)"],
+        "both statements come back, one from the base rather than the WAL"
+    );
+    object.close().expect("a clean close");
+}
+
+#[test]
+fn a_read_only_open_of_a_missing_object_is_not_found_and_creates_nothing() {
+    let tmp = common::tempdir();
+    let applied = Applied::default();
+    let namespace = namespace(tmp.path(), &applied);
+
+    let error = namespace
+        .open(
+            "tenant",
+            OpenOptions {
+                read_only: true,
+                ..OpenOptions::default()
+            },
+        )
+        .expect_err("a reader never creates the object it came to read");
+    assert_eq!(error.category(), Category::NotFound);
+    assert!(
+        !object_dir(tmp.path()).join(HEAD_KEY).exists(),
+        "nothing was published"
+    );
+
+    let error = namespace
+        .open(
+            "tenant",
+            OpenOptions {
+                existing_only: true,
+                ..OpenOptions::default()
+            },
+        )
+        .expect_err("existing_only means existing");
+    assert_eq!(error.category(), Category::NotFound);
+}
+
+#[test]
+fn a_read_only_handle_serves_the_manifest_and_refuses_to_write() {
+    let tmp = common::tempdir();
+    let applied = Applied::default();
+
+    let (object, _) = writer(tmp.path(), &applied);
+    object.execute("INSERT INTO t VALUES (1)").expect("a write");
+    object.flush().expect("a flush");
+    object.close().expect("a clean close");
+
+    let replayed = Applied::default();
+    let (reader, existed) = namespace(tmp.path(), &replayed)
+        .open(
+            "tenant",
+            OpenOptions {
+                read_only: true,
+                ..OpenOptions::default()
+            },
+        )
+        .expect("a reader");
+    assert!(existed);
+    assert!(reader.read_only());
+    assert_eq!(replayed.statements(), vec!["INSERT INTO t VALUES (1)"]);
+    assert_eq!(
+        reader.generation(),
+        1,
+        "a reader takes no lease, so the generation does not move"
+    );
+
+    let error = reader
+        .execute("INSERT INTO t VALUES (2)")
+        .expect_err("a reader cannot write");
+    assert_eq!(error.category(), Category::ClassificationRefused);
+    reader.close().expect("a clean close");
+
+    // And the lease it never took is still free for a writer.
+    let (writer, _) = writer(tmp.path(), &Applied::default());
+    writer.close().expect("a clean close");
+}
+
+#[test]
+fn a_manifest_naming_something_that_is_not_there_is_corrupt() {
+    let tmp = common::tempdir();
+    let applied = Applied::default();
+
+    let (object, _) = writer(tmp.path(), &applied);
+    object.execute("INSERT INTO t VALUES (1)").expect("a write");
+    let segment = object.flush().expect("a flush").expect("a segment");
+    object.close().expect("a clean close");
+
+    fs::remove_file(object_dir(tmp.path()).join(&segment.key)).expect("remove the segment");
+
+    let error = namespace(tmp.path(), &Applied::default())
+        .open("tenant", OpenOptions::default())
+        .expect_err("a missing segment is incomplete state, not an empty object");
+    assert_eq!(error.category(), Category::Corrupt);
+}
+
+#[test]
+fn an_object_whose_bytes_changed_under_the_manifest_is_corrupt() {
+    let tmp = common::tempdir();
+
+    for damage in ["truncate", "replace"] {
+        let tmp = tmp.path().join(damage);
+        fs::create_dir_all(&tmp).expect("a root per case");
+        let (object, _) = writer(&tmp, &Applied::default());
+        object.execute("INSERT INTO t VALUES (1)").expect("a write");
+        let segment = object.flush().expect("a flush").expect("a segment");
+        object.close().expect("a clean close");
+
+        let path = object_dir(&tmp).join(&segment.key);
+        let original = fs::read(&path).expect("the segment");
+        fs::remove_file(&path).expect("the published segment is immutable, so replace it");
+        match damage {
+            // A truncated upload has the right prefix and the wrong length.
+            "truncate" => fs::write(&path, &original[..original.len() - 5]),
+            // A replaced object can have the right length and the wrong bytes.
+            "replace" => fs::write(
+                &path,
+                original
+                    .iter()
+                    .map(|b| if *b == b'1' { b'2' } else { *b })
+                    .collect::<Vec<u8>>(),
+            ),
+            _ => unreachable!(),
+        }
+        .expect("damage the segment");
+
+        let error = namespace(&tmp, &Applied::default())
+            .open("tenant", OpenOptions::default())
+            .expect_err("a segment that is not what the head describes");
+        assert_eq!(error.category(), Category::Corrupt, "{damage}");
+    }
+}
+
+#[test]
+fn an_unreadable_head_is_corrupt_rather_than_a_cold_object() {
+    let tmp = common::tempdir();
+    let cases = [
+        ("not json at all", "{"),
+        ("not an object", "[1, 2, 3]"),
+        (
+            "a manifest with no database",
+            &document_with(&[(r#""db": "mem""#, r#""db": """#)]),
+        ),
+        (
+            "a lease that is neither held nor released",
+            &document_with(&[(
+                r#""owner": null, "instance": null, "expires_at": null"#,
+                r#""owner": "someone", "instance": null, "expires_at": null"#,
+            )]),
+        ),
+        (
+            "a reference that could leave the object",
+            &document_with(&[(
+                r#""base": null"#,
+                r#""base": {"key": "../elsewhere.tar.gz", "size": 1,
+                    "sha256": "0000000000000000000000000000000000000000000000000000000000000000"}"#,
+            )]),
+        ),
+        (
+            "a reference with no digest",
+            &document_with(&[(
+                r#""base": null"#,
+                r#""base": {"key": "checkpoints/1-1-aaaaaaaa.tar.gz", "size": 1}"#,
+            )]),
+        ),
+    ];
+
+    for (what, document) in cases {
+        let root = tmp.path().join(what.replace(' ', "-"));
+        plant_head(&root, document);
+        let error = namespace(&root, &Applied::default())
+            .open("tenant", OpenOptions::default())
+            .expect_err("a head that does not mean what it says");
+        assert_eq!(error.category(), Category::Corrupt, "{what}");
+    }
+}
+
+#[test]
+fn the_negotiation_fields_decide_what_opens() {
+    let tmp = common::tempdir();
+
+    // A producer on a different but compatible release opens.
+    let root = tmp.path().join("compatible");
+    plant_head(&root, COLD_DOCUMENT);
+    let (object, existed) = writer(&root, &Applied::default());
+    assert!(existed, "the planted object was adopted");
+    assert_eq!(
+        object.generation(),
+        5,
+        "the released lease is taken at the next generation"
+    );
+    object.close().expect("a clean close");
+
+    let refusals = [
+        (
+            "future-protocol-version",
+            document_with(&[(
+                r#""version": 1, "reader_features""#,
+                r#""version": 2, "reader_features""#,
+            )]),
+            Category::ProtocolUnsupported,
+        ),
+        (
+            "unknown-reader-feature",
+            document_with(&[(
+                r#""reader_features": []"#,
+                r#""reader_features": ["parquet-wal"]"#,
+            )]),
+            Category::ProtocolUnsupported,
+        ),
+        (
+            "engine-reader-too-old",
+            document_with(&[(
+                r#""min_reader": "26.7.2-rc.2""#,
+                r#""min_reader": "27.1.0""#,
+            )]),
+            Category::EngineIncompatible,
+        ),
+        (
+            "backup-format-too-new",
+            document_with(&[(r#""backup_format": 1"#, r#""backup_format": 2"#)]),
+            Category::EngineIncompatible,
+        ),
+        (
+            "another-engine",
+            document_with(&[(r#""name": "chdb""#, r#""name": "duckdb""#)]),
+            Category::EngineIncompatible,
+        ),
+    ];
+    for (what, document, expected) in refusals {
+        let root = tmp.path().join(what);
+        plant_head(&root, &document);
+        match namespace(&root, &Applied::default()).open("tenant", OpenOptions::default()) {
+            Ok(_) => panic!("{what} must not open"),
+            Err(error) => assert_eq!(error.category(), expected, "{what}"),
+        }
+    }
+}
+
+#[test]
+fn an_unknown_writer_feature_allows_a_reader_and_refuses_the_lease() {
+    let tmp = common::tempdir();
+    let document = document_with(&[(
+        r#""writer_features": []"#,
+        r#""writer_features": ["preamble"]"#,
+    )]);
+    plant_head(tmp.path(), &document);
+
+    let error = namespace(tmp.path(), &Applied::default())
+        .open("tenant", OpenOptions::default())
+        .expect_err("writing needs semantics this build does not have");
+    assert_eq!(error.category(), Category::ProtocolUnsupported);
+    assert_eq!(error.features(), ["preamble"]);
+
+    let (reader, _) = namespace(tmp.path(), &Applied::default())
+        .open(
+            "tenant",
+            OpenOptions {
+                read_only: true,
+                ..OpenOptions::default()
+            },
+        )
+        .expect("reading is still sound");
+    reader.close().expect("a clean close");
+}
+
+#[test]
+fn a_field_this_build_does_not_know_survives_the_whole_lifecycle() {
+    let tmp = common::tempdir();
+    let document = document_with(&[
+        (
+            r#""manifest": {"db""#,
+            r#""tenancy": {"shard": 7}, "manifest": {"db""#,
+        ),
+        (
+            r#""seq": 0"#,
+            r#""seq": 0, "compaction": {"policy": "tiered"}"#,
+        ),
+    ]);
+    plant_head(tmp.path(), &document);
+
+    let (object, _) = writer(tmp.path(), &Applied::default());
+    object.execute("INSERT INTO t VALUES (1)").expect("a write");
+    object.flush().expect("a flush");
+    object.checkpoint().expect("a checkpoint");
+    object.close().expect("a clean close");
+
+    let head = head_json(tmp.path());
+    assert_eq!(head["tenancy"]["shard"], 7, "a top-level unknown survived");
+    assert_eq!(
+        head["manifest"]["compaction"]["policy"], "tiered",
+        "an unknown inside a known block survived"
+    );
+    assert!(
+        head["manifest"]["base"].is_object(),
+        "and the known fields moved on"
+    );
+}
+
+#[test]
+fn a_document_in_another_key_order_reads_the_same() {
+    let tmp = common::tempdir();
+    plant_head(
+        tmp.path(),
+        r#"{"manifest":{"seq":0,"wal":[],"base":null,"db":"mem"},
+            "lease":{"expires_at":null,"instance":null,"owner":null,"generation":1},
+            "engine":{"min_reader":"26.7.2","backup_format":1,"version":"26.7.2","name":"chdb"},
+            "protocol":{"writer_features":[],"reader_features":[],"version":1}}"#,
+    );
+    let (object, existed) = writer(tmp.path(), &Applied::default());
+    assert!(existed);
+    assert_eq!(object.database(), "mem");
+    object.close().expect("a clean close");
+}
+
+#[test]
+fn a_quoted_database_name_travels_through_the_manifest() {
+    let tmp = common::tempdir();
+    let applied = Applied::default();
+    let (object, _) = namespace(tmp.path(), &applied)
+        .open(
+            "tenant",
+            OpenOptions {
+                database: Some("my-db one`two".to_string()),
+                ..OpenOptions::default()
+            },
+        )
+        .expect("a writer");
+    assert_eq!(object.database(), "my-db one`two");
+    object.close().expect("a clean close");
+
+    assert_eq!(head_json(tmp.path())["manifest"]["db"], "my-db one`two");
+    let (reopened, _) = writer(tmp.path(), &Applied::default());
+    assert_eq!(
+        reopened.database(),
+        "my-db one`two",
+        "the object owns its database name, not the caller"
+    );
+    reopened.close().expect("a clean close");
+}
+
+// -------------------------------------------------------- §7.3 entry gates
+
+#[test]
+fn the_method_name_is_not_the_gate() {
+    let tmp = common::tempdir();
+    let (object, _) = writer(tmp.path(), &Applied::default());
+
+    // execute refuses everything that is not one local mutation …
+    for (sql, expected) in [
+        ("SELECT 1", Category::ClassificationRefused),
+        (
+            "INSERT INTO t VALUES (1); INSERT INTO t VALUES (2)",
+            Category::ClassificationRefused,
+        ),
+        ("USE other", Category::ClassificationRefused),
+        ("CREATE DATABASE other", Category::ClassificationRefused),
+        (
+            "CREATE FUNCTION f AS x -> x",
+            Category::ClassificationRefused,
+        ),
+        (
+            "INSERT INTO elsewhere.t VALUES (1)",
+            Category::ClassificationRefused,
+        ),
+        ("blah blah", Category::ClassificationRefused),
+        (
+            "CREATE USER bob IDENTIFIED BY 'password'",
+            Category::ClassificationRefused,
+        ),
+    ] {
+        let error = object.execute(sql).expect_err("refused by analysis");
+        assert_eq!(error.category(), expected, "{sql}");
+    }
+
+    // … and query refuses everything that is not one read.
+    for sql in [
+        "INSERT INTO t VALUES (1)",
+        "SELECT 1; SELECT 2",
+        "blah blah",
+    ] {
+        let error = object
+            .query(sql, OutputFormat::CSV)
+            .expect_err("refused by analysis");
+        assert_eq!(error.category(), Category::ClassificationRefused, "{sql}");
+    }
+
+    assert_eq!(
+        object.stats().executed_statements,
+        0,
+        "a refusal runs nothing"
+    );
+    object.close().expect("a clean close");
+}
+
+#[test]
+fn a_credential_bearing_mutation_is_refused_without_being_echoed() {
+    let tmp = common::tempdir();
+    let (object, _) = writer(tmp.path(), &Applied::default());
+
+    let error = object
+        .execute("ALTER TABLE t MODIFY SETTING s = 'PASSWORD hunter2'")
+        .expect_err("the WAL outlives the statement");
+    assert_eq!(error.category(), Category::SecretRefused);
+    assert!(
+        !error.to_string().contains("hunter2"),
+        "the refusal must not carry the credential: {error}"
+    );
+    object.close().expect("a clean close");
+}
+
+#[test]
+fn a_statement_over_the_frozen_limit_is_refused_before_it_runs() {
+    let tmp = common::tempdir();
+    let applied = Applied::default();
+    let (object, _) = writer(tmp.path(), &applied);
+
+    let huge = format!(
+        "INSERT INTO t VALUES ('{}')",
+        "x".repeat(chdb_rust::durable::MAX_SQL_BYTES as usize)
+    );
+    let error = object
+        .execute(&huge)
+        .expect_err("over the per-statement limit");
+    assert_eq!(error.category(), Category::LimitExceeded);
+    assert!(
+        applied.statements().is_empty(),
+        "a statement the WAL cannot hold must not reach the engine"
+    );
+    object.close().expect("a clean close");
+}
+
+// -------------------------------------------------------- §7.4 fault matrix
+
+/// A namespace over a backend that can be told to misbehave.
+fn faulty(root: &Path, applied: &Applied, backend: &Arc<FaultyBackend>) -> Namespace {
+    let backend = Arc::clone(backend);
+    Namespace::with_backend(Box::new(move |_id| {
+        Ok(Arc::clone(&backend) as Arc<dyn Backend>)
+    }))
+    .with_engine(FakeEngine::factory(applied))
+    .with_owner("conformance")
+    .with_tuning(brisk())
+    .with_scratch_root(root.to_path_buf())
+}
+
+#[test]
+fn a_wal_upload_that_lands_with_a_lost_response_is_reconciled_as_committed() {
+    let tmp = common::tempdir();
+    let backend = FaultyBackend::new(tmp.path().join("object"));
+    let namespace = faulty(tmp.path(), &Applied::default(), &backend);
+    let (object, _) = namespace
+        .open("tenant", OpenOptions::default())
+        .expect("a writer");
+
+    object.execute("INSERT INTO t VALUES (1)").expect("a write");
+    backend.on_put(Fault::LoseTheResponse);
+    let segment = object
+        .flush()
+        .expect("re-reading the unique key settles it")
+        .expect("a segment");
+    backend.on_put(Fault::None);
+
+    assert_eq!(object.manifest().wal[0].key, segment.key);
+    assert_eq!(object.stats().pending_statements, 0);
+    object.close().expect("a clean close");
+}
+
+#[test]
+fn a_head_commit_that_lands_with_a_lost_response_is_reconciled_as_committed() {
+    let tmp = common::tempdir();
+    let backend = FaultyBackend::new(tmp.path().join("object"));
+    let namespace = faulty(tmp.path(), &Applied::default(), &backend);
+    let (object, _) = namespace
+        .open("tenant", OpenOptions::default())
+        .expect("a writer");
+
+    object.execute("INSERT INTO t VALUES (1)").expect("a write");
+    backend.on_replace(Fault::LoseTheResponse);
+    let segment = object
+        .flush()
+        .expect("the manifest names the key, so the commit landed")
+        .expect("a segment");
+    backend.on_replace(Fault::None);
+
+    assert_eq!(object.manifest().wal[0].key, segment.key);
+    assert_eq!(object.stats().committed_statements, 1);
+    object.close().expect("a clean close");
+}
+
+#[test]
+fn a_commit_that_cannot_be_proven_is_reported_as_ambiguous() {
+    let tmp = common::tempdir();
+    let backend = FaultyBackend::new(tmp.path().join("object"));
+    let namespace = faulty(tmp.path(), &Applied::default(), &backend);
+    let (object, _) = namespace
+        .open("tenant", OpenOptions::default())
+        .expect("a writer");
+
+    object.execute("INSERT INTO t VALUES (1)").expect("a write");
+    backend.on_replace(Fault::Unknowable);
+    let error = object.flush().expect_err("nothing proves the outcome");
+    backend.on_replace(Fault::None);
+
+    assert_eq!(error.category(), Category::CommitAmbiguous);
+    assert_eq!(
+        object.stats().pending_statements,
+        1,
+        "an unproven commit keeps the buffer"
+    );
+    object.close().expect("a close that flushes what was kept");
+}
+
+#[test]
+fn a_wal_upload_whose_commit_is_refused_leaves_the_old_manifest_authoritative() {
+    let tmp = common::tempdir();
+    let backend = FaultyBackend::new(tmp.path().join("object"));
+    let namespace = faulty(tmp.path(), &Applied::default(), &backend);
+    let (object, _) = namespace
+        .open("tenant", OpenOptions::default())
+        .expect("a writer");
+
+    object.execute("INSERT INTO t VALUES (1)").expect("a write");
+    backend.on_replace(Fault::Refuse);
+    let error = object.flush().expect_err("the head never moved");
+    backend.on_replace(Fault::None);
+
+    assert_eq!(error.category(), Category::Timeout);
+    assert!(
+        object.manifest().wal.is_empty(),
+        "the old manifest is still the authoritative one"
+    );
+    assert_eq!(
+        object.stats().pending_statements,
+        1,
+        "and the statement is still ours to publish"
+    );
+
+    // The retry publishes a fresh unique segment rather than overwriting.
+    let segment = object.flush().expect("a retry").expect("a segment");
+    assert_eq!(object.manifest().wal[0].key, segment.key);
+    object.close().expect("a clean close");
+}
+
+#[test]
+fn a_checkpoint_whose_commit_is_refused_leaves_the_old_base_restorable() {
+    let tmp = common::tempdir();
+    let backend = FaultyBackend::new(tmp.path().join("object"));
+    let applied = Applied::default();
+    let namespace = faulty(tmp.path(), &applied, &backend);
+    let (object, _) = namespace
+        .open("tenant", OpenOptions::default())
+        .expect("a writer");
+
+    object.execute("INSERT INTO t VALUES (1)").expect("a write");
+    object.flush().expect("a flush");
+    let committed = object.manifest();
+
+    object.execute("INSERT INTO t VALUES (2)").expect("a write");
+    backend.on_replace(Fault::Refuse);
+    let error = object.checkpoint().expect_err("the head never moved");
+    backend.on_replace(Fault::None);
+    assert_eq!(error.category(), Category::Timeout);
+
+    assert_eq!(
+        object.manifest(),
+        committed,
+        "the old base and WAL are still what a recovery would use"
+    );
+    assert_eq!(object.stats().pending_statements, 1);
+    object.close().expect("a clean close");
+}
+
+#[test]
+fn only_one_writer_wins_a_race_for_a_cold_object() {
+    let tmp = common::tempdir();
+    let backend = FaultyBackend::new(tmp.path().join("object"));
+
+    let first = faulty(tmp.path(), &Applied::default(), &backend)
+        .open("tenant", OpenOptions::default())
+        .expect("the first writer");
+    let error = faulty(tmp.path(), &Applied::default(), &backend)
+        .open("tenant", OpenOptions::default())
+        .expect_err("the second writer finds it held");
+    assert_eq!(error.category(), Category::LeaseHeld);
+    assert_eq!(error.owner(), Some("conformance"));
+
+    first.0.close().expect("a clean close");
+
+    // Released, so the next writer is free to take it.
+    let second = faulty(tmp.path(), &Applied::default(), &backend)
+        .open("tenant", OpenOptions::default())
+        .expect("the lease was given back");
+    second.0.close().expect("a clean close");
+}
+
+#[test]
+fn a_force_takeover_fences_the_writer_it_displaced() {
+    let tmp = common::tempdir();
+    let backend = FaultyBackend::new(tmp.path().join("object"));
+
+    let (displaced, _) = faulty(tmp.path(), &Applied::default(), &backend)
+        .open("tenant", OpenOptions::default())
+        .expect("the first writer");
+    displaced
+        .execute("INSERT INTO t VALUES (1)")
+        .expect("a write nobody will see");
+
+    let (taker, _) = faulty(tmp.path(), &Applied::default(), &backend)
+        .open(
+            "tenant",
+            OpenOptions {
+                force: true,
+                ..OpenOptions::default()
+            },
+        )
+        .expect("an administrative takeover");
+    assert_eq!(taker.generation(), 2);
+
+    let error = displaced
+        .flush()
+        .expect_err("the fence is the compare-and-set");
+    assert_eq!(error.category(), Category::LeaseFenced);
+    assert!(displaced.is_fenced());
+
+    // A fenced writer still reports its loss on close, rather than silently
+    // dropping the statement it never published.
+    let error = displaced.close().expect_err("unflushed work was lost");
+    assert_eq!(error.category(), Category::LeaseFenced);
+    taker.close().expect("a clean close");
+}
+
+#[test]
+fn a_writer_that_cannot_confirm_its_lease_fences_itself() {
+    let tmp = common::tempdir();
+    let backend = FaultyBackend::new(tmp.path().join("object"));
+    let namespace = Namespace::with_backend({
+        let backend = Arc::clone(&backend);
+        Box::new(move |_id| Ok(Arc::clone(&backend) as Arc<dyn Backend>))
+    })
+    .with_engine(FakeEngine::factory(&Applied::default()))
+    .with_scratch_root(tmp.path().to_path_buf())
+    .with_tuning(Tuning {
+        lease_ttl: std::time::Duration::from_millis(300),
+        heartbeat_interval: std::time::Duration::from_millis(90),
+        clock_skew_allowance: std::time::Duration::from_millis(10),
+        commit_deadline: std::time::Duration::from_millis(100),
+        max_commit_attempts: 2,
+    });
+    let (object, _) = namespace
+        .open("tenant", OpenOptions::default())
+        .expect("a writer");
+
+    // Every renewal from here on fails, so the locally believed validity window
+    // runs out.
+    backend.on_replace(Fault::Refuse);
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    let error = object
+        .execute("INSERT INTO t VALUES (1)")
+        .expect_err("past its own expiry, a writer stops writing");
+    assert_eq!(error.category(), Category::LeaseFenced);
+    assert!(object.is_fenced());
+
+    backend.on_replace(Fault::None);
+    // Reads are still served: §5.7 fences writes, not reads.
+    object
+        .query("SELECT 1", OutputFormat::CSV)
+        .expect("a fenced writer may still read its own local state");
+    let _ = object.close();
+}
+
+#[test]
+fn a_restore_that_fails_hands_back_no_session_and_no_lease() {
+    let tmp = common::tempdir();
+    let applied = Applied::default();
+
+    let (object, _) = writer(tmp.path(), &applied);
+    object.execute("INSERT INTO t VALUES (1)").expect("a write");
+    object.checkpoint().expect("a checkpoint");
+    object.close().expect("a clean close");
+
+    let scratch_root = tmp.path().join("scratch");
+    let error = Namespace::new(tmp.path().to_str().expect("a UTF-8 root"))
+        .expect("a namespace")
+        .with_engine(FakeEngine::factory_with(
+            &Applied::default(),
+            "26.7.2",
+            1,
+            true,
+            None,
+        ))
+        .with_scratch_root(&scratch_root)
+        .with_tuning(brisk())
+        .open("tenant", OpenOptions::default())
+        .expect_err("a partial recovery is not a session");
+    assert_eq!(error.category(), Category::EngineIncompatible);
+
+    assert_eq!(
+        fs::read_dir(&scratch_root).into_iter().flatten().count(),
+        0,
+        "the scratch tree of a failed open goes with it"
+    );
+
+    // The lease it took on the way in was given back, so the next writer is not
+    // blocked for a TTL.
+    let (object, _) = writer(tmp.path(), &Applied::default());
+    object.close().expect("a clean close");
+}
+
+#[test]
+fn a_replay_that_fails_stops_the_open() {
+    let tmp = common::tempdir();
+    let (object, _) = writer(tmp.path(), &Applied::default());
+    object
+        .execute("INSERT INTO t VALUES (1)")
+        .expect("a write that will not replay");
+    object.flush().expect("a flush");
+    object.close().expect("a clean close");
+
+    let error = Namespace::new(tmp.path().to_str().expect("a UTF-8 root"))
+        .expect("a namespace")
+        .with_engine(FakeEngine::factory_with(
+            &Applied::default(),
+            "26.7.2",
+            1,
+            false,
+            Some("VALUES (1)"),
+        ))
+        .with_tuning(brisk())
+        .open("tenant", OpenOptions::default())
+        .expect_err("a statement that will not replay stops the open");
+    assert_eq!(error.category(), Category::Engine);
+}
+
+#[test]
+fn close_takes_the_handle_and_the_scratch_tree_with_it() {
+    let tmp = common::tempdir();
+    let applied = Applied::default();
+    let namespace = namespace(tmp.path(), &applied);
+    let (object, _) = namespace
+        .open(
+            "tenant",
+            OpenOptions {
+                database: Some("mem".to_string()),
+                ..OpenOptions::default()
+            },
+        )
+        .expect("a writer");
+    let scratch = object.scratch_path().to_path_buf();
+    object.execute("INSERT INTO t VALUES (1)").expect("a write");
+    object.close().expect("a clean close");
+
+    assert!(!scratch.exists(), "close removes the scratch tree");
+}
+
+#[test]
+fn a_dropped_handle_reclaims_locally_without_pretending_to_be_a_close() {
+    let tmp = common::tempdir();
+    let applied = Applied::default();
+    let scratch;
+    {
+        let (object, _) = writer(tmp.path(), &applied);
+        scratch = object.scratch_path().to_path_buf();
+        object.execute("INSERT INTO t VALUES (1)").expect("a write");
+        // No close: the handle just goes.
+    }
+    assert!(!scratch.exists(), "the scratch tree is still reclaimed");
+
+    let head = head_json(tmp.path());
+    assert_eq!(
+        head["lease"]["owner"], "conformance",
+        "the lease is left to expire rather than released, because Drop is not a barrier"
+    );
+    assert!(
+        head["manifest"]["wal"].as_array().unwrap().is_empty(),
+        "and the unflushed statement was never published"
+    );
+}
+
+#[test]
+fn concurrent_writers_on_one_handle_serialize_and_coalesce() {
+    let tmp = common::tempdir();
+    let applied = Applied::default();
+    let (object, _) = writer(tmp.path(), &applied);
+    let object = Arc::new(object);
+
+    let mut threads = Vec::new();
+    for n in 0..8 {
+        let object = Arc::clone(&object);
+        threads.push(std::thread::spawn(move || {
+            let ticket = object
+                .execute(&format!("INSERT INTO t VALUES ({n})"))
+                .expect("a write");
+            object.flush_through(ticket).expect("a barrier");
+        }));
+    }
+    for thread in threads {
+        thread.join().expect("a thread");
+    }
+
+    let stats = object.stats();
+    assert_eq!(stats.executed_statements, 8);
+    assert_eq!(stats.committed_statements, 8);
+    assert_eq!(stats.pending_statements, 0);
+    assert!(
+        stats.wal_segments <= 8,
+        "callers that arrive together share a segment"
+    );
+    assert_eq!(applied.statements().len(), 8);
+
+    // Sequence numbers advance once per published reference, never skipping.
+    let manifest = object.manifest();
+    assert_eq!(manifest.seq as usize, manifest.wal.len());
+
+    Arc::try_unwrap(object)
+        .expect("the threads are done")
+        .close()
+        .expect("a clean close");
+}
+
+#[test]
+fn what_this_writer_publishes_is_what_the_frozen_layout_says() {
+    let tmp = common::tempdir();
+    let (object, _) = writer(tmp.path(), &Applied::default());
+    object.execute("INSERT INTO t VALUES (1)").expect("a write");
+    object.flush().expect("a flush");
+    object.checkpoint().expect("a checkpoint");
+    object.close().expect("a clean close");
+
+    let dir = object_dir(tmp.path());
+    let mut published: HashMap<String, usize> = HashMap::new();
+    for entry in walk(&dir) {
+        let relative = entry
+            .strip_prefix(&dir)
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        let bucket = relative.split('/').next().unwrap_or_default().to_string();
+        *published.entry(bucket).or_default() += 1;
+    }
+    assert_eq!(published.get("wal").copied(), Some(1), "one WAL segment");
+    assert_eq!(
+        published.get("checkpoints").copied(),
+        Some(1),
+        "one checkpoint"
+    );
+    assert!(published.contains_key(HEAD_KEY), "and one head");
+
+    let head = head_json(tmp.path());
+    let base = head["manifest"]["base"]["key"]
+        .as_str()
+        .expect("a base key");
+    assert!(
+        base.starts_with("checkpoints/") && base.ends_with(".tar.gz"),
+        "{base}"
+    );
+    assert_eq!(
+        head["manifest"]["base"]["sha256"].as_str().unwrap().len(),
+        64
+    );
+    assert_eq!(head["protocol"]["version"], 1);
+    assert_eq!(head["engine"]["name"], "chdb");
+    assert_eq!(head["engine"]["backup_format"], 1);
+}
+
+/// Every file under `dir`, ignoring the local backend's own bookkeeping.
+fn walk(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let Ok(entries) = fs::read_dir(dir) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.starts_with('.') {
+            continue; // .head-versions and .tmp belong to the backend, not the protocol
+        }
+        if path.is_dir() {
+            out.extend(walk(&path));
+        } else {
+            out.push(path);
+        }
+    }
+    out
+}
+
+#[test]
+fn a_base_and_the_wal_on_top_of_it_are_replayed_in_order() {
+    let tmp = common::tempdir();
+
+    let (object, _) = writer(tmp.path(), &Applied::default());
+    object.execute("INSERT INTO t VALUES (1)").expect("a write");
+    object.checkpoint().expect("a checkpoint");
+    object.execute("INSERT INTO t VALUES (2)").expect("a write");
+    object.flush().expect("a flush");
+    object.execute("INSERT INTO t VALUES (3)").expect("a write");
+    object.flush().expect("a second flush");
+    object.close().expect("a clean close");
+
+    let head = head_json(tmp.path());
+    assert!(head["manifest"]["base"].is_object());
+    assert_eq!(head["manifest"]["wal"].as_array().unwrap().len(), 2);
+
+    let restored = Applied::default();
+    let (object, _) = writer(tmp.path(), &restored);
+    assert_eq!(
+        restored.statements(),
+        vec![
+            "INSERT INTO t VALUES (1)",
+            "INSERT INTO t VALUES (2)",
+            "INSERT INTO t VALUES (3)",
+        ],
+        "the base first, then every segment in manifest order"
+    );
+    object.close().expect("a clean close");
+}
+
+#[test]
+fn a_base_that_is_missing_or_damaged_stops_the_open() {
+    let tmp = common::tempdir();
+
+    for damage in ["missing", "truncated", "replaced"] {
+        let root = tmp.path().join(damage);
+        fs::create_dir_all(&root).expect("a root per case");
+        let (object, _) = writer(&root, &Applied::default());
+        object.execute("INSERT INTO t VALUES (1)").expect("a write");
+        let base = object.checkpoint().expect("a checkpoint");
+        object.close().expect("a clean close");
+
+        let path = object_dir(&root).join(&base.key);
+        let original = fs::read(&path).expect("the archive");
+        fs::remove_file(&path).expect("a published archive is immutable, so replace it");
+        match damage {
+            "missing" => Ok(()),
+            "truncated" => fs::write(&path, &original[..original.len() - 3]),
+            "replaced" => fs::write(&path, vec![b'x'; original.len()]),
+            _ => unreachable!(),
+        }
+        .expect("damage the archive");
+
+        let error = namespace(&root, &Applied::default())
+            .open("tenant", OpenOptions::default())
+            .expect_err("a base that is not what the head describes");
+        assert_eq!(
+            error.category(),
+            Category::Corrupt,
+            "{damage}: the engine must never be handed unverified bytes"
+        );
+    }
+}
+
+#[test]
+fn a_heartbeat_running_through_commits_does_not_disturb_them() {
+    let tmp = common::tempdir();
+    let applied = Applied::default();
+    // A heartbeat every 60ms, so several renewals land inside the loop below
+    // and contend for the same head as the flushes do.
+    let (object, _) = Namespace::new(tmp.path().to_str().expect("a UTF-8 root"))
+        .expect("a namespace")
+        .with_engine(FakeEngine::factory(&applied))
+        .with_tuning(Tuning {
+            lease_ttl: std::time::Duration::from_millis(300),
+            heartbeat_interval: std::time::Duration::from_millis(60),
+            clock_skew_allowance: std::time::Duration::from_millis(50),
+            commit_deadline: std::time::Duration::from_millis(500),
+            max_commit_attempts: 5,
+        })
+        .open(
+            "tenant",
+            OpenOptions {
+                database: Some("mem".to_string()),
+                ..OpenOptions::default()
+            },
+        )
+        .expect("a writer");
+
+    for n in 0..12 {
+        object
+            .execute(&format!("INSERT INTO t VALUES ({n})"))
+            .expect("a write");
+        object.flush().expect("a flush");
+        std::thread::sleep(std::time::Duration::from_millis(30));
+    }
+
+    let manifest = object.manifest();
+    assert_eq!(manifest.wal.len(), 12, "one segment per flush");
+    assert_eq!(
+        manifest.seq, 12,
+        "the sequence advances once per published reference, and a heartbeat is not one"
+    );
+    assert!(!object.is_fenced(), "renewals kept the lease");
+    object.close().expect("a clean close");
+}

--- a/tests/durable_engine.rs
+++ b/tests/durable_engine.rs
@@ -1,0 +1,391 @@
+//! Durable objects against the real engine.
+//!
+//! `durable_conformance.rs` drives the state machine with a fake, which is what
+//! lets it reach a second writer and a lost commit response. This file is the
+//! other half: what ClickHouse's own parser decides, what a real `BACKUP` and
+//! `RESTORE` carry, and what the one-data-path-per-process constraint means for
+//! a caller.
+//!
+//! Every test here needs the process engine to itself, so each takes [`engine`]
+//! first and closes its object before returning.
+
+use std::time::Duration;
+
+use chdb_rust::durable::{Category, DurableObject, Namespace, OpenOptions, Tuning};
+use chdb_rust::format::OutputFormat;
+use chdb_rust::{active_engine_path, active_engine_refs};
+
+mod common;
+
+/// Takes the process engine for one test.
+///
+/// chdb-core binds one data path per process, so these cannot overlap.
+/// Serializing here rather than relying on `--test-threads=1` means a plain
+/// `cargo test` reports real failures instead of collisions.
+fn engine() -> std::sync::MutexGuard<'static, ()> {
+    static ENGINE: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    ENGINE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+fn namespace(root: &std::path::Path) -> Namespace {
+    Namespace::new(root.to_str().expect("a UTF-8 root"))
+        .expect("a local namespace")
+        .with_owner("engine-test")
+        .with_tuning(Tuning {
+            lease_ttl: Duration::from_secs(10),
+            heartbeat_interval: Duration::from_secs(3),
+            ..Tuning::default()
+        })
+}
+
+fn open(root: &std::path::Path) -> (DurableObject, bool) {
+    namespace(root)
+        .open(
+            "tenant",
+            OpenOptions {
+                database: Some("mem".to_string()),
+                ..OpenOptions::default()
+            },
+        )
+        .expect("a writer")
+}
+
+fn text(bytes: Vec<u8>) -> String {
+    String::from_utf8(bytes)
+        .expect("a UTF-8 result")
+        .trim()
+        .to_string()
+}
+
+#[test]
+fn a_database_survives_the_process_that_wrote_it() {
+    let _engine = engine();
+    let tmp = common::tempdir();
+
+    let (object, existed) = open(tmp.path());
+    assert!(!existed);
+    object
+        .execute("CREATE TABLE events (id UInt64, tag String) ENGINE = MergeTree ORDER BY id")
+        .expect("DDL is a mutation like any other");
+    object
+        .execute("INSERT INTO events VALUES (1, 'first')")
+        .expect("a write");
+    let ticket = object
+        .execute("INSERT INTO events VALUES (2, 'second')")
+        .expect("a write");
+
+    assert_eq!(
+        text(
+            object
+                .query("SELECT count() FROM events", OutputFormat::CSV)
+                .expect("a read")
+        ),
+        "2",
+        "a write is visible locally the moment it returns"
+    );
+
+    object.flush_through(ticket).expect("a durability barrier");
+    object.close().expect("a clean close");
+
+    // A different handle, a different scratch directory, the same data.
+    let (object, existed) = open(tmp.path());
+    assert!(existed);
+    assert_eq!(
+        text(
+            object
+                .query("SELECT tag FROM events ORDER BY id", OutputFormat::CSV)
+                .expect("a read")
+        ),
+        "\"first\"\n\"second\"",
+        "the WAL replayed onto an empty engine"
+    );
+
+    // And once folded into a base, the WAL is no longer what carries it.
+    object.checkpoint().expect("a checkpoint");
+    assert!(object.manifest().wal.is_empty());
+    object.close().expect("a clean close");
+
+    let (object, _) = open(tmp.path());
+    assert_eq!(
+        text(
+            object
+                .query("SELECT count() FROM events", OutputFormat::CSV)
+                .expect("a read")
+        ),
+        "2",
+        "restored from the base alone"
+    );
+    object.close().expect("a clean close");
+}
+
+#[test]
+fn the_parser_decides_what_a_durable_object_will_run() {
+    let _engine = engine();
+    let tmp = common::tempdir();
+    let (object, _) = open(tmp.path());
+    object
+        .execute("CREATE TABLE t (n UInt64) ENGINE = MergeTree ORDER BY n")
+        .expect("DDL");
+
+    let refused = [
+        // Two statements have no single replayable WAL record.
+        (
+            "a batch",
+            "INSERT INTO t VALUES (1); INSERT INTO t VALUES (2)",
+        ),
+        // Session state is the object's to manage, not the caller's.
+        ("a current-database change", "USE default"),
+        ("a settings change", "SET max_threads = 1"),
+        (
+            "an async-insert relaxation",
+            "INSERT INTO t SETTINGS async_insert = 1 VALUES (1)",
+        ),
+        // The object owns one database; its container is not a logged mutation.
+        ("a database lifecycle change", "CREATE DATABASE other"),
+        // A checkpoint of one database cannot carry state that lives beside it.
+        ("a global UDF", "CREATE FUNCTION plus_one AS (x) -> x + 1"),
+        // Writes a checkpoint would not capture.
+        (
+            "a write to another database",
+            "INSERT INTO other.t VALUES (1)",
+        ),
+        (
+            "a write outside the engine",
+            "INSERT INTO FUNCTION file('out.csv', CSV) SELECT 1",
+        ),
+        // Nothing was proven about text that did not parse.
+        ("text that is not SQL", "this is not sql"),
+        // A read is not a write, and has its own entry point.
+        ("a read", "SELECT 1"),
+    ];
+    for (what, sql) in refused {
+        let error = object.execute(sql).expect_err("refused by the parser");
+        assert_eq!(
+            error.category(),
+            Category::ClassificationRefused,
+            "{what}: {error}"
+        );
+    }
+
+    // A semicolon inside inline data is data, not a statement boundary — which
+    // is the case no prefix list or regular expression can get right.
+    object
+        .execute("INSERT INTO t VALUES (1)")
+        .expect("one statement");
+    object
+        .execute("ALTER TABLE t ADD COLUMN tag String DEFAULT 'a;b'")
+        .expect("a semicolon in a literal is not a second statement");
+
+    // And query refuses anything that is not exactly one read. Note what is
+    // *not* in this list: `blah blah` parses, as an implicit SELECT of two
+    // identifiers, and is a perfectly good read that then fails on an unknown
+    // column. Only the parser can tell those apart, which is the argument for
+    // asking it.
+    for sql in [
+        "INSERT INTO t VALUES (2)",
+        "SELECT 1; SELECT 2",
+        "this is not sql",
+    ] {
+        let error = object
+            .query(sql, OutputFormat::CSV)
+            .expect_err("refused by the parser");
+        assert_eq!(error.category(), Category::ClassificationRefused, "{sql}");
+    }
+
+    object.close().expect("a clean close");
+}
+
+#[test]
+fn a_credential_may_be_read_with_but_never_logged() {
+    let _engine = engine();
+    let tmp = common::tempdir();
+    let (object, _) = open(tmp.path());
+    object
+        .execute("CREATE TABLE t (n UInt64) ENGINE = MergeTree ORDER BY n")
+        .expect("DDL");
+    object
+        .flush()
+        .expect("a flush, so what follows is measured from empty");
+
+    let secret_write = "INSERT INTO t SELECT 1 FROM \
+         s3('https://example.invalid/x.csv', 'AKIAEXAMPLE', 'hunter2', 'CSV', 'n UInt64')";
+    let error = object
+        .execute(secret_write)
+        .expect_err("a WAL segment is stored in plain text");
+    assert_eq!(error.category(), Category::SecretRefused);
+    assert!(
+        !error.to_string().contains("hunter2"),
+        "the refusal must not carry the credential: {error}"
+    );
+
+    // A read carrying the same credential is allowed through the gate: it never
+    // reaches the WAL. It then fails on the unreachable host, and that failure
+    // must not echo the statement either.
+    let error = object
+        .query(
+            "SELECT * FROM s3('https://example.invalid/x.csv', 'AKIAEXAMPLE', 'hunter2', 'CSV', 'n UInt64')",
+            OutputFormat::CSV,
+        )
+        .expect_err("example.invalid does not resolve");
+    assert_eq!(
+        error.category(),
+        Category::Engine,
+        "the gate let it through; the network did not"
+    );
+
+    assert_eq!(
+        object.stats().pending_statements,
+        0,
+        "neither the refused write nor the failed read reached the WAL"
+    );
+    object.close().expect("a clean close");
+}
+
+#[test]
+fn a_database_name_that_needs_quoting_round_trips_through_backup_and_restore() {
+    let _engine = engine();
+    let tmp = common::tempdir();
+
+    let (object, _) = namespace(tmp.path())
+        .open(
+            "tenant",
+            OpenOptions {
+                database: Some("my-db".to_string()),
+                ..OpenOptions::default()
+            },
+        )
+        .expect("a writer");
+    assert_eq!(object.database(), "my-db");
+    object
+        .execute("CREATE TABLE t (n UInt64) ENGINE = MergeTree ORDER BY n")
+        .expect("an unqualified name resolves to the object's database");
+    object
+        .execute("INSERT INTO t VALUES (42)")
+        .expect("a write");
+    object.checkpoint().expect("a checkpoint of a quoted name");
+    object.close().expect("a clean close");
+
+    let (object, _) = namespace(tmp.path())
+        .open("tenant", OpenOptions::default())
+        .expect("a writer");
+    assert_eq!(
+        object.database(),
+        "my-db",
+        "the object owns its database name, not the caller"
+    );
+    assert_eq!(
+        text(
+            object
+                .query("SELECT n FROM t", OutputFormat::CSV)
+                .expect("a read")
+        ),
+        "42"
+    );
+    object.close().expect("a clean close");
+}
+
+#[test]
+fn a_second_object_in_one_process_is_refused_with_both_paths_named() {
+    let _engine = engine();
+    let tmp = common::tempdir();
+
+    let (first, _) = open(tmp.path());
+    let error = namespace(tmp.path())
+        .open(
+            "other-tenant",
+            OpenOptions {
+                database: Some("mem".to_string()),
+                ..OpenOptions::default()
+            },
+        )
+        .expect_err("chdb-core binds one data path per process");
+    assert_eq!(error.category(), Category::Engine);
+    let message = error.to_string();
+    assert!(
+        message.contains("one data path per process"),
+        "the registry's own message should reach the caller: {message}"
+    );
+
+    first.close().expect("a clean close");
+    assert_eq!(
+        active_engine_refs(),
+        0,
+        "closing the first object frees the engine"
+    );
+    assert_eq!(active_engine_path(), None);
+
+    // And now the second one opens, which is the half that proves the failed
+    // open left nothing behind.
+    let (second, _) = namespace(tmp.path())
+        .open(
+            "other-tenant",
+            OpenOptions {
+                database: Some("mem".to_string()),
+                ..OpenOptions::default()
+            },
+        )
+        .expect("the engine is free");
+    second.close().expect("a clean close");
+}
+
+#[test]
+fn a_read_only_open_serves_what_was_committed_and_takes_no_lease() {
+    let _engine = engine();
+    let tmp = common::tempdir();
+
+    let (object, _) = open(tmp.path());
+    object
+        .execute("CREATE TABLE t (n UInt64) ENGINE = MergeTree ORDER BY n")
+        .expect("DDL");
+    object.execute("INSERT INTO t VALUES (1)").expect("a write");
+    object.flush().expect("a flush");
+    object
+        .execute("INSERT INTO t VALUES (2)")
+        .expect("a write nobody else will see yet");
+    object
+        .close()
+        .expect("a clean close, which flushes the rest");
+
+    let (reader, _) = namespace(tmp.path())
+        .open(
+            "tenant",
+            OpenOptions {
+                read_only: true,
+                ..OpenOptions::default()
+            },
+        )
+        .expect("a reader");
+    assert_eq!(
+        text(
+            reader
+                .query("SELECT count() FROM t", OutputFormat::CSV)
+                .expect("a read")
+        ),
+        "2",
+        "close published what execute had only buffered"
+    );
+    assert!(reader
+        .execute("INSERT INTO t VALUES (3)")
+        .is_err_and(|e| e.category() == Category::ClassificationRefused));
+    reader.close().expect("a clean close");
+}
+
+#[test]
+fn a_missing_object_is_not_found_rather_than_created() {
+    let _engine = engine();
+    let tmp = common::tempdir();
+
+    let error = namespace(tmp.path())
+        .open(
+            "never-written",
+            OpenOptions {
+                read_only: true,
+                ..OpenOptions::default()
+            },
+        )
+        .expect_err("a reader never creates the object it came to read");
+    assert_eq!(error.category(), Category::NotFound);
+    assert_eq!(active_engine_refs(), 0, "and it started no engine");
+}

--- a/tests/durable_s3.rs
+++ b/tests/durable_s3.rs
@@ -1,0 +1,407 @@
+//! Durable objects against a real S3-compatible bucket.
+//!
+//! Everything here is skipped unless `CHDB_DURABLE_S3_BUCKET` names one, so a
+//! machine without credentials still runs the rest of the suite. Point it at a
+//! bucket you own:
+//!
+//! ```sh
+//! eval "$(aws configure export-credentials --profile my-profile --format env)"
+//! export CHDB_DURABLE_S3_BUCKET=my-bucket
+//! export CHDB_DURABLE_S3_REGION=eu-central-1
+//! cargo test --features durable-s3 --test durable_s3 -- --test-threads=1
+//! ```
+//!
+//! `CHDB_DURABLE_S3_ENDPOINT` points the same tests at MinIO or R2.
+//!
+//! These are the tests the local backend cannot stand in for. Its conditional
+//! operations are an honest implementation of the same contract, but only a
+//! real provider can settle whether `If-None-Match: *` and `If-Match: <etag>`
+//! behave the way the protocol assumes — and that assumption is what the whole
+//! single-writer guarantee rests on.
+//!
+//! V1 has no destroy and no garbage collection, so a run leaves its objects
+//! behind under a unique prefix. Give the test bucket a lifecycle rule, or
+//! delete the prefix afterwards.
+
+use std::sync::MutexGuard;
+use std::time::Duration;
+
+use chdb_rust::durable::{
+    Backend, Category, Namespace, OpenOptions, PutOutcome, ReplaceOutcome, S3Backend, S3Options,
+    Tuning, HEAD_KEY,
+};
+use chdb_rust::format::OutputFormat;
+
+/// The bucket to run against, or `None` when this machine has none.
+fn bucket() -> Option<String> {
+    std::env::var("CHDB_DURABLE_S3_BUCKET")
+        .ok()
+        .filter(|bucket| !bucket.is_empty())
+}
+
+fn region() -> Option<String> {
+    std::env::var("CHDB_DURABLE_S3_REGION")
+        .ok()
+        .filter(|region| !region.is_empty())
+}
+
+fn endpoint() -> Option<String> {
+    std::env::var("CHDB_DURABLE_S3_ENDPOINT")
+        .ok()
+        .filter(|endpoint| !endpoint.is_empty())
+}
+
+/// A prefix nothing else is using: one per run, one per test.
+///
+/// Unique rather than cleaned up, because V1 has no delete — two runs sharing a
+/// prefix would have the second one restoring the first one's database and
+/// reporting a failure that is really a collision.
+fn prefix(test: &str) -> String {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|since| since.as_micros())
+        .unwrap_or_default();
+    format!("chdb-rust-test/{stamp}-{test}")
+}
+
+/// Takes the process engine for one test, as the engine tests do: chdb-core
+/// binds one data path per process.
+fn engine() -> MutexGuard<'static, ()> {
+    static ENGINE: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    ENGINE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// A backend straight onto one prefix, for the tests that exercise the two
+/// conditional operations without an engine in the way.
+fn backend(prefix: &str) -> Option<S3Backend> {
+    let bucket = bucket()?;
+    Some(
+        S3Backend::new(S3Options {
+            bucket,
+            prefix: prefix.to_string(),
+            region: region(),
+            endpoint: endpoint(),
+            timeout: Some(Duration::from_secs(60)),
+            ..S3Options::default()
+        })
+        .expect("an S3 backend"),
+    )
+}
+
+fn namespace(prefix: &str) -> Option<Namespace> {
+    let bucket = bucket()?;
+    let mut url = format!("s3://{bucket}/{prefix}");
+    let mut query = Vec::new();
+    if let Some(region) = region() {
+        query.push(format!("region={region}"));
+    }
+    if let Some(endpoint) = endpoint() {
+        query.push(format!("endpoint={endpoint}"));
+    }
+    if !query.is_empty() {
+        url.push('?');
+        url.push_str(&query.join("&"));
+    }
+    Some(
+        Namespace::new(&url)
+            .expect("an s3 namespace")
+            .with_owner("s3-test")
+            .with_tuning(Tuning {
+                lease_ttl: Duration::from_secs(30),
+                heartbeat_interval: Duration::from_secs(10),
+                ..Tuning::default()
+            }),
+    )
+}
+
+/// Prints why a test did nothing, so a skipped run does not read as a passing
+/// one.
+macro_rules! require_bucket {
+    ($value:expr) => {
+        match $value {
+            Some(value) => value,
+            None => {
+                eprintln!("skipped: set CHDB_DURABLE_S3_BUCKET to run the S3 tests");
+                return;
+            }
+        }
+    };
+}
+
+#[test]
+fn a_conditional_create_lets_exactly_one_writer_win() {
+    let backend = require_bucket!(backend(&prefix("create")));
+
+    assert_eq!(
+        backend
+            .put_bytes_if_absent(HEAD_KEY, b"first")
+            .expect("a create"),
+        PutOutcome::Created
+    );
+    assert_eq!(
+        backend
+            .put_bytes_if_absent(HEAD_KEY, b"second")
+            .expect("a second create"),
+        PutOutcome::AlreadyExists,
+        "If-None-Match: * is what makes this a race nobody can both win"
+    );
+
+    let tagged = backend
+        .get_bytes_with_etag(HEAD_KEY)
+        .expect("a read")
+        .expect("the object");
+    assert_eq!(
+        tagged.data, b"first",
+        "the loser never overwrote the winner"
+    );
+    assert!(!tagged.etag.is_empty(), "a CAS token has to come back");
+}
+
+#[test]
+fn a_compare_and_swap_refuses_a_stale_token() {
+    let backend = require_bucket!(backend(&prefix("cas")));
+
+    backend
+        .put_bytes_if_absent(HEAD_KEY, b"generation-1")
+        .expect("a create");
+    let first = backend
+        .get_bytes_with_etag(HEAD_KEY)
+        .expect("a read")
+        .expect("the object");
+
+    let second = match backend
+        .replace_if_match(HEAD_KEY, b"generation-2", &first.etag)
+        .expect("a replace")
+    {
+        ReplaceOutcome::Done { etag } => etag,
+        other => panic!("expected the first replace to apply, got {other:?}"),
+    };
+    assert_ne!(second, first.etag, "a committed write moves the token");
+
+    // The token the first reader held describes a version that is gone. This is
+    // the fence: a superseded writer's next commit cannot land.
+    assert_eq!(
+        backend
+            .replace_if_match(HEAD_KEY, b"generation-3", &first.etag)
+            .expect("a replace"),
+        ReplaceOutcome::NotMatched
+    );
+    assert!(
+        matches!(
+            backend
+                .replace_if_match(HEAD_KEY, b"generation-3", &second)
+                .expect("a replace"),
+            ReplaceOutcome::Done { .. }
+        ),
+        "the current token still works"
+    );
+
+    assert_eq!(
+        backend
+            .get_bytes(HEAD_KEY)
+            .expect("a read")
+            .expect("the object"),
+        b"generation-3"
+    );
+}
+
+#[test]
+fn an_absent_key_is_an_answer_rather_than_a_failure() {
+    let backend = require_bucket!(backend(&prefix("absent")));
+    assert!(backend.get_bytes(HEAD_KEY).expect("a read").is_none());
+    assert!(backend
+        .get_bytes_with_etag(HEAD_KEY)
+        .expect("a read")
+        .is_none());
+    assert!(backend.open_reader(HEAD_KEY).expect("an open").is_none());
+}
+
+#[test]
+fn a_file_is_uploaded_whole_and_streams_back() {
+    use std::io::Read as _;
+
+    let backend = require_bucket!(backend(&prefix("file")));
+    let tmp = std::env::temp_dir().join(format!("chdb-s3-{}.bin", std::process::id()));
+    // Larger than one buffer, so this exercises the streaming path rather than
+    // a single write.
+    let body: Vec<u8> = (0..(3 * 1024 * 1024u32)).map(|n| n as u8).collect();
+    std::fs::write(&tmp, &body).expect("a local archive");
+
+    let digest = chdb_rust::durable::Digest::of(&body);
+
+    let key = "checkpoints/1-1-aaaaaaaa.tar.gz";
+    assert_eq!(
+        backend
+            .put_file_if_absent(key, &tmp, &digest)
+            .expect("an upload"),
+        PutOutcome::Created
+    );
+    let mut reader = backend
+        .open_reader(key)
+        .expect("an open")
+        .expect("the archive");
+    let mut back = Vec::new();
+    reader.read_to_end(&mut back).expect("a download");
+    assert_eq!(back.len(), body.len());
+    assert_eq!(back, body, "an archive has to come back byte for byte");
+
+    std::fs::remove_file(&tmp).ok();
+}
+
+#[test]
+fn a_database_survives_in_a_bucket() {
+    let _engine = engine();
+    let prefix = prefix("roundtrip");
+    let namespace = require_bucket!(namespace(&prefix));
+
+    let (object, existed) = namespace
+        .open(
+            "tenant",
+            OpenOptions {
+                database: Some("mem".to_string()),
+                ..OpenOptions::default()
+            },
+        )
+        .expect("a writer");
+    assert!(!existed, "a fresh prefix holds nothing");
+
+    object
+        .execute("CREATE TABLE events (id UInt64, tag String) ENGINE = MergeTree ORDER BY id")
+        .expect("DDL");
+    object
+        .execute("INSERT INTO events VALUES (1, 'first')")
+        .expect("a write");
+    let ticket = object
+        .execute("INSERT INTO events VALUES (2, 'second')")
+        .expect("a write");
+    object.flush_through(ticket).expect("a durability barrier");
+    object.close().expect("a clean close");
+
+    // A different handle, a different scratch directory, the same bucket.
+    let (object, existed) = namespace
+        .open("tenant", OpenOptions::default())
+        .expect("a second writer");
+    assert!(existed);
+    let rows = object
+        .query("SELECT tag FROM events ORDER BY id", OutputFormat::CSV)
+        .expect("a read");
+    assert_eq!(
+        String::from_utf8_lossy(&rows).trim(),
+        "\"first\"\n\"second\"",
+        "the WAL replayed out of S3"
+    );
+
+    // And a checkpoint, which is the path that uploads a file rather than a
+    // buffer.
+    let base = object.checkpoint().expect("a checkpoint");
+    assert!(base.key.starts_with("checkpoints/"), "{}", base.key);
+    assert!(object.manifest().wal.is_empty());
+    object.close().expect("a clean close");
+
+    let (object, _) = namespace
+        .open("tenant", OpenOptions::default())
+        .expect("a third writer");
+    let rows = object
+        .query("SELECT count() FROM events", OutputFormat::CSV)
+        .expect("a read");
+    assert_eq!(
+        String::from_utf8_lossy(&rows).trim(),
+        "2",
+        "restored from the checkpoint alone"
+    );
+    object.close().expect("a clean close");
+}
+
+#[test]
+fn a_second_writer_finds_the_lease_held() {
+    let _engine = engine();
+    let prefix = prefix("lease");
+    let namespace = require_bucket!(namespace(&prefix));
+
+    let (held, _) = namespace
+        .open(
+            "tenant",
+            OpenOptions {
+                database: Some("mem".to_string()),
+                ..OpenOptions::default()
+            },
+        )
+        .expect("the first writer");
+
+    // The second open is refused while taking the lease, before it ever starts
+    // an engine — which is also why this does not collide with the one data
+    // path the first writer holds.
+    let error = namespace
+        .open("tenant", OpenOptions::default())
+        .expect_err("the lease is someone else's");
+    assert_eq!(error.category(), Category::LeaseHeld);
+    assert_eq!(error.owner(), Some("s3-test"));
+
+    held.close().expect("a clean close");
+
+    // Released on close, so the next writer is free to take it.
+    let (next, _) = namespace
+        .open("tenant", OpenOptions::default())
+        .expect("the lease was given back");
+    assert_eq!(next.generation(), 2, "every takeover moves the fence");
+    next.close().expect("a clean close");
+}
+
+#[test]
+fn a_reader_sees_what_a_writer_committed_and_takes_no_lease() {
+    let _engine = engine();
+    let prefix = prefix("reader");
+    let namespace = require_bucket!(namespace(&prefix));
+
+    let (writer, _) = namespace
+        .open(
+            "tenant",
+            OpenOptions {
+                database: Some("mem".to_string()),
+                ..OpenOptions::default()
+            },
+        )
+        .expect("a writer");
+    writer
+        .execute("CREATE TABLE t (n UInt64) ENGINE = MergeTree ORDER BY n")
+        .expect("DDL");
+    writer.execute("INSERT INTO t VALUES (7)").expect("a write");
+    writer.close().expect("a clean close");
+
+    let (reader, existed) = namespace
+        .open(
+            "tenant",
+            OpenOptions {
+                read_only: true,
+                ..OpenOptions::default()
+            },
+        )
+        .expect("a reader");
+    assert!(existed);
+    let rows = reader
+        .query("SELECT n FROM t", OutputFormat::CSV)
+        .expect("a read");
+    assert_eq!(String::from_utf8_lossy(&rows).trim(), "7");
+    assert!(reader
+        .execute("INSERT INTO t VALUES (8)")
+        .is_err_and(|e| e.category() == Category::ClassificationRefused));
+    reader.close().expect("a clean close");
+}
+
+#[test]
+fn a_read_only_open_of_a_prefix_nobody_has_written_is_not_found() {
+    let _engine = engine();
+    let namespace = require_bucket!(namespace(&prefix("missing")));
+    let error = namespace
+        .open(
+            "tenant",
+            OpenOptions {
+                read_only: true,
+                ..OpenOptions::default()
+            },
+        )
+        .expect_err("a reader never creates the object it came to read");
+    assert_eq!(error.category(), Category::NotFound);
+}


### PR DESCRIPTION
Implements [chDB Durable V1](https://github.com/chdb-io/chdb/blob/main/dev-docs/CHDB_DURABLE_V1_CONTRACT.md)
for Rust: one database as an object in storage you own — a full checkpoint plus
a statement WAL under one compare-and-set `head.json` holding the writer lease.
Objects written here are the ones the Python, Node and Go bindings already read,
and vice versa.

This is step 9 of the multi-binding roadmap, and it lands on top of the
Session/registry work in #43, which was step 8.

```rust
let namespace = Namespace::new("s3://my-bucket/durable?region=eu-central-1")?
    .with_owner("worker-1");
let (object, existed) = namespace.open("tenant-123", OpenOptions {
    database: Some("mem".to_string()),
    ..OpenOptions::default()
})?;

if !existed {
    object.execute("CREATE TABLE events (id UInt64) ENGINE = MergeTree ORDER BY id")?;
}
let ticket = object.execute("INSERT INTO events VALUES (1)")?;
object.flush_through(ticket)?;   // now it survives losing this machine
object.checkpoint()?;
object.close()?;
```

## What is in it

**`src/admin.rs`** — the chdb-core management ABI, not behind any feature:
`Connection::backup_database`, `restore_database` and `classify_query` over
`chdb_backup_database_n` / `chdb_restore_database_n` / `chdb_classify_query_n`.
Compiled only when the linked header declares all three (new `has_durable_abi`
cfg), so an older engine still builds.

Both exist because the answers belong to the engine. Backup and restore take the
database name and path as *arguments*, so core builds the AST and quotes both —
nothing in this crate assembles `BACKUP` text. Analysis is ClickHouse's own
parser answering what a prefix list cannot: how many executable statements is
this, does every persistent write land in one named database, does the text
embed a credential.

**`--features durable`** — the control plane: object layout, strict `head.json`
parsing with unknown-field round-trip, lease / CAS / fencing / heartbeat, the
statement WAL, full checkpoints, §5.8 reconcile, the frozen error categories, a
`Backend` trait, and a local-directory backend.

**`--features durable-s3`** — S3-compatible storage: AWS, R2, MinIO.

## Four things this had to get right

**Nothing is reported as committed without proof.** Every commit path can end in
`commit_ambiguous`, and a lost response is settled by looking: each published key
carries a UUID, so finding it in the manifest proves the write landed.

**`execute` is not a durability barrier.** It runs the statement locally and
buffers it; `flush` publishes it. The distinction is in the type — the ticket
`execute` returns is what `flush_through` takes.

**A writer that cannot confirm its lease stops writing**, at the moment its
locally believed window lapses rather than on the next error.

**The frozen format is validated strictly and written back leniently.** A head
that fails its schema is `corrupt`, not coerced; a field this build does not
recognise survives a round-trip.

## The S3 backend

The two conditional writes are the provider's own: `If-None-Match: *` for a
create nobody can both win, `If-Match: <etag>` for the compare-and-swap that
fences a superseded writer. A 412 is reported as a compare-and-swap outcome, not
a transport error.

Requests are signed in-crate rather than through `aws-sdk-s3`. Two operations do
not justify an async runtime and several dozen crates in every caller's graph,
and `Backend` is synchronous, so an SDK built on Tokio would be driven from a
`block_on` inside every call. This matches what chdb-go does, which is also what
keeps the status-code mapping identical between the two bindings.

`AWS_CA_BUNDLE` is honoured, so a host behind a TLS-inspecting proxy works the
way `aws s3` does beside it. Credentials never appear in a namespace URL.

Known limit: single `PutObject`, so an object caps at 5 GiB and a larger
checkpoint fails with `limit_exceeded` rather than truncating. Multipart is the
fix and is not here.

## Testing

`cargo test --features durable-s3 -- --test-threads=1` → **241 tests**, with the
S3 integration tests skipping themselves (loudly) when no bucket is configured.

- `durable_conformance.rs` (32) — the state machine against a fake engine and a
  fault-injecting backend: §7.2 fixtures written by hand as another binding would
  have left them, §7.3 gates, §7.4 fault matrix (lost responses, refused commits,
  force takeover, self-fence, failed restore and replay).
- `durable_engine.rs` (7) — the entry gates in front of ClickHouse's own parser,
  real backup/restore round-trips, quoted database names, and the
  one-data-path-per-process refusal.
- `durable_s3.rs` (8) — run against a real bucket in `eu-central-1`: conditional
  create, compare-and-swap against a stale token, a 3 MiB archive uploaded and
  streamed back byte for byte, a database written / closed / recovered into a
  fresh handle, and a second writer refused with `lease_held`.

**Cross-binding check (§7.5):** the `head.json` that S3 run produced was read
back by the Python and Go bindings' own parsers. Both accept it; Go also
confirms the `min_reader` gate, where 26.7.3 opens the object and 26.7.2-rc.1 is
refused.

## Not in this PR, deliberately

`Namespace::scan`, restore-progress callbacks, multipart upload, and the
base-download / lease-CAS overlap the Python binding does with a thread pool.

## Release gate

The engine pin stays at **v26.7.2-rc.2**, which is where backup, restore and
statement analysis first appeared, and what local builds and CI test against.
This crate does not publish against a release candidate: the pin moves to
**v26.7.3** and the matrix runs again before anything goes to crates.io. The
note lives beside the pin in `Cargo.toml`, because that is the line that changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Durable V1 database protocol with local and S3 backends
> - Adds the complete Durable V1 protocol: version comparison, WAL JSONL encoding/decoding, lease-based writer fencing, compatibility negotiation, head parsing, and object state machine across [src/durable/](https://github.com/chdb-io/chdb-rust/pull/44/files#diff-cdcc0a85add2165364fa8fd5c8b2cbd1cdd3464dbeab16db42d092264a657343)
> - Implements a `Backend` trait with `LocalBackend` (filesystem) and `S3Backend` (S3-compatible, gated behind `durable-s3`), both supporting conditional create and compare-and-swap for atomic head updates
> - Adds a `ChdbEngine` seam that drives chDB with synchronous-write settings, quoted database identifiers, backup/restore, and parser-backed query classification via [src/durable/chdb_engine.rs](https://github.com/chdb-io/chdb-rust/pull/44/files#diff-b4f316969dbc196959a660ce2f148d7d5c4cedc0d8172ffe71df67c2176cf212)
> - Adds a categorized error model (`Category`, `Error`, `Details`) covering absence, lease, compatibility, corruption, limits, and ambiguous-commit failures
> - Adds conformance tests with a fake engine, real-engine integration tests, optional S3 tests, a runnable example, CI steps, and feature flags (`durable`, `durable-s3`) in [Cargo.toml](https://github.com/chdb-io/chdb-rust/pull/44/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542)
> - Risk: enabling the `durable` feature without the management ABI now fails at compile time via the `has_durable_abi` gate in [build.rs](https://github.com/chdb-io/chdb-rust/pull/44/files#diff-d0d98998092552a1d3259338c2c71e118a5b8343dd4703c0c7f552ada7f9cb42); `S3Backend` and related types are only available when `durable-s3` is enabled
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fc79705.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->