### PR TITLE
Feat add parameterized query support

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -144,6 +144,10 @@ For large result sets, avoid loading everything into a `QueryResult` at once. Us
 - **Arrow IPC stream bytes** — [`examples/11_query_streaming_arrow.rs`](../examples/11_query_streaming_arrow.rs) streams raw Arrow IPC data through `execute_stream` with `OutputFormat::ArrowStream`, then decodes each chunk with the Arrow `StreamReader`.
 - **Typed Arrow record batches** — [`examples/12_arrow_query_stream.rs`](../examples/12_arrow_query_stream.rs) uses `Session::execute_stream_arrow` to receive `RecordBatch` values directly via the Arrow C Data Interface, with no IPC serialization. Requires the `arrow` feature: `cargo run --example 12_arrow_query_stream`.
 
+### Parameterized Queries
+
+[`examples/13_query_with_params.rs`](../examples/13_query_with_params.rs) binds request filters with ClickHouse `{name:Type}` placeholders via `Session::execute_with_params`, instead of splicing values into the SQL string.
+
 ## Output Formats
 
 chdb-rust supports many output formats. Here are some common ones:

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -7,12 +7,13 @@ This document provides simple and easy-to-follow examples for using chdb-rust, a
 1. [Basic Setup](#basic-setup)
 2. [Stateless Queries](#stateless-queries)
 3. [Stateful Sessions](#stateful-sessions)
-4. [Working with Query Results](#working-with-query-results)
-5. [Output Formats](#output-formats)
-6. [Reading from Files](#reading-from-files)
-7. [Error Handling](#error-handling)
-8. [Fast Bulk Inserts (Arrow)](#fast-bulk-inserts-arrow)
-9. [Durable Objects](#durable-objects)
+4. [Parameterized Queries](#parameterized-queries)
+5. [Working with Query Results](#working-with-query-results)
+6. [Output Formats](#output-formats)
+7. [Reading from Files](#reading-from-files)
+8. [Error Handling](#error-handling)
+9. [Fast Bulk Inserts (Arrow)](#fast-bulk-inserts-arrow)
+10. [Durable Objects](#durable-objects)
 
 ## Basic Setup
 
@@ -99,6 +100,44 @@ fn main() -> Result<(), chdb_rust::error::Error> {
 }
 ```
 
+## Parameterized Queries
+
+ClickHouse `{name:Type}` placeholders bind values in the chDB library. The SQL names
+the type; the Rust value is encoded and substituted during planning. Names
+match placeholders by name, not by order.
+
+```rust
+use chdb_rust::arg::Arg;
+use chdb_rust::execute_with_params;
+use chdb_rust::format::OutputFormat;
+use chdb_rust::query_param::QueryParams;
+
+fn main() -> Result<(), chdb_rust::error::Error> {
+    let result = execute_with_params(
+        "SELECT {x:UInt64} + {y:UInt64} AS total",
+        Some(&[Arg::OutputFormat(OutputFormat::CSV)]),
+        [("y", 5_u64), ("x", 7_u64)],
+    )?;
+    println!("{}", result.data_utf8_lossy());
+
+    let params = QueryParams::new()
+        .bind("sku", "SKU-101")
+        .bind("min_qty", 10_u64);
+    let result = execute_with_params(
+        "SELECT {sku:String} AS sku, {min_qty:UInt64} AS min_qty",
+        Some(&[Arg::OutputFormat(OutputFormat::CSV)]),
+        params,
+    )?;
+    println!("{}", result.data_utf8_lossy());
+
+    Ok(())
+}
+```
+
+`Session::execute_with_params` is the same binding on a persistent session.
+[`examples/13_query_with_params.rs`](../examples/13_query_with_params.rs) uses it
+for an inventory lookup with mixed-type filters.
+
 ## Working with Query Results
 
 The `QueryResult` type provides several methods to access query results:
@@ -143,10 +182,6 @@ For large result sets, avoid loading everything into a `QueryResult` at once. Us
 - **Text or other output formats** — [`examples/10_query_streaming.rs`](../examples/10_query_streaming.rs) shows how to pull result chunks with `Session::execute_stream` and a format such as `JSONEachRow`.
 - **Arrow IPC stream bytes** — [`examples/11_query_streaming_arrow.rs`](../examples/11_query_streaming_arrow.rs) streams raw Arrow IPC data through `execute_stream` with `OutputFormat::ArrowStream`, then decodes each chunk with the Arrow `StreamReader`.
 - **Typed Arrow record batches** — [`examples/12_arrow_query_stream.rs`](../examples/12_arrow_query_stream.rs) uses `Session::execute_stream_arrow` to receive `RecordBatch` values directly via the Arrow C Data Interface, with no IPC serialization. Requires the `arrow` feature: `cargo run --example 12_arrow_query_stream`.
-
-### Parameterized Queries
-
-[`examples/13_query_with_params.rs`](../examples/13_query_with_params.rs) binds request filters with ClickHouse `{name:Type}` placeholders via `Session::execute_with_params`, instead of splicing values into the SQL string.
 
 ## Output Formats
 

--- a/examples/13_query_with_params.rs
+++ b/examples/13_query_with_params.rs
@@ -58,6 +58,8 @@ fn main() -> Result<(), chdb_rust::error::Error> {
 
     // Same-typed values can be passed as an array of (name, value) tuples;
     // `Into<QueryParam>` converts each value for the C API.
+    //
+    // Mixed-type values are addressed below.
     let result = session.execute_with_params(
         "SELECT sku, product, qty, unit_cost
          FROM stock

--- a/examples/13_query_with_params.rs
+++ b/examples/13_query_with_params.rs
@@ -1,0 +1,96 @@
+/// Example: Parameterized Queries
+///
+/// A small inventory lookup that binds request filters to ClickHouse
+/// `{name:Type}` placeholders with `execute_with_params`, instead of
+/// splicing values into the SQL string.
+use chdb_rust::arg::Arg;
+use chdb_rust::format::OutputFormat;
+use chdb_rust::query_param::QueryParams;
+use chdb_rust::session::SessionBuilder;
+
+fn main() -> Result<(), chdb_rust::error::Error> {
+    println!("=== Inventory Lookup (Parameterized Queries) ===\n");
+
+    let tmp_dir = std::env::temp_dir().join("chdb-inventory-params");
+    let session = SessionBuilder::new()
+        .with_data_path(tmp_dir)
+        .with_auto_cleanup(true)
+        .build()?;
+
+    println!("1. Creating warehouse stock table...");
+
+    session.execute(
+        "CREATE DATABASE warehouse; USE warehouse",
+        Some(&[Arg::MultiQuery]),
+    )?;
+
+    session.execute(
+        "CREATE TABLE stock (
+            sku String,
+            product String,
+            category String,
+            warehouse String,
+            qty UInt32,
+            unit_cost Float64
+        ) ENGINE = MergeTree() ORDER BY (warehouse, sku)",
+        None,
+    )?;
+
+    println!("2. Loading sample stock...");
+
+    session.execute(
+        "INSERT INTO stock VALUES
+        ('SKU-100', 'USB-C cable', 'cables', 'east', 42, 4.50),
+        ('SKU-101', 'HDMI cable', 'cables', 'east', 8, 7.25),
+        ('SKU-200', 'Laptop stand', 'desks', 'east', 15, 29.00),
+        ('SKU-201', 'Monitor arm', 'desks', 'west', 3, 89.00),
+        ('SKU-300', 'Webcam', 'peripherals', 'west', 22, 54.00),
+        ('SKU-301', 'USB hub', 'peripherals', 'east', 5, 18.75),
+        ('SKU-302', 'Docking station', 'peripherals', 'west', 1, 149.00)",
+        None,
+    )?;
+
+    // Filters that would normally come from an HTTP request or CLI args.
+    let warehouse = "east";
+    let category = "cables";
+
+    println!("3. '{category}' stock in warehouse '{warehouse}':\n");
+
+    // Same-typed values can be passed as an array of (name, value) tuples;
+    // `Into<QueryParam>` converts each value for the C API.
+    let result = session.execute_with_params(
+        "SELECT sku, product, qty, unit_cost
+         FROM stock
+         WHERE warehouse = {warehouse:String}
+           AND category = {category:String}
+         ORDER BY sku ASC",
+        Some(&[Arg::OutputFormat(OutputFormat::Pretty)]),
+        [("warehouse", warehouse), ("category", category)],
+    )?;
+
+    println!("{}", result.data_utf8_lossy());
+    println!();
+
+    let max_qty = 10_u32;
+    let min_cost = 50.0_f64;
+
+    println!("4. Items with qty <= {max_qty} or unit_cost >= ${min_cost:.2}:\n");
+
+    // Mixed types go through `QueryParams`, which still uses `Into<QueryParam>`
+    // on each `bind` call.
+    let result = session.execute_with_params(
+        "SELECT warehouse, sku, product, qty, unit_cost
+         FROM stock
+         WHERE qty <= {max_qty:UInt32}
+            OR unit_cost >= {min_cost:Float64}
+         ORDER BY warehouse ASC, sku ASC",
+        Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)]),
+        QueryParams::new()
+            .bind("max_qty", max_qty)
+            .bind("min_cost", min_cost),
+    )?;
+
+    println!("{}", result.data_utf8_lossy());
+
+    Ok(())
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,6 +19,7 @@ cargo run --features durable --example 09_durable_object
 cargo run --example 10_query_streaming
 cargo run --example 11_query_streaming_arrow
 cargo run --example 12_arrow_query_stream
+cargo run --example 13_query_with_params
 ```
 
 ## Example Files
@@ -35,6 +36,7 @@ cargo run --example 12_arrow_query_stream
 10. **10_query_streaming.rs** - Streaming large query results in chunks without materializing the full output
 11. **11_query_streaming_arrow.rs** - Streaming large query results in chunks, decoding Arrow IPC bytes into human-readable tables (requires `--features arrow`)
 12. **12_arrow_query_stream.rs** - Streaming large query results as Arrow `RecordBatch` values via the C Data Interface (requires `--features arrow`)
+13. **13_query_with_params.rs** - Inventory low-stock / price filters bound with `{name:Type}` placeholders via `Session::execute_with_params`
 
 ## Prerequisites
 

--- a/src/arrow_query_stream.rs
+++ b/src/arrow_query_stream.rs
@@ -16,6 +16,7 @@ use arrow::record_batch::RecordBatch;
 use crate::bindings;
 use crate::connection::Connection;
 use crate::error::{Error, Result};
+use crate::query_param::QueryParam;
 use crate::query_result::QueryResult;
 
 enum ArrowQueryStreamConnection<'a> {
@@ -26,8 +27,11 @@ enum ArrowQueryStreamConnection<'a> {
 /// A streaming Arrow query result that yields record batches.
 ///
 /// Returned by [`Connection::query_stream_arrow`](crate::connection::Connection::query_stream_arrow),
-/// [`Session::execute_stream_arrow`](crate::session::Session::execute_stream_arrow), and
-/// [`execute_stream_arrow`](crate::execute_stream_arrow). Each batch is produced via the
+/// [`Connection::query_stream_arrow_with_params`](crate::connection::Connection::query_stream_arrow_with_params),
+/// [`Session::execute_stream_arrow`](crate::session::Session::execute_stream_arrow),
+/// [`Session::execute_stream_arrow_with_params`](crate::session::Session::execute_stream_arrow_with_params),
+/// [`execute_stream_arrow`](crate::execute_stream_arrow), and
+/// [`execute_stream_arrow_with_params`](crate::execute_stream_arrow_with_params). Each batch is produced via the
 /// Arrow C Data Interface.
 ///
 /// `ArrowQueryStream` also implements [`Iterator`].
@@ -63,6 +67,42 @@ impl<'a> ArrowQueryStream<'a> {
         })
     }
 
+    pub(crate) fn start_borrowed_with_params<K, V, I>(
+        conn: &'a Connection,
+        sql: &str,
+        params: I,
+    ) -> Result<Self>
+    where
+        K: AsRef<str>,
+        V: Into<QueryParam>,
+        I: IntoIterator<Item = (K, V)>,
+    {
+        let inner = Self::start_query_with_params(conn.handle(), sql, params)?;
+        Ok(Self {
+            conn: ArrowQueryStreamConnection::Borrowed(conn),
+            inner,
+            finished: false,
+        })
+    }
+
+    pub(crate) fn start_owned_with_params<K, V, I>(
+        conn: Connection,
+        sql: &str,
+        params: I,
+    ) -> Result<Self>
+    where
+        K: AsRef<str>,
+        V: Into<QueryParam>,
+        I: IntoIterator<Item = (K, V)>,
+    {
+        let inner = Self::start_query_with_params(conn.handle(), sql, params)?;
+        Ok(Self {
+            conn: ArrowQueryStreamConnection::Owned(conn),
+            inner,
+            finished: false,
+        })
+    }
+
     fn start_query(
         conn: bindings::chdb_connection,
         sql: &str,
@@ -85,6 +125,20 @@ impl<'a> ArrowQueryStream<'a> {
         std::mem::forget(ManuallyDrop::into_inner(probe));
 
         Ok(stream_ptr)
+    }
+
+    fn start_query_with_params<K, V, I>(
+        conn: bindings::chdb_connection,
+        sql: &str,
+        params: I,
+    ) -> Result<*mut bindings::chdb_result>
+    where
+        K: AsRef<str>,
+        V: Into<QueryParam>,
+        I: IntoIterator<Item = (K, V)>,
+    {
+        let _ = (conn, sql, params);
+        todo!("ArrowQueryStream::start_query_with_params")
     }
 
     fn conn_handle(&self) -> bindings::chdb_connection {

--- a/src/arrow_query_stream.rs
+++ b/src/arrow_query_stream.rs
@@ -24,17 +24,11 @@ enum ArrowQueryStreamConnection<'a> {
     Owned(Connection),
 }
 
-/// A streaming Arrow query result that yields record batches.
+/// A streaming Arrow query that yields [`RecordBatch`] values one block at a time.
 ///
-/// Returned by [`Connection::query_stream_arrow`](crate::connection::Connection::query_stream_arrow),
-/// [`Connection::query_stream_arrow_with_params`](crate::connection::Connection::query_stream_arrow_with_params),
-/// [`Session::execute_stream_arrow`](crate::session::Session::execute_stream_arrow),
-/// [`Session::execute_stream_arrow_with_params`](crate::session::Session::execute_stream_arrow_with_params),
-/// [`execute_stream_arrow`](crate::execute_stream_arrow), and
-/// [`execute_stream_arrow_with_params`](crate::execute_stream_arrow_with_params). Each batch is produced via the
-/// Arrow C Data Interface.
-///
-/// `ArrowQueryStream` also implements [`Iterator`].
+/// Batches come from the Arrow C Data Interface (no Arrow IPC). Create a stream from a
+/// [`Connection`], [`Session`](crate::session::Session), or the crate-level
+/// `execute_stream_arrow*` helpers. Implements [`Iterator`].
 ///
 /// # Thread Safety
 ///
@@ -140,6 +134,17 @@ impl<'a> ArrowQueryStream<'a> {
         let query_cstr = CString::new(sql)?;
         let encoded = EncodedParams::encode(params)?;
 
+        // SAFETY:
+        // - `conn` is a live `chdb_connection` from `Connection::handle()` on an open
+        //   connection that outlives this call (borrowed or owned by the stream).
+        // - `query_cstr` is NUL-terminated and outlives this call.
+        // - The format argument is null, matching `chdb_stream_query_arrow` (Arrow
+        //   path does not take a text output format).
+        // - `encoded` owns the name/value `CString`s; `names_ptr`/`values_ptr` alias
+        //   those buffers for the duration of the call. libchdb may read them only
+        //   during this call (parameter bind at stream start) and must not retain them.
+        // - When `encoded.len() == 0`, both pointer args are null, which the C API
+        //   accepts for an empty parameter list.
         let stream_ptr = unsafe {
             bindings::chdb_stream_query_arrow_with_params(
                 conn,

--- a/src/arrow_query_stream.rs
+++ b/src/arrow_query_stream.rs
@@ -62,7 +62,7 @@ impl<'a> ArrowQueryStream<'a> {
     }
 
     pub(crate) fn start_borrowed_with_params<K, V, I>(
-        conn: &'a Connection,
+        conn: &'a mut Connection,
         sql: &str,
         params: I,
     ) -> Result<Self>
@@ -162,9 +162,10 @@ impl<'a> ArrowQueryStream<'a> {
 
         let probe = ManuallyDrop::new(QueryResult::new(stream_ptr));
         if let Err(e) = probe.check_error_ref() {
-            let _ = ManuallyDrop::into_inner(probe);
+            drop(ManuallyDrop::into_inner(probe));
             return Err(e);
         }
+        std::mem::forget(ManuallyDrop::into_inner(probe));
 
         Ok(stream_ptr)
     }
@@ -387,6 +388,51 @@ mod tests {
     fn test_arrow_query_stream_syntax_error_fails_at_start() -> Result<()> {
         let mut conn = Connection::open_in_memory()?;
         let result = conn.query_stream_arrow("SELECT invalid syntax here");
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_arrow_query_stream_with_params_empty_filter_returns_none() -> Result<()> {
+        let tmp = tempdir();
+        let mut session = SessionBuilder::new()
+            .with_data_path(tmp.path())
+            .with_auto_cleanup(true)
+            .build()?;
+
+        session.execute(
+            "CREATE TABLE items (id UInt64) ENGINE = MergeTree() ORDER BY id",
+            None,
+        )?;
+        session.execute("INSERT INTO items VALUES (1), (2), (3)", None)?;
+
+        let mut stream = session.execute_stream_arrow_with_params(
+            "SELECT * FROM items WHERE id > {min_id:UInt64}",
+            [("min_id", 100_u64)],
+        )?;
+        assert!(stream.next_batch()?.is_none());
+        assert!(stream.next_batch()?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_arrow_query_stream_with_params_error_then_retry_returns_none() -> Result<()> {
+        let mut conn = Connection::open_in_memory()?;
+        let mut stream = conn.query_stream_arrow_with_params(
+            "SELECT * FROM nonexistent_table WHERE id = {id:UInt64}",
+            [("id", 1_u64)],
+        )?;
+
+        assert!(stream.next_batch().is_err());
+        assert!(stream.next_batch()?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_arrow_query_stream_with_params_syntax_error_fails_at_start() -> Result<()> {
+        let mut conn = Connection::open_in_memory()?;
+        let result =
+            conn.query_stream_arrow_with_params("SELECT invalid syntax here", [("x", 1_u64)]);
         assert!(result.is_err());
         Ok(())
     }

--- a/src/arrow_query_stream.rs
+++ b/src/arrow_query_stream.rs
@@ -16,7 +16,7 @@ use arrow::record_batch::RecordBatch;
 use crate::bindings;
 use crate::connection::Connection;
 use crate::error::{Error, Result};
-use crate::query_param::QueryParam;
+use crate::query_param::{EncodedParams, QueryParam};
 use crate::query_result::QueryResult;
 
 enum ArrowQueryStreamConnection<'a> {
@@ -137,8 +137,31 @@ impl<'a> ArrowQueryStream<'a> {
         V: Into<QueryParam>,
         I: IntoIterator<Item = (K, V)>,
     {
-        let _ = (conn, sql, params);
-        todo!("ArrowQueryStream::start_query_with_params")
+        let query_cstr = CString::new(sql)?;
+        let encoded = EncodedParams::encode(params)?;
+
+        let stream_ptr = unsafe {
+            bindings::chdb_stream_query_arrow_with_params(
+                conn,
+                query_cstr.as_ptr(),
+                std::ptr::null(),
+                encoded.names_ptr(),
+                encoded.values_ptr(),
+                encoded.len(),
+            )
+        };
+
+        if stream_ptr.is_null() {
+            return Err(Error::NoResult);
+        }
+
+        let probe = ManuallyDrop::new(QueryResult::new(stream_ptr));
+        if let Err(e) = probe.check_error_ref() {
+            let _ = ManuallyDrop::into_inner(probe);
+            return Err(e);
+        }
+
+        Ok(stream_ptr)
     }
 
     fn conn_handle(&self) -> bindings::chdb_connection {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -7,9 +7,12 @@ use std::ffi::{c_char, CString};
 #[cfg(all(feature = "arrow", direct_arrow_insert))]
 use crate::arrow_options::InsertOptions;
 #[cfg(feature = "arrow")]
+use crate::arrow_query_stream::ArrowQueryStream;
+#[cfg(feature = "arrow")]
 use crate::arrow_stream::{ArrowArray, ArrowSchema, ArrowStream};
 use crate::error::{Error, Result};
 use crate::format::OutputFormat;
+use crate::query_param::QueryParam;
 use crate::query_result::QueryResult;
 use crate::query_stream::QueryStream;
 use crate::{bindings, registry, CHDB_PROGRAM_NAME};
@@ -268,6 +271,42 @@ impl Connection {
         QueryStream::start_borrowed(self, sql, format)
     }
 
+    /// Execute a query with `{name:Type}` parameter binding and stream text chunks.
+    ///
+    /// Like [`Self::query_stream`], but SQL placeholders are bound from `params`
+    /// server-side before streaming begins.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use chdb_rust::connection::Connection;
+    /// use chdb_rust::format::OutputFormat;
+    ///
+    /// let conn = Connection::open_in_memory()?;
+    /// let mut stream = conn.query_stream_with_params(
+    ///     "SELECT {x:UInt64} AS v",
+    ///     OutputFormat::CSV,
+    ///     [("x", 11_u64)],
+    /// )?;
+    /// while let Some(chunk) = stream.next_chunk()? {
+    ///     print!("{}", chunk.data_utf8_lossy());
+    /// }
+    /// # Ok::<(), chdb_rust::error::Error>(())
+    /// ```
+    pub fn query_stream_with_params<'a, K, V, I>(
+        &'a self,
+        sql: &str,
+        format: OutputFormat,
+        params: I,
+    ) -> Result<QueryStream<'a>>
+    where
+        K: AsRef<str>,
+        V: Into<QueryParam>,
+        I: IntoIterator<Item = (K, V)>,
+    {
+        QueryStream::start_borrowed_with_params(self, sql, format, params)
+    }
+
     /// Execute a query and stream the result as Arrow record batches.
     ///
     /// Each call to [`Iterator::next`] or [`ArrowQueryStream::next_batch`] on the
@@ -294,6 +333,76 @@ impl Connection {
         sql: &str,
     ) -> Result<crate::arrow_query_stream::ArrowQueryStream<'a>> {
         crate::arrow_query_stream::ArrowQueryStream::start_borrowed(self, sql)
+    }
+
+    /// Execute a query with ClickHouse `{name:Type}` parameter binding.
+    ///
+    /// Parameter values are encoded and bound server-side; they are never
+    /// interpolated into the SQL text. Names in `params` need not match placeholder
+    /// order in the query.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use chdb_rust::connection::Connection;
+    /// use chdb_rust::format::OutputFormat;
+    ///
+    /// let conn = Connection::open_in_memory()?;
+    /// let result = conn.query_with_params(
+    ///     "SELECT {x:UInt64} + {y:UInt64} AS total",
+    ///     OutputFormat::CSV,
+    ///     [("x", 5_u64), ("y", 7_u64)],
+    /// )?;
+    /// # Ok::<(), chdb_rust::error::Error>(())
+    /// ```
+    pub fn query_with_params<K, V, I>(
+        &self,
+        sql: &str,
+        format: OutputFormat,
+        params: I,
+    ) -> Result<QueryResult>
+    where
+        K: AsRef<str>,
+        V: Into<QueryParam>,
+        I: IntoIterator<Item = (K, V)>,
+    {
+        let _ = (sql, format, params);
+        let _conn = unsafe { *self.inner };
+        todo!("Connection::query_with_params")
+    }
+
+    #[cfg(feature = "arrow")]
+    /// Execute a query with `{name:Type}` parameter binding and stream Arrow batches.
+    ///
+    /// Like [`Self::query_stream_arrow`], but SQL placeholders are bound from `params`
+    /// server-side before streaming begins.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use chdb_rust::connection::Connection;
+    ///
+    /// let conn = Connection::open_in_memory()?;
+    /// let mut stream = conn.query_stream_arrow_with_params(
+    ///     "SELECT {x:UInt64} AS v",
+    ///     [("x", 11_u64)],
+    /// )?;
+    /// while let Some(batch) = stream.next_batch()? {
+    ///     println!("rows: {}", batch.num_rows());
+    /// }
+    /// # Ok::<(), chdb_rust::error::Error>(())
+    /// ```
+    pub fn query_stream_arrow_with_params<'a, K, V, I>(
+        &'a self,
+        sql: &str,
+        params: I,
+    ) -> Result<ArrowQueryStream<'a>>
+    where
+        K: AsRef<str>,
+        V: Into<QueryParam>,
+        I: IntoIterator<Item = (K, V)>,
+    {
+        ArrowQueryStream::start_borrowed_with_params(self, sql, params)
     }
 
     #[cfg(feature = "arrow")]

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -274,7 +274,10 @@ impl Connection {
     /// Execute a query with ClickHouse `{name:Type}` parameter binding and stream text chunks.
     ///
     /// Like [`Self::query_stream`], but SQL placeholders are bound from `params`
-    /// before streaming begins.
+    /// before streaming begins. The connection is exclusively borrowed for the
+    /// stream's lifetime. Syntax errors fail when the stream is created. A
+    /// missing placeholder binding is reported on the first
+    /// [`QueryStream::next_chunk`], not at start.
     ///
     /// # Examples
     ///
@@ -293,6 +296,12 @@ impl Connection {
     /// }
     /// # Ok::<(), chdb_rust::error::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The query syntax is invalid
+    /// - The query cannot be started
     pub fn query_stream_with_params<'a, K, V, I>(
         &'a mut self,
         sql: &str,
@@ -337,9 +346,9 @@ impl Connection {
 
     /// Execute a query with ClickHouse `{name:Type}` parameter binding.
     ///
-    /// Parameter values are encoded and bound server-side; they are never
-    /// interpolated into the SQL text. Names in `params` need not match placeholder
-    /// order in the query.
+    /// Parameter values are encoded here and bound in the chDB library; they
+    /// are never interpolated into the SQL text. Names in `params` need not match placeholder
+    /// order in the query. An empty `params` list is a plain query.
     ///
     /// # Examples
     ///
@@ -355,6 +364,14 @@ impl Connection {
     /// )?;
     /// # Ok::<(), chdb_rust::error::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The query syntax is invalid
+    /// - A `{name:Type}` placeholder has no matching param
+    /// - A value cannot be parsed as the type declared in the placeholder
+    /// - The query execution fails for any other reason
     pub fn query_with_params<K, V, I>(
         &self,
         sql: &str,
@@ -403,7 +420,10 @@ impl Connection {
     /// Execute a query with ClickHouse `{name:Type}` parameter binding and stream Arrow batches.
     ///
     /// Like [`Self::query_stream_arrow`], but SQL placeholders are bound from `params`
-    /// server-side before streaming begins.
+    /// in the chDB library before streaming begins. The connection is exclusively borrowed
+    /// for the stream's lifetime. Syntax errors fail when the stream is created.
+    /// A missing placeholder binding is reported on the first
+    /// [`ArrowQueryStream::next_batch`], not at start.
     ///
     /// # Examples
     ///
@@ -420,6 +440,12 @@ impl Connection {
     /// }
     /// # Ok::<(), chdb_rust::error::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The query syntax is invalid
+    /// - The query cannot be started
     pub fn query_stream_arrow_with_params<'a, K, V, I>(
         &'a mut self,
         sql: &str,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -271,10 +271,10 @@ impl Connection {
         QueryStream::start_borrowed(self, sql, format)
     }
 
-    /// Execute a query with `{name:Type}` parameter binding and stream text chunks.
+    /// Execute a query with ClickHouse `{name:Type}` parameter binding and stream text chunks.
     ///
     /// Like [`Self::query_stream`], but SQL placeholders are bound from `params`
-    /// server-side before streaming begins.
+    /// before streaming begins.
     ///
     /// # Examples
     ///
@@ -351,7 +351,7 @@ impl Connection {
     /// let result = conn.query_with_params(
     ///     "SELECT {x:UInt64} + {y:UInt64} AS total",
     ///     OutputFormat::CSV,
-    ///     [("x", 5_u64), ("y", 7_u64)],
+    ///     [("y", 5_u64), ("x", 7_u64)],
     /// )?;
     /// # Ok::<(), chdb_rust::error::Error>(())
     /// ```
@@ -370,6 +370,15 @@ impl Connection {
         let format_cstr = CString::new(format.as_str())?;
         let encoded = EncodedParams::encode(params)?;
 
+        // SAFETY:
+        // - `self.inner` is non-null and points at a live `chdb_connection` for the
+        //   lifetime of `self` (set in `Connection::open`, freed only in `Drop`).
+        // - `query_cstr` and `format_cstr` are NUL-terminated and outlive this call.
+        // - `encoded` owns the name/value `CString`s; `names_ptr`/`values_ptr` alias
+        //   those buffers for the duration of the call. libchdb may read them only
+        //   during this call and must not retain the pointers afterward.
+        // - When `encoded.len() == 0`, both pointer args are null, which the C API
+        //   accepts for an empty parameter list.
         let conn = unsafe { *self.inner };
         let result_ptr = unsafe {
             bindings::chdb_query_with_params(
@@ -391,7 +400,7 @@ impl Connection {
     }
 
     #[cfg(feature = "arrow")]
-    /// Execute a query with `{name:Type}` parameter binding and stream Arrow batches.
+    /// Execute a query with ClickHouse `{name:Type}` parameter binding and stream Arrow batches.
     ///
     /// Like [`Self::query_stream_arrow`], but SQL placeholders are bound from `params`
     /// server-side before streaming begins.

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -282,7 +282,7 @@ impl Connection {
     /// use chdb_rust::connection::Connection;
     /// use chdb_rust::format::OutputFormat;
     ///
-    /// let conn = Connection::open_in_memory()?;
+    /// let mut conn = Connection::open_in_memory()?;
     /// let mut stream = conn.query_stream_with_params(
     ///     "SELECT {x:UInt64} AS v",
     ///     OutputFormat::CSV,
@@ -294,7 +294,7 @@ impl Connection {
     /// # Ok::<(), chdb_rust::error::Error>(())
     /// ```
     pub fn query_stream_with_params<'a, K, V, I>(
-        &'a self,
+        &'a mut self,
         sql: &str,
         format: OutputFormat,
         params: I,
@@ -410,7 +410,7 @@ impl Connection {
     /// ```no_run
     /// use chdb_rust::connection::Connection;
     ///
-    /// let conn = Connection::open_in_memory()?;
+    /// let mut conn = Connection::open_in_memory()?;
     /// let mut stream = conn.query_stream_arrow_with_params(
     ///     "SELECT {x:UInt64} AS v",
     ///     [("x", 11_u64)],
@@ -421,7 +421,7 @@ impl Connection {
     /// # Ok::<(), chdb_rust::error::Error>(())
     /// ```
     pub fn query_stream_arrow_with_params<'a, K, V, I>(
-        &'a self,
+        &'a mut self,
         sql: &str,
         params: I,
     ) -> Result<ArrowQueryStream<'a>>

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -12,7 +12,7 @@ use crate::arrow_query_stream::ArrowQueryStream;
 use crate::arrow_stream::{ArrowArray, ArrowSchema, ArrowStream};
 use crate::error::{Error, Result};
 use crate::format::OutputFormat;
-use crate::query_param::QueryParam;
+use crate::query_param::{EncodedParams, QueryParam};
 use crate::query_result::QueryResult;
 use crate::query_stream::QueryStream;
 use crate::{bindings, registry, CHDB_PROGRAM_NAME};
@@ -366,9 +366,28 @@ impl Connection {
         V: Into<QueryParam>,
         I: IntoIterator<Item = (K, V)>,
     {
-        let _ = (sql, format, params);
-        let _conn = unsafe { *self.inner };
-        todo!("Connection::query_with_params")
+        let query_cstr = CString::new(sql)?;
+        let format_cstr = CString::new(format.as_str())?;
+        let encoded = EncodedParams::encode(params)?;
+
+        let conn = unsafe { *self.inner };
+        let result_ptr = unsafe {
+            bindings::chdb_query_with_params(
+                conn,
+                query_cstr.as_ptr(),
+                format_cstr.as_ptr(),
+                encoded.names_ptr(),
+                encoded.values_ptr(),
+                encoded.len(),
+            )
+        };
+
+        if result_ptr.is_null() {
+            return Err(Error::NoResult);
+        }
+
+        let result = QueryResult::new(result_ptr);
+        result.check_error()
     }
 
     #[cfg(feature = "arrow")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,11 +89,15 @@ pub mod durable;
 pub mod error;
 pub mod format;
 pub mod log_level;
+pub mod query_param;
 pub mod query_result;
 pub mod query_stream;
 pub(crate) mod registry;
 pub mod session;
 pub mod version;
+
+pub use query_param::{QueryParam, QueryParams};
+pub use query_result::QueryResult;
 
 #[cfg(test)]
 mod test_utils;
@@ -104,7 +108,6 @@ use crate::arrow_query_stream::ArrowQueryStream;
 use crate::connection::Connection;
 use crate::error::Result;
 use crate::format::OutputFormat;
-use crate::query_result::QueryResult;
 use crate::query_stream::QueryStream;
 
 pub(crate) const CHDB_PROGRAM_NAME: &str = "clickhouse";
@@ -171,6 +174,40 @@ pub fn active_engine_refs() -> usize {
     registry::refs()
 }
 
+/// Execute a one-off parameterized query using an in-memory connection.
+///
+/// This is the parameterized counterpart to [`execute`]. Parameter values are
+/// bound server-side via ClickHouse `{name:Type}` placeholders.
+///
+/// # Examples
+///
+/// ```no_run
+/// use chdb_rust::arg::Arg;
+/// use chdb_rust::execute_with_params;
+/// use chdb_rust::format::OutputFormat;
+///
+/// let result = execute_with_params(
+///     "SELECT {x:UInt64} AS v",
+///     Some(&[Arg::OutputFormat(OutputFormat::CSV)]),
+///     [("x", 7_u64)],
+/// )?;
+/// # Ok::<(), chdb_rust::error::Error>(())
+/// ```
+pub fn execute_with_params<K, V, I>(
+    query: &str,
+    query_args: Option<&[Arg]>,
+    params: I,
+) -> Result<QueryResult>
+where
+    K: AsRef<str>,
+    V: Into<QueryParam>,
+    I: IntoIterator<Item = (K, V)>,
+{
+    let conn = Connection::open_in_memory()?;
+    let fmt = extract_output_format(query_args, OutputFormat::TabSeparated);
+    conn.query_with_params(query, fmt, params)
+}
+
 /// Execute a one-off streaming query using an in-memory connection.
 ///
 /// This function creates a temporary in-memory database connection, starts a
@@ -219,6 +256,42 @@ pub fn execute_stream(query: &str, query_args: Option<&[Arg]>) -> Result<QuerySt
     QueryStream::start_owned(conn, query, fmt)
 }
 
+/// Execute a one-off parameterized streaming query using an in-memory connection.
+///
+/// Parameterized counterpart to [`execute_stream`].
+///
+/// # Examples
+///
+/// ```no_run
+/// use chdb_rust::arg::Arg;
+/// use chdb_rust::execute_stream_with_params;
+/// use chdb_rust::format::OutputFormat;
+///
+/// let mut stream = execute_stream_with_params(
+///     "SELECT {x:UInt64} AS v",
+///     Some(&[Arg::OutputFormat(OutputFormat::CSV)]),
+///     [("x", 11_u64)],
+/// )?;
+/// while let Some(chunk) = stream.next_chunk()? {
+///     print!("{}", chunk.data_utf8_lossy());
+/// }
+/// # Ok::<(), chdb_rust::error::Error>(())
+/// ```
+pub fn execute_stream_with_params<K, V, I>(
+    query: &str,
+    query_args: Option<&[Arg]>,
+    params: I,
+) -> Result<QueryStream<'static>>
+where
+    K: AsRef<str>,
+    V: Into<QueryParam>,
+    I: IntoIterator<Item = (K, V)>,
+{
+    let conn = Connection::open_in_memory()?;
+    let fmt = extract_output_format(query_args, OutputFormat::TabSeparated);
+    QueryStream::start_owned_with_params(conn, query, fmt, params)
+}
+
 /// Execute a one-off Arrow streaming query using an in-memory connection.
 ///
 /// Returns an [`ArrowQueryStream`] that owns the temporary connection and yields
@@ -241,4 +314,34 @@ pub fn execute_stream(query: &str, query_args: Option<&[Arg]>) -> Result<QuerySt
 pub fn execute_stream_arrow(query: &str) -> Result<ArrowQueryStream<'static>> {
     let conn = Connection::open_in_memory()?;
     ArrowQueryStream::start_owned(conn, query)
+}
+
+/// Execute a one-off parameterized Arrow streaming query using an in-memory connection.
+///
+/// Parameterized counterpart to [`execute_stream_arrow`].
+///
+/// # Examples
+///
+/// ```no_run
+/// use chdb_rust::execute_stream_arrow_with_params;
+///
+/// let mut stream =
+///     execute_stream_arrow_with_params("SELECT {x:UInt64} AS v", [("x", 11_u64)])?;
+/// while let Some(batch) = stream.next_batch()? {
+///     println!("rows: {}", batch.num_rows());
+/// }
+/// # Ok::<(), chdb_rust::error::Error>(())
+/// ```
+#[cfg(feature = "arrow")]
+pub fn execute_stream_arrow_with_params<K, V, I>(
+    query: &str,
+    params: I,
+) -> Result<ArrowQueryStream<'static>>
+where
+    K: AsRef<str>,
+    V: Into<QueryParam>,
+    I: IntoIterator<Item = (K, V)>,
+{
+    let conn = Connection::open_in_memory()?;
+    ArrowQueryStream::start_owned_with_params(conn, query, params)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@
 //!
 //! - **Stateless queries**: Execute one-off queries without persistent storage
 //! - **Stateful sessions**: Create databases and tables with persistent storage
+//! - **Parameterized queries**: Bind ClickHouse `{name:Type}` placeholders with [`execute_with_params`] and [`QueryParam`]. Values are bound in the chDB library and never spliced into the SQL text
 //! - **Multiple output formats**: JSON, CSV, TabSeparated, and more
 //! - **Query result streaming**: Read large result sets in chunks with constant memory
 //! - **Arrow bulk insert** (feature `arrow`, on by default): [`insert_record_batch`](arrow_insert::insert_record_batch) via `ArrowStream('name')`. Use [`chdb_rust::arrow`](arrow) types so your Arrow version matches the crate.
@@ -176,8 +177,10 @@ pub fn active_engine_refs() -> usize {
 
 /// Execute a one-off query with ClickHouse `{name:Type}` parameter binding.
 ///
-/// Counterpart to [`execute`]. Parameter values are bound server-side and never
-/// interpolated into the SQL text.
+/// Counterpart to [`execute`]. Parameter values are bound in the chDB library
+/// and never interpolated into the SQL text. Names in `params` need not match placeholder
+/// order. An empty `params` list is a plain query: placeholders then fail with a
+/// substitution error.
 ///
 /// # Examples
 ///
@@ -193,6 +196,18 @@ pub fn active_engine_refs() -> usize {
 /// )?;
 /// # Ok::<(), chdb_rust::error::Error>(())
 /// ```
+///
+/// # Errors
+///
+/// This function will return an error if:
+/// - The query syntax is invalid
+/// - A `{name:Type}` placeholder has no matching param
+/// - A value cannot be parsed as the type declared in the placeholder
+/// - The connection cannot be established
+/// - The query execution fails
+/// - A connection is already open on a data path, since the in-memory
+///   connection this opens would be a second one. See
+///   [`Error::PathConflict`](error::Error::PathConflict).
 pub fn execute_with_params<K, V, I>(
     query: &str,
     query_args: Option<&[Arg]>,
@@ -258,7 +273,9 @@ pub fn execute_stream(query: &str, query_args: Option<&[Arg]>) -> Result<QuerySt
 
 /// Execute a one-off query with ClickHouse `{name:Type}` parameter binding and stream text chunks.
 ///
-/// Counterpart to [`execute_stream`].
+/// Counterpart to [`execute_stream`]. Syntax errors fail when the stream is
+/// created. A missing placeholder binding is reported on the first
+/// [`QueryStream::next_chunk`], not at start.
 ///
 /// # Examples
 ///
@@ -277,6 +294,15 @@ pub fn execute_stream(query: &str, query_args: Option<&[Arg]>) -> Result<QuerySt
 /// }
 /// # Ok::<(), chdb_rust::error::Error>(())
 /// ```
+///
+/// # Errors
+///
+/// This function will return an error if:
+/// - The query syntax is invalid
+/// - The connection cannot be established
+/// - The query cannot be started
+/// - A connection is already open on a data path. See
+///   [`Error::PathConflict`](error::Error::PathConflict).
 pub fn execute_stream_with_params<K, V, I>(
     query: &str,
     query_args: Option<&[Arg]>,
@@ -318,7 +344,9 @@ pub fn execute_stream_arrow(query: &str) -> Result<ArrowQueryStream<'static>> {
 
 /// Execute a one-off query with ClickHouse `{name:Type}` parameter binding and stream Arrow batches.
 ///
-/// Counterpart to [`execute_stream_arrow`].
+/// Counterpart to [`execute_stream_arrow`]. Syntax errors fail when the stream is
+/// created. A missing placeholder binding is reported on the first
+/// [`ArrowQueryStream::next_batch`], not at start.
 ///
 /// # Examples
 ///
@@ -332,6 +360,15 @@ pub fn execute_stream_arrow(query: &str) -> Result<ArrowQueryStream<'static>> {
 /// }
 /// # Ok::<(), chdb_rust::error::Error>(())
 /// ```
+///
+/// # Errors
+///
+/// This function will return an error if:
+/// - The query syntax is invalid
+/// - The connection cannot be established
+/// - The query cannot be started
+/// - A connection is already open on a data path. See
+///   [`Error::PathConflict`](error::Error::PathConflict).
 #[cfg(feature = "arrow")]
 pub fn execute_stream_arrow_with_params<K, V, I>(
     query: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,10 +174,10 @@ pub fn active_engine_refs() -> usize {
     registry::refs()
 }
 
-/// Execute a one-off parameterized query using an in-memory connection.
+/// Execute a one-off query with ClickHouse `{name:Type}` parameter binding.
 ///
-/// This is the parameterized counterpart to [`execute`]. Parameter values are
-/// bound server-side via ClickHouse `{name:Type}` placeholders.
+/// Counterpart to [`execute`]. Parameter values are bound server-side and never
+/// interpolated into the SQL text.
 ///
 /// # Examples
 ///
@@ -256,9 +256,9 @@ pub fn execute_stream(query: &str, query_args: Option<&[Arg]>) -> Result<QuerySt
     QueryStream::start_owned(conn, query, fmt)
 }
 
-/// Execute a one-off parameterized streaming query using an in-memory connection.
+/// Execute a one-off query with ClickHouse `{name:Type}` parameter binding and stream text chunks.
 ///
-/// Parameterized counterpart to [`execute_stream`].
+/// Counterpart to [`execute_stream`].
 ///
 /// # Examples
 ///
@@ -316,9 +316,9 @@ pub fn execute_stream_arrow(query: &str) -> Result<ArrowQueryStream<'static>> {
     ArrowQueryStream::start_owned(conn, query)
 }
 
-/// Execute a one-off parameterized Arrow streaming query using an in-memory connection.
+/// Execute a one-off query with ClickHouse `{name:Type}` parameter binding and stream Arrow batches.
 ///
-/// Parameterized counterpart to [`execute_stream_arrow`].
+/// Counterpart to [`execute_stream_arrow`].
 ///
 /// # Examples
 ///

--- a/src/query_param.rs
+++ b/src/query_param.rs
@@ -85,6 +85,8 @@ pub enum QueryParam {
     Text(String),
     /// Pre-formatted ClickHouse literal (e.g. `(7,'x')`, `[1, 2, 3]`).
     Raw(String),
+    /// ClickHouse `Array(...)` value, encoded as `[...]`.
+    Array(Vec<QueryParam>),
 }
 
 impl QueryParam {
@@ -93,7 +95,11 @@ impl QueryParam {
         Self::Raw(value.into())
     }
 
-    pub(crate) fn encode_nul_terminated(&self) -> Result<Cow<'_, str>> {
+    /// Encode this value as a root-level ClickHouse query parameter string.
+    ///
+    /// Root strings are unquoted. Nested values inside [`Self::Array`] use
+    /// nested rules (quoted strings, `NULL`).
+    pub fn encode(&self) -> Result<Cow<'_, str>> {
         Ok(match self {
             Self::Null => Cow::Borrowed("\\N"),
             Self::Bool(true) => Cow::Borrowed("true"),
@@ -102,7 +108,44 @@ impl QueryParam {
             Self::UInt64(value) => Cow::Owned(value.to_string()),
             Self::Float64(value) => Cow::Owned(value.to_string()),
             Self::Text(value) | Self::Raw(value) => Cow::Borrowed(value),
+            Self::Array(values) => Cow::Owned(Self::encode_array(values)?),
         })
+    }
+
+    /// Encode this value as an element inside an array/tuple/map literal.
+    fn encode_nested(&self) -> Result<Cow<'_, str>> {
+        Ok(match self {
+            Self::Null => Cow::Borrowed("NULL"),
+            Self::Bool(true) => Cow::Borrowed("true"),
+            Self::Bool(false) => Cow::Borrowed("false"),
+            Self::Int64(value) => Cow::Owned(value.to_string()),
+            Self::UInt64(value) => Cow::Owned(value.to_string()),
+            Self::Float64(value) => Cow::Owned(value.to_string()),
+            Self::Text(value) => Cow::Owned(Self::quote_nested_string(value)),
+            Self::Raw(value) => Cow::Borrowed(value),
+            Self::Array(values) => Cow::Owned(Self::encode_array(values)?),
+        })
+    }
+
+    fn encode_array(values: &[QueryParam]) -> Result<String> {
+        let mut parts = Vec::with_capacity(values.len());
+        for value in values {
+            parts.push(value.encode_nested()?.into_owned());
+        }
+        Ok(format!("[{}]", parts.join(", ")))
+    }
+
+    fn quote_nested_string(value: &str) -> String {
+        let mut encoded = String::with_capacity(value.len() + 2);
+        encoded.push('\'');
+        for ch in value.chars() {
+            if ch == '\'' || ch == '\\' {
+                encoded.push('\\');
+            }
+            encoded.push(ch);
+        }
+        encoded.push('\'');
+        encoded
     }
 }
 
@@ -129,7 +172,7 @@ impl EncodedParams {
 
         for (name, value) in params {
             let param = value.into();
-            let encoded = param.encode_nul_terminated()?;
+            let encoded = param.encode()?;
             name_cstrs.push(CString::new(name.as_ref())?);
             value_cstrs.push(CString::new(encoded.as_ref())?);
         }
@@ -264,36 +307,20 @@ where
     }
 }
 
-impl From<Vec<u64>> for QueryParam {
-    fn from(values: Vec<u64>) -> Self {
-        let body = values
-            .into_iter()
-            .map(|value| value.to_string())
-            .collect::<Vec<_>>()
-            .join(", ");
-        Self::Raw(format!("[{body}]"))
+impl<T> From<Vec<T>> for QueryParam
+where
+    T: Into<QueryParam>,
+{
+    fn from(values: Vec<T>) -> Self {
+        Self::Array(values.into_iter().map(Into::into).collect())
     }
 }
 
-impl From<Vec<i64>> for QueryParam {
-    fn from(values: Vec<i64>) -> Self {
-        let body = values
-            .into_iter()
-            .map(|value| value.to_string())
-            .collect::<Vec<_>>()
-            .join(", ");
-        Self::Raw(format!("[{body}]"))
-    }
-}
-
-impl From<&[u64]> for QueryParam {
-    fn from(values: &[u64]) -> Self {
-        Self::from(values.to_vec())
-    }
-}
-
-impl From<&[i64]> for QueryParam {
-    fn from(values: &[i64]) -> Self {
+impl<T> From<&[T]> for QueryParam
+where
+    T: Into<QueryParam> + Clone,
+{
+    fn from(values: &[T]) -> Self {
         Self::from(values.to_vec())
     }
 }

--- a/src/query_param.rs
+++ b/src/query_param.rs
@@ -6,6 +6,7 @@
 //! annotation in the SQL text.
 
 use std::borrow::Cow;
+use std::ffi::{c_char, CString};
 
 use crate::error::Result;
 
@@ -32,6 +33,40 @@ use crate::error::Result;
 #[derive(Debug, Default, Clone)]
 pub struct QueryParams {
     pairs: Vec<(String, QueryParam)>,
+}
+
+impl QueryParams {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn bind(mut self, name: impl AsRef<str>, value: impl Into<QueryParam>) -> Self {
+        self.pairs.push((name.as_ref().to_owned(), value.into()));
+        self
+    }
+}
+
+impl IntoIterator for QueryParams {
+    type Item = (String, QueryParam);
+    type IntoIter = std::vec::IntoIter<(String, QueryParam)>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.pairs.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a QueryParams {
+    type Item = (&'a str, &'a QueryParam);
+    type IntoIter = std::iter::Map<
+        std::slice::Iter<'a, (String, QueryParam)>,
+        fn(&'a (String, QueryParam)) -> (&'a str, &'a QueryParam),
+    >;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.pairs
+            .iter()
+            .map(|(name, value)| (name.as_str(), value))
+    }
 }
 
 /// A value bound to a `{name:Type}` placeholder in a parameterized query.
@@ -71,37 +106,65 @@ impl QueryParam {
     }
 }
 
-impl QueryParams {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn bind(mut self, name: impl AsRef<str>, value: impl Into<QueryParam>) -> Self {
-        self.pairs.push((name.as_ref().to_owned(), value.into()));
-        self
-    }
+/// NUL-terminated name/value C strings ready for `chdb_query_with_params`.
+///
+/// Pointers returned by [`Self::names_ptr`] / [`Self::values_ptr`] are valid only
+/// while this struct remains alive.
+pub(crate) struct EncodedParams {
+    _name_cstrs: Vec<CString>,
+    _value_cstrs: Vec<CString>,
+    name_ptrs: Vec<*const c_char>,
+    value_ptrs: Vec<*const c_char>,
 }
 
-impl IntoIterator for QueryParams {
-    type Item = (String, QueryParam);
-    type IntoIter = std::vec::IntoIter<(String, QueryParam)>;
+impl EncodedParams {
+    pub(crate) fn encode<K, V, I>(params: I) -> Result<Self>
+    where
+        K: AsRef<str>,
+        V: Into<QueryParam>,
+        I: IntoIterator<Item = (K, V)>,
+    {
+        let mut name_cstrs = Vec::new();
+        let mut value_cstrs = Vec::new();
 
-    fn into_iter(self) -> Self::IntoIter {
-        self.pairs.into_iter()
+        for (name, value) in params {
+            let param = value.into();
+            let encoded = param.encode_nul_terminated()?;
+            name_cstrs.push(CString::new(name.as_ref())?);
+            value_cstrs.push(CString::new(encoded.as_ref())?);
+        }
+
+        let name_ptrs = name_cstrs.iter().map(|s| s.as_ptr()).collect();
+        let value_ptrs = value_cstrs.iter().map(|s| s.as_ptr()).collect();
+
+        Ok(Self {
+            _name_cstrs: name_cstrs,
+            _value_cstrs: value_cstrs,
+            name_ptrs,
+            value_ptrs,
+        })
     }
-}
 
-impl<'a> IntoIterator for &'a QueryParams {
-    type Item = (&'a str, &'a QueryParam);
-    type IntoIter = std::iter::Map<
-        std::slice::Iter<'a, (String, QueryParam)>,
-        fn(&'a (String, QueryParam)) -> (&'a str, &'a QueryParam),
-    >;
+    pub(crate) fn len(&self) -> usize {
+        self.name_ptrs.len()
+    }
 
-    fn into_iter(self) -> Self::IntoIter {
-        self.pairs
-            .iter()
-            .map(|(name, value)| (name.as_str(), value))
+    /// Pointer to the parallel name C-string array, or null when empty.
+    pub(crate) fn names_ptr(&self) -> *const *const c_char {
+        if self.name_ptrs.is_empty() {
+            std::ptr::null()
+        } else {
+            self.name_ptrs.as_ptr()
+        }
+    }
+
+    /// Pointer to the parallel value C-string array, or null when empty.
+    pub(crate) fn values_ptr(&self) -> *const *const c_char {
+        if self.value_ptrs.is_empty() {
+            std::ptr::null()
+        } else {
+            self.value_ptrs.as_ptr()
+        }
     }
 }
 
@@ -266,5 +329,43 @@ mod tests {
         assert_eq!(collected[0].1, QueryParam::UInt64(5));
         assert_eq!(collected[1].0, "label");
         assert_eq!(collected[1].1, QueryParam::Text("ok".into()));
+    }
+
+    #[test]
+    fn encoded_params_empty_exposes_null_name_and_value_ptrs() -> Result<()> {
+        let encoded = EncodedParams::encode(std::iter::empty::<(&str, QueryParam)>())?;
+
+        assert_eq!(encoded.len(), 0);
+        assert!(encoded.names_ptr().is_null());
+        assert!(encoded.values_ptr().is_null());
+        Ok(())
+    }
+
+    #[test]
+    fn encoded_params_exposes_parallel_name_and_value_ptrs() -> Result<()> {
+        use std::ffi::CStr;
+
+        let encoded = EncodedParams::encode([
+            ("x", QueryParam::from(5_u64)),
+            ("label", QueryParam::from("ok")),
+        ])?;
+
+        assert_eq!(encoded.len(), 2);
+        assert!(!encoded.names_ptr().is_null());
+        assert!(!encoded.values_ptr().is_null());
+
+        unsafe {
+            assert_eq!(CStr::from_ptr(*encoded.names_ptr()).to_bytes(), b"x");
+            assert_eq!(
+                CStr::from_ptr(*encoded.names_ptr().add(1)).to_bytes(),
+                b"label"
+            );
+            assert_eq!(CStr::from_ptr(*encoded.values_ptr()).to_bytes(), b"5");
+            assert_eq!(
+                CStr::from_ptr(*encoded.values_ptr().add(1)).to_bytes(),
+                b"ok"
+            );
+        }
+        Ok(())
     }
 }

--- a/src/query_param.rs
+++ b/src/query_param.rs
@@ -2,8 +2,8 @@
 //!
 //! Values are encoded as strings for the libchdb C API.
 //!
-//! After the encoded values have been sent to chDB, the engine resolves types from the placeholder
-//! annotation in the SQL text.
+//! After the encoded values have been sent to chDB, they are parsed by the chDB core library and
+//! substituted in the query during planning.
 
 use std::borrow::Cow;
 use std::ffi::{c_char, CString};
@@ -300,24 +300,172 @@ impl From<&[i64]> for QueryParam {
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::CStr;
+
     use super::*;
 
     #[test]
-    fn encodes_scalars_for_nul_terminated_api() -> Result<()> {
-        assert_eq!(QueryParam::from(42_i64).encode_nul_terminated()?, "42");
-        assert_eq!(QueryParam::from(true).encode_nul_terminated()?, "true");
-        assert_eq!(QueryParam::from("hello").encode_nul_terminated()?, "hello");
-        assert_eq!(QueryParam::Null.encode_nul_terminated()?, "\\N");
+    fn encode_root_covers_every_variant() -> Result<()> {
+        assert_eq!(QueryParam::Null.encode()?, "\\N");
+        assert_eq!(QueryParam::Bool(true).encode()?, "true");
+        assert_eq!(QueryParam::Bool(false).encode()?, "false");
+        assert_eq!(QueryParam::Int64(-42).encode()?, "-42");
+        assert_eq!(QueryParam::UInt64(42).encode()?, "42");
+        assert_eq!(QueryParam::Float64(1.5).encode()?, "1.5");
+        assert_eq!(QueryParam::Text(String::new()).encode()?, "");
+        assert_eq!(QueryParam::Text("hello".into()).encode()?, "hello");
+        assert_eq!(QueryParam::Text("it's".into()).encode()?, "it's");
+        assert_eq!(QueryParam::Text(r"a\b".into()).encode()?, r"a\b");
+        assert_eq!(QueryParam::raw("").encode()?, "");
+        assert_eq!(QueryParam::raw("(7,'x')").encode()?, "(7,'x')");
+        assert_eq!(QueryParam::raw("[1, 2, 3]").encode()?, "[1, 2, 3]");
+        assert_eq!(QueryParam::Array(vec![]).encode()?, "[]");
+        assert_eq!(
+            QueryParam::Array(vec![QueryParam::Int64(1), QueryParam::Int64(2)]).encode()?,
+            "[1, 2]"
+        );
         Ok(())
     }
 
     #[test]
-    fn encodes_array_as_clickhouse_literal() -> Result<()> {
+    fn encode_nested_covers_every_variant_via_array() -> Result<()> {
         assert_eq!(
-            QueryParam::from(vec![1_u64, 2, 3]).encode_nul_terminated()?,
-            "[1, 2, 3]"
+            QueryParam::Array(vec![QueryParam::Null]).encode()?,
+            "[NULL]"
+        );
+        assert_eq!(
+            QueryParam::Array(vec![QueryParam::Bool(true), QueryParam::Bool(false)]).encode()?,
+            "[true, false]"
+        );
+        assert_eq!(
+            QueryParam::Array(vec![QueryParam::Int64(-1), QueryParam::UInt64(2)]).encode()?,
+            "[-1, 2]"
+        );
+        assert_eq!(
+            QueryParam::Array(vec![QueryParam::Float64(1.5)]).encode()?,
+            "[1.5]"
+        );
+        assert_eq!(
+            QueryParam::Array(vec![QueryParam::Text(String::new())]).encode()?,
+            "['']"
+        );
+        assert_eq!(
+            QueryParam::Array(vec![QueryParam::Text("hello".into())]).encode()?,
+            "['hello']"
+        );
+        assert_eq!(
+            QueryParam::Array(vec![QueryParam::raw("(7,'x')")]).encode()?,
+            "[(7,'x')]"
+        );
+        assert_eq!(
+            QueryParam::Array(vec![QueryParam::Array(vec![
+                QueryParam::Int64(1),
+                QueryParam::Int64(2),
+            ])])
+            .encode()?,
+            "[[1, 2]]"
         );
         Ok(())
+    }
+
+    #[test]
+    fn encode_nested_escapes_quotes_and_backslashes_in_text() -> Result<()> {
+        assert_eq!(
+            QueryParam::Array(vec![QueryParam::Text("'".into())]).encode()?,
+            r"['\'']"
+        );
+        assert_eq!(
+            QueryParam::Array(vec![QueryParam::Text(r"\".into())]).encode()?,
+            r"['\\']"
+        );
+        assert_eq!(
+            QueryParam::Array(vec![QueryParam::Text("it's".into())]).encode()?,
+            r"['it\'s']"
+        );
+        assert_eq!(
+            QueryParam::Array(vec![QueryParam::Text(r"a\b".into())]).encode()?,
+            r"['a\\b']"
+        );
+        assert_eq!(
+            QueryParam::Array(vec![QueryParam::Text(r"'\".into())]).encode()?,
+            r"['\'\\']"
+        );
+        assert_eq!(
+            QueryParam::Array(vec![
+                QueryParam::Text("a".into()),
+                QueryParam::Text("b".into()),
+            ])
+            .encode()?,
+            "['a', 'b']"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn encode_array_mixed_and_nested_shapes() -> Result<()> {
+        assert_eq!(
+            QueryParam::Array(vec![
+                QueryParam::Int64(1),
+                QueryParam::Null,
+                QueryParam::Text("x".into()),
+                QueryParam::Bool(true),
+            ])
+            .encode()?,
+            "[1, NULL, 'x', true]"
+        );
+        assert_eq!(
+            QueryParam::Array(vec![
+                QueryParam::Array(vec![QueryParam::Int64(1), QueryParam::Int64(2)]),
+                QueryParam::Array(vec![QueryParam::Int64(3), QueryParam::Int64(4)]),
+            ])
+            .encode()?,
+            "[[1, 2], [3, 4]]"
+        );
+        assert_eq!(
+            QueryParam::Array(vec![QueryParam::Array(vec![QueryParam::Text(
+                "it's".into()
+            )])])
+            .encode()?,
+            r"[['it\'s']]"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn from_option_none_encodes_as_root_null() -> Result<()> {
+        let value: Option<i64> = None;
+        assert_eq!(QueryParam::from(value).encode()?, "\\N");
+        Ok(())
+    }
+
+    #[test]
+    fn from_vec_and_slice_encode_as_arrays() -> Result<()> {
+        assert_eq!(QueryParam::from(Vec::<u64>::new()).encode()?, "[]");
+        assert_eq!(QueryParam::from(vec![1_u64, 2, 3]).encode()?, "[1, 2, 3]");
+        assert_eq!(QueryParam::from(vec![1_i32, 2, 3]).encode()?, "[1, 2, 3]");
+        assert_eq!(
+            QueryParam::from([4_i64, 5, 6].as_slice()).encode()?,
+            "[4, 5, 6]"
+        );
+        assert_eq!(
+            QueryParam::from(vec!["a".to_owned(), "b".to_owned()]).encode()?,
+            "['a', 'b']"
+        );
+        let values: Vec<Option<i64>> = vec![Some(1), None, Some(3)];
+        assert_eq!(QueryParam::from(values).encode()?, "[1, NULL, 3]");
+        assert_eq!(
+            QueryParam::from(vec![vec![1_u64, 2], vec![3, 4]]).encode()?,
+            "[[1, 2], [3, 4]]"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn from_vec_builds_array_variant() {
+        assert_eq!(
+            QueryParam::from(vec![1_i64, 2]),
+            QueryParam::Array(vec![QueryParam::Int64(1), QueryParam::Int64(2)])
+        );
     }
 
     #[test]
@@ -343,8 +491,6 @@ mod tests {
 
     #[test]
     fn encoded_params_exposes_parallel_name_and_value_ptrs() -> Result<()> {
-        use std::ffi::CStr;
-
         let encoded = EncodedParams::encode([
             ("x", QueryParam::from(5_u64)),
             ("label", QueryParam::from("ok")),

--- a/src/query_param.rs
+++ b/src/query_param.rs
@@ -137,9 +137,45 @@ impl QueryParam {
             Self::Int64(value) => Cow::Owned(value.to_string()),
             Self::UInt64(value) => Cow::Owned(value.to_string()),
             Self::Float64(value) => Cow::Owned(value.to_string()),
-            Self::Text(value) | Self::Raw(value) => Cow::Borrowed(value),
+            Self::Text(value) => Self::encode_text(value),
+            Self::Raw(value) => Cow::Borrowed(value),
             Self::Array(values) => Cow::Owned(Self::encode_array(values)?),
         })
+    }
+
+    /// Escape `\`, tab, and newline so `deserializeTextEscaped` reconstructs `value`.
+    fn encode_text(value: &str) -> Cow<'_, str> {
+        let mut encoded = None;
+        let mut last = 0;
+
+        for (i, ch) in value.char_indices() {
+            let esc = match ch {
+                '\\' => r"\\",
+                '\t' => r"\t",
+                '\n' => r"\n",
+                _ => continue,
+            };
+            let buf = encoded.get_or_insert_with(|| String::with_capacity(value.len()));
+            buf.push_str(&value[last..i]);
+            buf.push_str(esc);
+            last = i + ch.len_utf8();
+        }
+
+        match encoded {
+            None => Cow::Borrowed(value),
+            Some(mut buf) => {
+                buf.push_str(&value[last..]);
+                Cow::Owned(buf)
+            }
+        }
+    }
+
+    fn encode_array(values: &[QueryParam]) -> Result<String> {
+        let mut parts = Vec::with_capacity(values.len());
+        for value in values {
+            parts.push(value.encode_nested()?.into_owned());
+        }
+        Ok(format!("[{}]", parts.join(", ")))
     }
 
     /// Encode this value as an element inside an array/tuple/map literal.
@@ -157,22 +193,18 @@ impl QueryParam {
         })
     }
 
-    fn encode_array(values: &[QueryParam]) -> Result<String> {
-        let mut parts = Vec::with_capacity(values.len());
-        for value in values {
-            parts.push(value.encode_nested()?.into_owned());
-        }
-        Ok(format!("[{}]", parts.join(", ")))
-    }
-
+    /// Quote `value` as an array or tuple element, escaping `\`, tab, newline, and `'`.
     fn quote_nested_string(value: &str) -> String {
         let mut encoded = String::with_capacity(value.len() + 2);
         encoded.push('\'');
         for ch in value.chars() {
-            if ch == '\'' || ch == '\\' {
-                encoded.push('\\');
+            match ch {
+                '\\' => encoded.push_str(r"\\"),
+                '\t' => encoded.push_str(r"\t"),
+                '\n' => encoded.push_str(r"\n"),
+                '\'' => encoded.push_str(r"\'"),
+                other => encoded.push(other),
             }
-            encoded.push(ch);
         }
         encoded.push('\'');
         encoded
@@ -374,7 +406,7 @@ mod tests {
         assert_eq!(QueryParam::Text(String::new()).encode()?, "");
         assert_eq!(QueryParam::Text("hello".into()).encode()?, "hello");
         assert_eq!(QueryParam::Text("it's".into()).encode()?, "it's");
-        assert_eq!(QueryParam::Text(r"a\b".into()).encode()?, r"a\b");
+        assert_eq!(QueryParam::Text(r"a\b".into()).encode()?, r"a\\b");
         assert_eq!(QueryParam::raw("").encode()?, "");
         assert_eq!(QueryParam::raw("(7,'x')").encode()?, "(7,'x')");
         assert_eq!(QueryParam::raw("[1, 2, 3]").encode()?, "[1, 2, 3]");
@@ -383,6 +415,30 @@ mod tests {
             QueryParam::Array(vec![QueryParam::Int64(1), QueryParam::Int64(2)]).encode()?,
             "[1, 2]"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn encode_text_escapes_sequences_so_chdb_sees_a_literal() -> Result<()> {
+        assert_eq!(QueryParam::Text(r"C:\temp".into()).encode()?, r"C:\\temp");
+        assert_eq!(QueryParam::Text(r"\".into()).encode()?, r"\\");
+        assert_eq!(QueryParam::Text(r"\\".into()).encode()?, r"\\\\");
+        assert_eq!(QueryParam::Text("a\tb".into()).encode()?, r"a\tb");
+        assert_eq!(QueryParam::Text("a\nb".into()).encode()?, r"a\nb");
+        assert_eq!(QueryParam::Text("it's".into()).encode()?, "it's");
+        assert_eq!(QueryParam::Text("a\rb".into()).encode()?, "a\rb");
+        assert_eq!(QueryParam::Text("a\u{08}b".into()).encode()?, "a\u{08}b");
+        assert_eq!(QueryParam::Text("a\u{0c}b".into()).encode()?, "a\u{0c}b");
+        assert_eq!(QueryParam::Text("a\0b".into()).encode()?, "a\0b");
+        assert_eq!(QueryParam::Text("hello".into()).encode()?, "hello");
+        Ok(())
+    }
+
+    #[test]
+    fn encode_raw_passes_escape_sequences_through_unchanged() -> Result<()> {
+        assert_eq!(QueryParam::raw(r"C:\temp").encode()?, r"C:\temp");
+        assert_eq!(QueryParam::raw("a\tb").encode()?, "a\tb");
+        assert_eq!(QueryParam::raw(r"it\'s").encode()?, r"it\'s");
         Ok(())
     }
 
@@ -448,6 +504,18 @@ mod tests {
         assert_eq!(
             QueryParam::Array(vec![QueryParam::Text(r"'\".into())]).encode()?,
             r"['\'\\']"
+        );
+        assert_eq!(
+            QueryParam::Array(vec![QueryParam::Text(r"C:\temp".into())]).encode()?,
+            r"['C:\\temp']"
+        );
+        assert_eq!(
+            QueryParam::Array(vec![QueryParam::Text("a\tb".into())]).encode()?,
+            r"['a\tb']"
+        );
+        assert_eq!(
+            QueryParam::Array(vec![QueryParam::Text("a\nb".into())]).encode()?,
+            r"['a\nb']"
         );
         assert_eq!(
             QueryParam::Array(vec![

--- a/src/query_param.rs
+++ b/src/query_param.rs
@@ -1,0 +1,270 @@
+//! ClickHouse query parameter values for `{name:Type}` placeholders.
+//!
+//! Values are encoded as strings for the libchdb C API.
+//!
+//! After the encoded values have been sent to chDB, the engine resolves types from the placeholder
+//! annotation in the SQL text.
+
+use std::borrow::Cow;
+
+use crate::error::Result;
+
+/// Builder for mixed-type parameter maps.
+///
+/// # Examples
+///
+/// ```no_run
+/// use chdb_rust::connection::Connection;
+/// use chdb_rust::format::OutputFormat;
+/// use chdb_rust::query_param::QueryParams;
+///
+/// let conn = Connection::open_in_memory()?;
+/// let params = QueryParams::new()
+///     .bind("x", 5_u64)
+///     .bind("label", "ok");
+/// let _ = conn.query_with_params(
+///     "SELECT {x:UInt64} AS x, {label:String} AS label",
+///     OutputFormat::CSV,
+///     params,
+/// )?;
+/// # Ok::<(), chdb_rust::error::Error>(())
+/// ```
+#[derive(Debug, Default, Clone)]
+pub struct QueryParams {
+    pairs: Vec<(String, QueryParam)>,
+}
+
+/// A value bound to a `{name:Type}` placeholder in a parameterized query.
+///
+/// Use [`From`] conversions for scalars, strings, options, and arrays. For pre-formatted
+/// ClickHouse literals (tuples, etc.), use [`Self::raw`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum QueryParam {
+    /// SQL NULL for `Nullable(...)` placeholders (`\N`).
+    Null,
+    Bool(bool),
+    Int64(i64),
+    UInt64(u64),
+    Float64(f64),
+    /// Raw text for `String`, `Date`, `Identifier`, and similar placeholders.
+    Text(String),
+    /// Pre-formatted ClickHouse literal (e.g. `(7,'x')`, `[1, 2, 3]`).
+    Raw(String),
+}
+
+impl QueryParam {
+    /// Pass a pre-formatted ClickHouse parameter literal through unchanged.
+    pub fn raw(value: impl Into<String>) -> Self {
+        Self::Raw(value.into())
+    }
+
+    pub(crate) fn encode_nul_terminated(&self) -> Result<Cow<'_, str>> {
+        Ok(match self {
+            Self::Null => Cow::Borrowed("\\N"),
+            Self::Bool(true) => Cow::Borrowed("true"),
+            Self::Bool(false) => Cow::Borrowed("false"),
+            Self::Int64(value) => Cow::Owned(value.to_string()),
+            Self::UInt64(value) => Cow::Owned(value.to_string()),
+            Self::Float64(value) => Cow::Owned(value.to_string()),
+            Self::Text(value) | Self::Raw(value) => Cow::Borrowed(value),
+        })
+    }
+}
+
+impl QueryParams {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn bind(mut self, name: impl AsRef<str>, value: impl Into<QueryParam>) -> Self {
+        self.pairs.push((name.as_ref().to_owned(), value.into()));
+        self
+    }
+}
+
+impl IntoIterator for QueryParams {
+    type Item = (String, QueryParam);
+    type IntoIter = std::vec::IntoIter<(String, QueryParam)>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.pairs.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a QueryParams {
+    type Item = (&'a str, &'a QueryParam);
+    type IntoIter = std::iter::Map<
+        std::slice::Iter<'a, (String, QueryParam)>,
+        fn(&'a (String, QueryParam)) -> (&'a str, &'a QueryParam),
+    >;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.pairs
+            .iter()
+            .map(|(name, value)| (name.as_str(), value))
+    }
+}
+
+impl From<bool> for QueryParam {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<i8> for QueryParam {
+    fn from(value: i8) -> Self {
+        Self::Int64(i64::from(value))
+    }
+}
+
+impl From<i16> for QueryParam {
+    fn from(value: i16) -> Self {
+        Self::Int64(i64::from(value))
+    }
+}
+
+impl From<i32> for QueryParam {
+    fn from(value: i32) -> Self {
+        Self::Int64(i64::from(value))
+    }
+}
+
+impl From<i64> for QueryParam {
+    fn from(value: i64) -> Self {
+        Self::Int64(value)
+    }
+}
+
+impl From<u8> for QueryParam {
+    fn from(value: u8) -> Self {
+        Self::UInt64(u64::from(value))
+    }
+}
+
+impl From<u16> for QueryParam {
+    fn from(value: u16) -> Self {
+        Self::UInt64(u64::from(value))
+    }
+}
+
+impl From<u32> for QueryParam {
+    fn from(value: u32) -> Self {
+        Self::UInt64(u64::from(value))
+    }
+}
+
+impl From<u64> for QueryParam {
+    fn from(value: u64) -> Self {
+        Self::UInt64(value)
+    }
+}
+
+impl From<f32> for QueryParam {
+    fn from(value: f32) -> Self {
+        Self::Float64(f64::from(value))
+    }
+}
+
+impl From<f64> for QueryParam {
+    fn from(value: f64) -> Self {
+        Self::Float64(value)
+    }
+}
+
+impl From<String> for QueryParam {
+    fn from(value: String) -> Self {
+        Self::Text(value)
+    }
+}
+
+impl From<&str> for QueryParam {
+    fn from(value: &str) -> Self {
+        Self::Text(value.to_owned())
+    }
+}
+
+impl From<&QueryParam> for QueryParam {
+    fn from(value: &QueryParam) -> Self {
+        value.clone()
+    }
+}
+
+impl<T> From<Option<T>> for QueryParam
+where
+    T: Into<QueryParam>,
+{
+    fn from(value: Option<T>) -> Self {
+        match value {
+            None => Self::Null,
+            Some(value) => value.into(),
+        }
+    }
+}
+
+impl From<Vec<u64>> for QueryParam {
+    fn from(values: Vec<u64>) -> Self {
+        let body = values
+            .into_iter()
+            .map(|value| value.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        Self::Raw(format!("[{body}]"))
+    }
+}
+
+impl From<Vec<i64>> for QueryParam {
+    fn from(values: Vec<i64>) -> Self {
+        let body = values
+            .into_iter()
+            .map(|value| value.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        Self::Raw(format!("[{body}]"))
+    }
+}
+
+impl From<&[u64]> for QueryParam {
+    fn from(values: &[u64]) -> Self {
+        Self::from(values.to_vec())
+    }
+}
+
+impl From<&[i64]> for QueryParam {
+    fn from(values: &[i64]) -> Self {
+        Self::from(values.to_vec())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encodes_scalars_for_nul_terminated_api() -> Result<()> {
+        assert_eq!(QueryParam::from(42_i64).encode_nul_terminated()?, "42");
+        assert_eq!(QueryParam::from(true).encode_nul_terminated()?, "true");
+        assert_eq!(QueryParam::from("hello").encode_nul_terminated()?, "hello");
+        assert_eq!(QueryParam::Null.encode_nul_terminated()?, "\\N");
+        Ok(())
+    }
+
+    #[test]
+    fn encodes_array_as_clickhouse_literal() -> Result<()> {
+        assert_eq!(
+            QueryParam::from(vec![1_u64, 2, 3]).encode_nul_terminated()?,
+            "[1, 2, 3]"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn query_params_builder_collects_mixed_types() {
+        let params = QueryParams::new().bind("x", 5_u64).bind("label", "ok");
+        let collected: Vec<_> = params.into_iter().collect();
+        assert_eq!(collected.len(), 2);
+        assert_eq!(collected[0].0, "x");
+        assert_eq!(collected[0].1, QueryParam::UInt64(5));
+        assert_eq!(collected[1].0, "label");
+        assert_eq!(collected[1].1, QueryParam::Text("ok".into()));
+    }
+}

--- a/src/query_param.rs
+++ b/src/query_param.rs
@@ -1,9 +1,16 @@
 //! ClickHouse query parameter values for `{name:Type}` placeholders.
 //!
-//! Values are encoded as strings for the libchdb C API.
+//! Values are encoded as strings for the libchdb C API. The SQL still names the
+//! ClickHouse type; this crate does not interpolate values into the query text.
+//! After chDB receives the encoded strings, it parses them and substitutes them
+//! during planning.
 //!
-//! After the encoded values have been sent to chDB, they are parsed by the chDB core library and
-//! substituted in the query during planning.
+//! ```no_run
+//! use chdb_rust::execute_with_params;
+//!
+//! let result = execute_with_params("SELECT {x:UInt64} AS v", None, [("x", 7_u64)])?;
+//! # Ok::<(), chdb_rust::error::Error>(())
+//! ```
 
 use std::borrow::Cow;
 use std::ffi::{c_char, CString};
@@ -11,6 +18,11 @@ use std::ffi::{c_char, CString};
 use crate::error::Result;
 
 /// Builder for mixed-type parameter maps.
+///
+/// An iterator of `(name, value)` pairs is enough when every value converts to
+/// the same [`QueryParam`] type. Use this builder when the types differ, or when
+/// you want to assemble the map incrementally. Binding the same name twice keeps
+/// the later value.
 ///
 /// # Examples
 ///
@@ -36,10 +48,19 @@ pub struct QueryParams {
 }
 
 impl QueryParams {
+    /// An empty parameter map.
+    ///
+    /// Passing this to a query that still has `{name:Type}` placeholders fails
+    /// with a substitution error. A query with no placeholders runs as a plain
+    /// query.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Append a named value and return the map for further binds.
+    ///
+    /// `name` is the identifier inside `{name:Type}`. A second bind of the same
+    /// name replaces the earlier value at query time (last write wins).
     pub fn bind(mut self, name: impl AsRef<str>, value: impl Into<QueryParam>) -> Self {
         self.pairs.push((name.as_ref().to_owned(), value.into()));
         self
@@ -72,14 +93,20 @@ impl<'a> IntoIterator for &'a QueryParams {
 /// A value bound to a `{name:Type}` placeholder in a parameterized query.
 ///
 /// Use [`From`] conversions for scalars, strings, options, and arrays. For pre-formatted
-/// ClickHouse literals (tuples, etc.), use [`Self::raw`].
+/// ClickHouse literals (tuples, etc.), use [`Self::raw`]. The type in the SQL
+/// placeholder is what the engine parses; these variants only choose the string
+/// encoding sent over the C API.
 #[derive(Debug, Clone, PartialEq)]
 pub enum QueryParam {
     /// SQL NULL for `Nullable(...)` placeholders (`\N`).
     Null,
+    /// ClickHouse `Bool`, encoded as `true` or `false`.
     Bool(bool),
+    /// Signed 64-bit integer. Wider integers should go through [`Self::raw`].
     Int64(i64),
+    /// Unsigned 64-bit integer.
     UInt64(u64),
+    /// 64-bit floating point.
     Float64(f64),
     /// Raw text for `String`, `Date`, `Identifier`, and similar placeholders.
     Text(String),
@@ -91,6 +118,9 @@ pub enum QueryParam {
 
 impl QueryParam {
     /// Pass a pre-formatted ClickHouse parameter literal through unchanged.
+    ///
+    /// The string is sent as-is. It must already be valid for the placeholder
+    /// type (`(7,'x')` for a tuple, `[1, 2, 3]` for an array).
     pub fn raw(value: impl Into<String>) -> Self {
         Self::Raw(value.into())
     }

--- a/src/query_param.rs
+++ b/src/query_param.rs
@@ -152,7 +152,9 @@ impl QueryParam {
 /// NUL-terminated name/value C strings ready for `chdb_query_with_params`.
 ///
 /// Pointers returned by [`Self::names_ptr`] / [`Self::values_ptr`] are valid only
-/// while this struct remains alive.
+/// while this struct remains alive. Callers must keep `EncodedParams` live across
+/// the FFI call that consumes those pointers. The chDB C API is assumed to copy
+/// parameter names and values during that call and not retain the pointers.
 pub(crate) struct EncodedParams {
     _name_cstrs: Vec<CString>,
     _value_cstrs: Vec<CString>,

--- a/src/query_stream.rs
+++ b/src/query_stream.rs
@@ -85,7 +85,7 @@ impl<'a> QueryStream<'a> {
     }
 
     pub(crate) fn start_borrowed_with_params<K, V, I>(
-        conn: &'a Connection,
+        conn: &'a mut Connection,
         sql: &str,
         format: OutputFormat,
         params: I,
@@ -186,7 +186,13 @@ impl<'a> QueryStream<'a> {
             return Err(Error::NoResult);
         }
 
-        Self::check_stream_error(stream_ptr)?;
+        let probe = ManuallyDrop::new(QueryResult::new(stream_ptr));
+        if let Err(e) = probe.check_error_ref() {
+            drop(ManuallyDrop::into_inner(probe));
+            return Err(e);
+        }
+        std::mem::forget(ManuallyDrop::into_inner(probe));
+
         Ok(stream_ptr)
     }
 
@@ -443,6 +449,32 @@ mod tests {
     fn test_query_stream_syntax_error_fails_at_start() -> Result<()> {
         let mut conn = Connection::open_in_memory()?;
         let result = conn.query_stream("SELECT invalid syntax here", OutputFormat::JSONEachRow);
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_query_stream_with_params_error_then_retry_returns_none() -> Result<()> {
+        let mut conn = Connection::open_in_memory()?;
+        let mut stream = conn.query_stream_with_params(
+            "SELECT * FROM nonexistent_table WHERE id = {id:UInt64}",
+            OutputFormat::JSONEachRow,
+            [("id", 1_u64)],
+        )?;
+
+        assert!(stream.next_chunk().is_err());
+        assert!(stream.next_chunk()?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_query_stream_with_params_syntax_error_fails_at_start() -> Result<()> {
+        let mut conn = Connection::open_in_memory()?;
+        let result = conn.query_stream_with_params(
+            "SELECT invalid syntax here",
+            OutputFormat::JSONEachRow,
+            [("x", 1_u64)],
+        );
         assert!(result.is_err());
         Ok(())
     }

--- a/src/query_stream.rs
+++ b/src/query_stream.rs
@@ -10,7 +10,7 @@ use crate::bindings;
 use crate::connection::Connection;
 use crate::error::{Error, Result};
 use crate::format::OutputFormat;
-use crate::query_param::QueryParam;
+use crate::query_param::{EncodedParams, QueryParam};
 use crate::query_result::QueryResult;
 
 enum QueryStreamConnection<'a> {
@@ -158,8 +158,27 @@ impl<'a> QueryStream<'a> {
         V: Into<QueryParam>,
         I: IntoIterator<Item = (K, V)>,
     {
-        let _ = (conn, sql, format, params);
-        todo!("QueryStream::start_query_with_params")
+        let query_cstr = CString::new(sql)?;
+        let format_cstr = CString::new(format.as_str())?;
+        let encoded = EncodedParams::encode(params)?;
+
+        let stream_ptr = unsafe {
+            bindings::chdb_stream_query_with_params(
+                conn,
+                query_cstr.as_ptr(),
+                format_cstr.as_ptr(),
+                encoded.names_ptr(),
+                encoded.values_ptr(),
+                encoded.len(),
+            )
+        };
+
+        if stream_ptr.is_null() {
+            return Err(Error::NoResult);
+        }
+
+        Self::check_stream_error(stream_ptr)?;
+        Ok(stream_ptr)
     }
 
     fn conn_handle(&self) -> bindings::chdb_connection {

--- a/src/query_stream.rs
+++ b/src/query_stream.rs
@@ -162,6 +162,15 @@ impl<'a> QueryStream<'a> {
         let format_cstr = CString::new(format.as_str())?;
         let encoded = EncodedParams::encode(params)?;
 
+        // SAFETY:
+        // - `conn` is a live `chdb_connection` from `Connection::handle()` on an open
+        //   connection that outlives this call (borrowed or owned by the stream).
+        // - `query_cstr` and `format_cstr` are NUL-terminated and outlive this call.
+        // - `encoded` owns the name/value `CString`s; `names_ptr`/`values_ptr` alias
+        //   those buffers for the duration of the call. libchdb may read them only
+        //   during this call (parameter bind at stream start) and must not retain them.
+        // - When `encoded.len() == 0`, both pointer args are null, which the C API
+        //   accepts for an empty parameter list.
         let stream_ptr = unsafe {
             bindings::chdb_stream_query_with_params(
                 conn,

--- a/src/query_stream.rs
+++ b/src/query_stream.rs
@@ -10,6 +10,7 @@ use crate::bindings;
 use crate::connection::Connection;
 use crate::error::{Error, Result};
 use crate::format::OutputFormat;
+use crate::query_param::QueryParam;
 use crate::query_result::QueryResult;
 
 enum QueryStreamConnection<'a> {
@@ -20,8 +21,11 @@ enum QueryStreamConnection<'a> {
 /// A streaming query result that yields data in chunks.
 ///
 /// `QueryStream` is returned by [`Connection::query_stream`](crate::connection::Connection::query_stream),
-/// [`Session::execute_stream`](crate::session::Session::execute_stream), and
-/// [`execute_stream`](crate::execute_stream). Each chunk is a [`QueryResult`] that the caller owns
+/// [`Connection::query_stream_with_params`](crate::connection::Connection::query_stream_with_params),
+/// [`Session::execute_stream`](crate::session::Session::execute_stream),
+/// [`Session::execute_stream_with_params`](crate::session::Session::execute_stream_with_params),
+/// [`execute_stream`](crate::execute_stream), and
+/// [`execute_stream_with_params`](crate::execute_stream_with_params). Each chunk is a [`QueryResult`] that the caller owns
 /// and must drop before requesting the next chunk.
 ///
 /// `QueryStream` also implements [`Iterator`], so you can collect chunks with adapter methods
@@ -80,6 +84,44 @@ impl<'a> QueryStream<'a> {
         })
     }
 
+    pub(crate) fn start_borrowed_with_params<K, V, I>(
+        conn: &'a Connection,
+        sql: &str,
+        format: OutputFormat,
+        params: I,
+    ) -> Result<Self>
+    where
+        K: AsRef<str>,
+        V: Into<QueryParam>,
+        I: IntoIterator<Item = (K, V)>,
+    {
+        let stream = Self::start_query_with_params(conn.handle(), sql, format, params)?;
+        Ok(Self {
+            conn: QueryStreamConnection::Borrowed(conn),
+            stream,
+            finished: false,
+        })
+    }
+
+    pub(crate) fn start_owned_with_params<K, V, I>(
+        conn: Connection,
+        sql: &str,
+        format: OutputFormat,
+        params: I,
+    ) -> Result<Self>
+    where
+        K: AsRef<str>,
+        V: Into<QueryParam>,
+        I: IntoIterator<Item = (K, V)>,
+    {
+        let stream = Self::start_query_with_params(conn.handle(), sql, format, params)?;
+        Ok(Self {
+            conn: QueryStreamConnection::Owned(conn),
+            stream,
+            finished: false,
+        })
+    }
+
     fn start_query(
         conn: bindings::chdb_connection,
         sql: &str,
@@ -103,6 +145,21 @@ impl<'a> QueryStream<'a> {
         std::mem::forget(ManuallyDrop::into_inner(probe));
 
         Ok(stream_ptr)
+    }
+
+    fn start_query_with_params<K, V, I>(
+        conn: bindings::chdb_connection,
+        sql: &str,
+        format: OutputFormat,
+        params: I,
+    ) -> Result<*mut bindings::chdb_result>
+    where
+        K: AsRef<str>,
+        V: Into<QueryParam>,
+        I: IntoIterator<Item = (K, V)>,
+    {
+        let _ = (conn, sql, format, params);
+        todo!("QueryStream::start_query_with_params")
     }
 
     fn conn_handle(&self) -> bindings::chdb_connection {

--- a/src/session.rs
+++ b/src/session.rs
@@ -417,7 +417,7 @@ impl Session {
             .query_stream(query, fmt)
     }
 
-    /// Execute a parameterized query and stream the result in chunks.
+    /// Execute a query with ClickHouse `{name:Type}` parameter binding and stream the result in chunks.
     ///
     /// Output format may be supplied via `query_args`; other [`Arg`] variants are
     /// ignored here, matching [`Self::execute_stream`].
@@ -553,7 +553,7 @@ impl Session {
             .query_stream_arrow(query)
     }
 
-    /// Execute a parameterized query and stream the result as Arrow record batches.
+    /// Execute a query with ClickHouse `{name:Type}` parameter binding and stream Arrow record batches.
     ///
     /// Session-level counterpart of
     /// [`Connection::query_stream_arrow_with_params`](crate::connection::Connection::query_stream_arrow_with_params).

--- a/src/session.rs
+++ b/src/session.rs
@@ -19,9 +19,12 @@ use crate::arrow_insert::{
 };
 #[cfg(feature = "arrow")]
 use crate::arrow_options::InsertOptions;
+#[cfg(feature = "arrow")]
+use crate::arrow_query_stream::ArrowQueryStream;
 use crate::connection::Connection;
 use crate::error::{Error, Result};
 use crate::format::OutputFormat;
+use crate::query_param::QueryParam;
 use crate::query_result::QueryResult;
 use crate::query_stream::QueryStream;
 
@@ -414,6 +417,44 @@ impl Session {
             .query_stream(query, fmt)
     }
 
+    /// Execute a parameterized query and stream the result in chunks.
+    ///
+    /// Output format may be supplied via `query_args`; other [`Arg`] variants are
+    /// ignored here, matching [`Self::execute_stream`].
+    pub fn execute_stream_with_params<'a, K, V, I>(
+        &'a self,
+        query: &str,
+        query_args: Option<&[Arg]>,
+        params: I,
+    ) -> Result<QueryStream<'a>>
+    where
+        K: AsRef<str>,
+        V: Into<QueryParam>,
+        I: IntoIterator<Item = (K, V)>,
+    {
+        let fmt = extract_output_format(query_args, self.default_format);
+        self.conn.query_stream_with_params(query, fmt, params)
+    }
+
+    /// Execute a query with ClickHouse `{name:Type}` parameter binding.
+    ///
+    /// Output format may be supplied via `query_args`; other [`Arg`] variants are
+    /// ignored here, matching [`Self::execute`].
+    pub fn execute_with_params<K, V, I>(
+        &self,
+        query: &str,
+        query_args: Option<&[Arg]>,
+        params: I,
+    ) -> Result<QueryResult>
+    where
+        K: AsRef<str>,
+        V: Into<QueryParam>,
+        I: IntoIterator<Item = (K, V)>,
+    {
+        let fmt = extract_output_format(query_args, self.default_format);
+        self.conn.query_with_params(query, fmt, params)
+    }
+
     /// Access the session's [`Connection`] for Arrow registration and low-level queries.
     pub fn connection(&self) -> &Connection {
         self.conn
@@ -510,6 +551,26 @@ impl Session {
             .as_mut()
             .expect("a session holds its connection until it is dropped")
             .query_stream_arrow(query)
+    }
+
+    /// Execute a parameterized query and stream the result as Arrow record batches.
+    ///
+    /// Session-level counterpart of
+    /// [`Connection::query_stream_arrow_with_params`](crate::connection::Connection::query_stream_arrow_with_params).
+    ///
+    /// Available when the crate is built with the `arrow` feature.
+    #[cfg(feature = "arrow")]
+    pub fn execute_stream_arrow_with_params<'a, K, V, I>(
+        &'a self,
+        query: &str,
+        params: I,
+    ) -> Result<ArrowQueryStream<'a>>
+    where
+        K: AsRef<str>,
+        V: Into<QueryParam>,
+        I: IntoIterator<Item = (K, V)>,
+    {
+        self.conn.query_stream_arrow_with_params(query, params)
     }
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -422,7 +422,7 @@ impl Session {
     /// Output format may be supplied via `query_args`; other [`Arg`] variants are
     /// ignored here, matching [`Self::execute_stream`].
     pub fn execute_stream_with_params<'a, K, V, I>(
-        &'a self,
+        &'a mut self,
         query: &str,
         query_args: Option<&[Arg]>,
         params: I,
@@ -433,7 +433,10 @@ impl Session {
         I: IntoIterator<Item = (K, V)>,
     {
         let fmt = extract_output_format(query_args, self.default_format);
-        self.conn.query_stream_with_params(query, fmt, params)
+        self.conn
+            .as_mut()
+            .expect("a session holds its connection until it is dropped")
+            .query_stream_with_params(query, fmt, params)
     }
 
     /// Execute a query with ClickHouse `{name:Type}` parameter binding.
@@ -452,7 +455,7 @@ impl Session {
         I: IntoIterator<Item = (K, V)>,
     {
         let fmt = extract_output_format(query_args, self.default_format);
-        self.conn.query_with_params(query, fmt, params)
+        self.connection().query_with_params(query, fmt, params)
     }
 
     /// Access the session's [`Connection`] for Arrow registration and low-level queries.
@@ -561,7 +564,7 @@ impl Session {
     /// Available when the crate is built with the `arrow` feature.
     #[cfg(feature = "arrow")]
     pub fn execute_stream_arrow_with_params<'a, K, V, I>(
-        &'a self,
+        &'a mut self,
         query: &str,
         params: I,
     ) -> Result<ArrowQueryStream<'a>>
@@ -570,7 +573,10 @@ impl Session {
         V: Into<QueryParam>,
         I: IntoIterator<Item = (K, V)>,
     {
-        self.conn.query_stream_arrow_with_params(query, params)
+        self.conn
+            .as_mut()
+            .expect("a session holds its connection until it is dropped")
+            .query_stream_arrow_with_params(query, params)
     }
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -419,8 +419,41 @@ impl Session {
 
     /// Execute a query with ClickHouse `{name:Type}` parameter binding and stream the result in chunks.
     ///
-    /// Output format may be supplied via `query_args`; other [`Arg`] variants are
-    /// ignored here, matching [`Self::execute_stream`].
+    /// Like [`Self::execute_stream`], but SQL placeholders are bound from `params`
+    /// before streaming begins. The session is exclusively borrowed for the
+    /// stream's lifetime. Output format may be supplied via `query_args`; other
+    /// [`Arg`] variants are ignored here, matching [`Self::execute_stream`].
+    /// Syntax errors fail when the stream is created. A missing placeholder
+    /// binding is reported on the first [`QueryStream::next_chunk`], not at start.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use chdb_rust::arg::Arg;
+    /// use chdb_rust::format::OutputFormat;
+    /// use chdb_rust::session::SessionBuilder;
+    ///
+    /// let mut session = SessionBuilder::new()
+    ///     .with_data_path("/tmp/mydb")
+    ///     .with_auto_cleanup(true)
+    ///     .build()?;
+    ///
+    /// let mut stream = session.execute_stream_with_params(
+    ///     "SELECT {x:UInt64} AS v",
+    ///     Some(&[Arg::OutputFormat(OutputFormat::CSV)]),
+    ///     [("x", 11_u64)],
+    /// )?;
+    /// while let Some(chunk) = stream.next_chunk()? {
+    ///     print!("{}", chunk.data_utf8_lossy());
+    /// }
+    /// # Ok::<(), chdb_rust::error::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The query syntax is invalid
+    /// - The query cannot be started
     pub fn execute_stream_with_params<'a, K, V, I>(
         &'a mut self,
         query: &str,
@@ -441,8 +474,38 @@ impl Session {
 
     /// Execute a query with ClickHouse `{name:Type}` parameter binding.
     ///
-    /// Output format may be supplied via `query_args`; other [`Arg`] variants are
-    /// ignored here, matching [`Self::execute`].
+    /// Like [`Self::execute`], but SQL placeholders are bound from `params`
+    /// in the chDB library and never interpolated into the SQL text. Output format may
+    /// be supplied via `query_args`; other [`Arg`] variants are ignored here,
+    /// matching [`Self::execute`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use chdb_rust::arg::Arg;
+    /// use chdb_rust::format::OutputFormat;
+    /// use chdb_rust::session::SessionBuilder;
+    ///
+    /// let session = SessionBuilder::new()
+    ///     .with_data_path("/tmp/mydb")
+    ///     .with_auto_cleanup(true)
+    ///     .build()?;
+    ///
+    /// let result = session.execute_with_params(
+    ///     "SELECT {x:UInt64} AS v",
+    ///     Some(&[Arg::OutputFormat(OutputFormat::CSV)]),
+    ///     [("x", 7_u64)],
+    /// )?;
+    /// # Ok::<(), chdb_rust::error::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The query syntax is invalid
+    /// - A `{name:Type}` placeholder has no matching param
+    /// - A value cannot be parsed as the type declared in the placeholder
+    /// - The query execution fails for any other reason
     pub fn execute_with_params<K, V, I>(
         &self,
         query: &str,
@@ -560,8 +623,35 @@ impl Session {
     ///
     /// Session-level counterpart of
     /// [`Connection::query_stream_arrow_with_params`](crate::connection::Connection::query_stream_arrow_with_params).
+    /// The session is exclusively borrowed for the stream's lifetime.
     ///
     /// Available when the crate is built with the `arrow` feature.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use chdb_rust::session::SessionBuilder;
+    ///
+    /// let mut session = SessionBuilder::new()
+    ///     .with_data_path("/tmp/mydb")
+    ///     .with_auto_cleanup(true)
+    ///     .build()?;
+    ///
+    /// let mut stream = session.execute_stream_arrow_with_params(
+    ///     "SELECT {x:UInt64} AS v",
+    ///     [("x", 11_u64)],
+    /// )?;
+    /// while let Some(batch) = stream.next_batch()? {
+    ///     println!("rows: {}", batch.num_rows());
+    /// }
+    /// # Ok::<(), chdb_rust::error::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The query syntax is invalid
+    /// - The query cannot be started
     #[cfg(feature = "arrow")]
     pub fn execute_stream_arrow_with_params<'a, K, V, I>(
         &'a mut self,

--- a/tests/query_with_params.rs
+++ b/tests/query_with_params.rs
@@ -1,0 +1,363 @@
+//! Integration tests for ClickHouse query parameter binding via the safe Rust API.
+//!
+//! Mirrors chdb-core's `tests/test_c_api_query_with_params.py` scenarios.
+//!
+//! Run with: `RUST_TEST_THREADS=1 cargo test --test query_with_params`
+
+use arrow::array::{Array, UInt64Array};
+use chdb_rust::arg::Arg;
+use chdb_rust::connection::Connection;
+use chdb_rust::error::{Error, Result};
+use chdb_rust::execute_stream_arrow_with_params;
+use chdb_rust::execute_stream_with_params;
+use chdb_rust::execute_with_params;
+use chdb_rust::format::OutputFormat;
+use chdb_rust::query_param::QueryParams;
+use chdb_rust::session::SessionBuilder;
+
+mod common {
+    use super::*;
+
+    #[test]
+    fn int64_param_returns_bound_value() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        let result =
+            conn.query_with_params("SELECT {x:Int64} AS v", OutputFormat::CSV, [("x", 42_i64)])?;
+        assert_eq!(result.data_utf8_lossy(), "42\n");
+        Ok(())
+    }
+
+    #[test]
+    fn string_param_returns_bound_value() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        let result = conn.query_with_params(
+            "SELECT {s:String} AS v",
+            OutputFormat::CSV,
+            [("s", "hello")],
+        )?;
+        assert_eq!(result.data_utf8_lossy(), "\"hello\"\n");
+        Ok(())
+    }
+
+    #[test]
+    fn date_param_arithmetic_returns_expected_value() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        let result = conn.query_with_params(
+            "SELECT toDate({d:Date}) + 1 AS d",
+            OutputFormat::CSV,
+            [("d", "2025-01-01")],
+        )?;
+        assert_eq!(result.data_utf8_lossy(), "\"2025-01-02\"\n");
+        Ok(())
+    }
+
+    #[test]
+    fn multiple_params_bind_by_name() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        let result = conn.query_with_params(
+            "SELECT {x:UInt64} - {y:UInt64} AS total",
+            OutputFormat::CSV,
+            [("x", 5_u64), ("y", 7_u64)],
+        )?;
+        assert_eq!(result.data_utf8_lossy(), "-2\n");
+        Ok(())
+    }
+
+    #[test]
+    fn missing_param_returns_substitution_error() {
+        let conn = Connection::open_in_memory().expect("connection");
+        let err = conn
+            .query_with_params(
+                "SELECT {x:UInt64} AS v",
+                OutputFormat::CSV,
+                QueryParams::new(),
+            )
+            .unwrap_err();
+        assert!(matches!(err, Error::QueryError(msg) if msg.contains("Substitution")));
+    }
+
+    #[test]
+    fn invalid_type_returns_parse_error() {
+        let conn = Connection::open_in_memory().expect("connection");
+        let err = conn
+            .query_with_params(
+                "SELECT {x:UInt64} AS v",
+                OutputFormat::CSV,
+                [("x", "not-a-number")],
+            )
+            .unwrap_err();
+
+        assert!(
+            matches!(err, Error::QueryError(msg) if msg.contains("cannot be parsed as UInt64"))
+        );
+    }
+
+    #[test]
+    fn params_cleared_after_call() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+
+        let first =
+            conn.query_with_params("SELECT {x:Int64} AS v", OutputFormat::CSV, [("x", 1_i64)])?;
+        assert_eq!(first.data_utf8_lossy(), "1\n");
+
+        let second =
+            conn.query_with_params("SELECT {x:Int64} AS v", OutputFormat::CSV, [("x", 99_i64)])?;
+        assert_eq!(second.data_utf8_lossy(), "99\n");
+
+        let err = conn
+            .query_with_params(
+                "SELECT {x:Int64} AS v",
+                OutputFormat::CSV,
+                QueryParams::new(),
+            )
+            .unwrap_err();
+
+        assert!(matches!(err, Error::QueryError(msg) if msg.contains("Substitution")));
+
+        Ok(())
+    }
+
+    #[test]
+    fn empty_params_falls_through_to_plain_query() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        let result =
+            conn.query_with_params("SELECT 1 AS v", OutputFormat::CSV, QueryParams::new())?;
+        assert_eq!(result.data_utf8_lossy(), "1\n");
+        Ok(())
+    }
+
+    #[test]
+    fn duplicate_param_names_last_wins() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        let result = conn.query_with_params(
+            "SELECT {x:Int64} AS v",
+            OutputFormat::CSV,
+            [("x", 1_i64), ("x", 42_i64)],
+        )?;
+        assert_eq!(result.data_utf8_lossy(), "42\n");
+        Ok(())
+    }
+
+    #[test]
+    fn array_param_for_in_clause() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        let result = conn.query_with_params(
+            "SELECT sum(arrayJoin({ids:Array(UInt32)})) AS total",
+            OutputFormat::CSV,
+            [("ids", vec![1_u64, 3, 5])],
+        )?;
+        assert_eq!(result.data_utf8_lossy(), "9\n");
+        Ok(())
+    }
+
+    #[test]
+    fn session_execute_with_params_uses_bound_values() -> Result<()> {
+        let session = SessionBuilder::new()
+            .with_data_path(std::env::temp_dir().join("chdb-rust-query-params-session"))
+            .with_auto_cleanup(true)
+            .build()?;
+
+        session.execute(
+        "CREATE TABLE events (event_type String, created_at String) ENGINE = MergeTree() ORDER BY tuple()",
+            None,
+        )?;
+        session.execute(
+            "INSERT INTO events VALUES ('purchase', '2025-01-15'), ('view', '2025-01-01')",
+            None,
+        )?;
+
+        let result = session.execute_with_params(
+        "SELECT count() FROM events WHERE event_type = {event:String} AND created_at >= {since:String}",
+        Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)]),
+        [("event", "purchase"), ("since", "2025-01-01")],
+    )?;
+        assert_eq!(result.data_utf8_lossy(), "{\"count()\":1}\n");
+
+        Ok(())
+    }
+
+    #[test]
+    fn execute_with_params_stateless_entry_point() -> Result<()> {
+        let result = execute_with_params(
+            "SELECT {x:UInt64} AS v",
+            Some(&[Arg::OutputFormat(OutputFormat::CSV)]),
+            [("x", 7_u64)],
+        )?;
+        assert_eq!(result.data_utf8_lossy(), "7\n");
+        Ok(())
+    }
+}
+
+mod text_stream {
+    use super::*;
+
+    #[test]
+    fn stream_with_params_returns_bound_scalar() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        let mut stream = conn.query_stream_with_params(
+            "SELECT {x:UInt64} AS v",
+            OutputFormat::CSV,
+            [("x", 11_u64)],
+        )?;
+
+        let chunk = stream.next_chunk()?.expect("expected a chunk");
+        assert_eq!(chunk.data_utf8_lossy(), "11\n");
+        assert!(stream.next_chunk()?.is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn stream_with_params_limits_row_count() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        let mut stream = conn.query_stream_with_params(
+            "SELECT number FROM numbers({n:UInt64})",
+            OutputFormat::CSV,
+            [("n", 5_u64)],
+        )?;
+
+        let mut rows = 0_u64;
+        while let Some(chunk) = stream.next_chunk()? {
+            rows += chunk.rows_read();
+        }
+        assert_eq!(rows, 5);
+
+        Ok(())
+    }
+
+    #[test]
+    fn stream_with_params_missing_param_returns_substitution_error() {
+        let conn = Connection::open_in_memory().expect("connection");
+        let result = conn.query_stream_with_params(
+            "SELECT {x:UInt64} AS v",
+            OutputFormat::CSV,
+            QueryParams::new(),
+        );
+        assert!(matches!(result, Err(Error::QueryError(msg)) if msg.contains("Substitution")));
+    }
+
+    #[test]
+    fn execute_stream_with_params_stateless_entry_point() -> Result<()> {
+        let mut stream = execute_stream_with_params(
+            "SELECT {x:UInt64} AS v",
+            Some(&[Arg::OutputFormat(OutputFormat::CSV)]),
+            [("x", 7_u64)],
+        )?;
+        let chunk = stream.next_chunk()?.expect("expected a chunk");
+        assert_eq!(chunk.data_utf8_lossy(), "7\n");
+        Ok(())
+    }
+
+    #[test]
+    fn session_execute_stream_with_params() -> Result<()> {
+        let session = SessionBuilder::new()
+            .with_data_path(std::env::temp_dir().join("chdb-rust-query-params-text-stream"))
+            .with_auto_cleanup(true)
+            .build()?;
+
+        session.execute(
+            "CREATE TABLE items (id UInt64) ENGINE = MergeTree() ORDER BY id",
+            None,
+        )?;
+        session.execute("INSERT INTO items VALUES (1), (2), (3)", None)?;
+
+        let mut stream = session.execute_stream_with_params(
+            "SELECT id FROM items WHERE id >= {min_id:UInt64}",
+            Some(&[Arg::OutputFormat(OutputFormat::CSV)]),
+            [("min_id", 2_u64)],
+        )?;
+
+        let mut rows = 0_u64;
+        while let Some(chunk) = stream.next_chunk()? {
+            rows += chunk.rows_read();
+        }
+        assert_eq!(rows, 2);
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "arrow")]
+mod arrow_stream {
+    use super::*;
+
+    #[test]
+    fn stream_arrow_with_params_returns_bound_scalar() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        let mut stream =
+            conn.query_stream_arrow_with_params("SELECT {x:UInt64} AS v", [("x", 11_u64)])?;
+
+        let batch = stream.next_batch()?.expect("expected a batch");
+        assert_eq!(batch.num_rows(), 1);
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .expect("UInt64 column");
+        assert_eq!(col.value(0), 11);
+        assert!(stream.next_batch()?.is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn stream_arrow_with_params_limits_row_count() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        let mut stream = conn.query_stream_arrow_with_params(
+            "SELECT number FROM numbers({n:UInt64})",
+            [("n", 5_u64)],
+        )?;
+
+        let mut rows = 0_usize;
+        while let Some(batch) = stream.next_batch()? {
+            rows += batch.num_rows();
+        }
+        assert_eq!(rows, 5);
+
+        Ok(())
+    }
+
+    #[test]
+    fn stream_arrow_missing_param_returns_substitution_error() {
+        let conn = Connection::open_in_memory().expect("connection");
+        let result =
+            conn.query_stream_arrow_with_params("SELECT {x:UInt64} AS v", QueryParams::new());
+        assert!(matches!(result, Err(Error::QueryError(msg)) if msg.contains("Substitution")));
+    }
+
+    #[test]
+    fn execute_stream_arrow_with_params_stateless_entry_point() -> Result<()> {
+        let mut stream =
+            execute_stream_arrow_with_params("SELECT {x:UInt64} AS v", [("x", 7_u64)])?;
+        let batch = stream.next_batch()?.expect("expected a batch");
+        assert_eq!(batch.num_rows(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn session_execute_stream_arrow_with_params() -> Result<()> {
+        let session = SessionBuilder::new()
+            .with_data_path(std::env::temp_dir().join("chdb-rust-query-params-arrow-stream"))
+            .with_auto_cleanup(true)
+            .build()?;
+
+        session.execute(
+            "CREATE TABLE items (id UInt64) ENGINE = MergeTree() ORDER BY id",
+            None,
+        )?;
+        session.execute("INSERT INTO items VALUES (1), (2), (3)", None)?;
+
+        let mut stream = session.execute_stream_arrow_with_params(
+            "SELECT id FROM items WHERE id >= {min_id:UInt64}",
+            [("min_id", 2_u64)],
+        )?;
+
+        let mut rows = 0_usize;
+        while let Some(batch) = stream.next_batch()? {
+            rows += batch.num_rows();
+        }
+        assert_eq!(rows, 2);
+
+        Ok(())
+    }
+}

--- a/tests/query_with_params.rs
+++ b/tests/query_with_params.rs
@@ -40,6 +40,30 @@ mod common {
     }
 
     #[test]
+    fn string_param_preserves_literal_backslash_sequences() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        let result = conn.query_with_params(
+            r"SELECT {s:String} = 'C:\\temp' AS v",
+            OutputFormat::CSV,
+            [("s", r"C:\temp")],
+        )?;
+        assert_eq!(result.data_utf8_lossy(), "1\n");
+        Ok(())
+    }
+
+    #[test]
+    fn string_param_preserves_literal_tab() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        let result = conn.query_with_params(
+            r"SELECT {s:String} = 'a\tb' AS v",
+            OutputFormat::CSV,
+            [("s", "a\tb")],
+        )?;
+        assert_eq!(result.data_utf8_lossy(), "1\n");
+        Ok(())
+    }
+
+    #[test]
     fn date_param_arithmetic_returns_expected_value() -> Result<()> {
         let conn = Connection::open_in_memory()?;
         let result = conn.query_with_params(

--- a/tests/query_with_params.rs
+++ b/tests/query_with_params.rs
@@ -193,7 +193,7 @@ mod text_stream {
 
     #[test]
     fn stream_with_params_returns_bound_scalar() -> Result<()> {
-        let conn = Connection::open_in_memory()?;
+        let mut conn = Connection::open_in_memory()?;
         let mut stream = conn.query_stream_with_params(
             "SELECT {x:UInt64} AS v",
             OutputFormat::CSV,
@@ -209,7 +209,7 @@ mod text_stream {
 
     #[test]
     fn stream_with_params_limits_row_count() -> Result<()> {
-        let conn = Connection::open_in_memory()?;
+        let mut conn = Connection::open_in_memory()?;
         let mut stream = conn.query_stream_with_params(
             "SELECT number FROM numbers({n:UInt64})",
             OutputFormat::CSV,
@@ -227,7 +227,7 @@ mod text_stream {
 
     #[test]
     fn stream_with_params_missing_param_returns_substitution_error() {
-        let conn = Connection::open_in_memory().expect("connection");
+        let mut conn = Connection::open_in_memory().expect("connection");
         let mut stream = conn
             .query_stream_with_params(
                 "SELECT {x:UInt64} AS v",
@@ -253,7 +253,7 @@ mod text_stream {
 
     #[test]
     fn session_execute_stream_with_params() -> Result<()> {
-        let session = SessionBuilder::new()
+        let mut session = SessionBuilder::new()
             .with_data_path(std::env::temp_dir().join("chdb-rust-query-params-text-stream"))
             .with_auto_cleanup(true)
             .build()?;
@@ -286,7 +286,7 @@ mod arrow_stream {
 
     #[test]
     fn stream_arrow_with_params_returns_bound_scalar() -> Result<()> {
-        let conn = Connection::open_in_memory()?;
+        let mut conn = Connection::open_in_memory()?;
         let mut stream =
             conn.query_stream_arrow_with_params("SELECT {x:UInt64} AS v", [("x", 11_u64)])?;
 
@@ -305,7 +305,7 @@ mod arrow_stream {
 
     #[test]
     fn stream_arrow_with_params_limits_row_count() -> Result<()> {
-        let conn = Connection::open_in_memory()?;
+        let mut conn = Connection::open_in_memory()?;
         let mut stream = conn.query_stream_arrow_with_params(
             "SELECT number FROM numbers({n:UInt64})",
             [("n", 5_u64)],
@@ -322,7 +322,7 @@ mod arrow_stream {
 
     #[test]
     fn stream_arrow_missing_param_returns_substitution_error() {
-        let conn = Connection::open_in_memory().expect("connection");
+        let mut conn = Connection::open_in_memory().expect("connection");
         let mut stream = conn
             .query_stream_arrow_with_params("SELECT {x:UInt64} AS v", QueryParams::new())
             .expect("stream start succeeds; bind error arrives on fetch");
@@ -341,7 +341,7 @@ mod arrow_stream {
 
     #[test]
     fn session_execute_stream_arrow_with_params() -> Result<()> {
-        let session = SessionBuilder::new()
+        let mut session = SessionBuilder::new()
             .with_data_path(std::env::temp_dir().join("chdb-rust-query-params-arrow-stream"))
             .with_auto_cleanup(true)
             .build()?;

--- a/tests/query_with_params.rs
+++ b/tests/query_with_params.rs
@@ -323,9 +323,11 @@ mod arrow_stream {
     #[test]
     fn stream_arrow_missing_param_returns_substitution_error() {
         let conn = Connection::open_in_memory().expect("connection");
-        let result =
-            conn.query_stream_arrow_with_params("SELECT {x:UInt64} AS v", QueryParams::new());
-        assert!(matches!(result, Err(Error::QueryError(msg)) if msg.contains("Substitution")));
+        let mut stream = conn
+            .query_stream_arrow_with_params("SELECT {x:UInt64} AS v", QueryParams::new())
+            .expect("stream start succeeds; bind error arrives on fetch");
+        let err = stream.next_batch().unwrap_err();
+        assert!(matches!(err, Error::QueryError(msg) if msg.contains("Substitution")));
     }
 
     #[test]

--- a/tests/query_with_params.rs
+++ b/tests/query_with_params.rs
@@ -228,12 +228,15 @@ mod text_stream {
     #[test]
     fn stream_with_params_missing_param_returns_substitution_error() {
         let conn = Connection::open_in_memory().expect("connection");
-        let result = conn.query_stream_with_params(
-            "SELECT {x:UInt64} AS v",
-            OutputFormat::CSV,
-            QueryParams::new(),
-        );
-        assert!(matches!(result, Err(Error::QueryError(msg)) if msg.contains("Substitution")));
+        let mut stream = conn
+            .query_stream_with_params(
+                "SELECT {x:UInt64} AS v",
+                OutputFormat::CSV,
+                QueryParams::new(),
+            )
+            .expect("stream start succeeds; bind error arrives on fetch");
+        let err = stream.next_chunk().unwrap_err();
+        assert!(matches!(err, Error::QueryError(msg) if msg.contains("Substitution")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds ClickHouse `{name:Type}` query parameter binding. Values are encoded as strings for libchdb and substituted during planning. Names bind by name, not by order.

- `QueryParam` / `QueryParams` encode scalars, `Option`, arrays/slices/vectors, and pre-formatted literals (`QueryParam::raw`) for the C ABI
- Materialized and streaming entry points at crate, `Connection`, and `Session` level: `execute_with_params`, `query_with_params`, `query_stream_with_params`, `query_stream_arrow_with_params`, and the matching `Session::execute_*_with_params` helpers
- Docs: example `13_query_with_params` and a Parameterized Queries section in `docs/examples.md`.

Out of scope: `serde` integration for custom types. libchdb only accepts string parameters; callers of types this crate does not encode must use `QueryParam::raw` or an explicit `From` conversion.

## Test plan

- [ ] `cargo fmt --check`
- [ ] `cargo clippy --all-targets --all-features -- --deny warnings`
- [ ] `cargo test --all-features -- --test-threads=1`
- [ ] `cargo run --example 13_query_with_params`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add parameterized query support to `Connection`, `Session`, and crate-level APIs
> - Introduces `QueryParam` and `QueryParams` types in [src/query_param.rs](https://github.com/chdb-io/chdb-rust/pull/45/files#diff-dd2928d7ae88a612d02445ef464713b8734b120be5cbf22b1a945f38fc42bd4a) to encode scalar, array, nullable, and raw-literal values into FFI name/value arrays
> - Adds `query_with_params`, `query_stream_with_params`, and `query_stream_arrow_with_params` methods to `Connection`, `Session`, `QueryStream`, and `ArrowQueryStream` for executing queries with named placeholders separate from SQL text
> - Exposes stateless crate-level helpers `execute_with_params`, `execute_stream_with_params`, and `execute_stream_arrow_with_params`, and re-exports `QueryParam`, `QueryParams`, and `QueryResult` from [src/lib.rs](https://github.com/chdb-io/chdb-rust/pull/45/files#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759)
> - Behavioral Change: Missing parameter bindings or syntax errors in parameterized APIs may surface during stream creation or on the first fetch rather than at the initial call site, depending on chDB evaluation timing
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd08e15.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->